### PR TITLE
Remove unwanted space from valid characters list

### DIFF
--- a/src/openzaak/components/catalogi/models/validators.py
+++ b/src/openzaak/components/catalogi/models/validators.py
@@ -38,7 +38,7 @@ def validate_uppercase(value):
 
 
 letters_numbers_underscores_validator = RegexValidator(
-    _lazy_re_compile("^[A-Za-z0-9 _]*$"),
+    _lazy_re_compile("^[A-Za-z0-9_]*$"),
     message=_("Voer alleen letters, cijfers en/of liggende streepjes in."),
     code="invalid",
 )


### PR DESCRIPTION
The regex in:
	letters_numbers_underscores_validator
looks like it was copy-pasted from:
	letters_numbers_underscores_spaces_validator

This commit removes the space as a valid character from
the letters_numbers_underscores_validator.

Addresses: https://github.com/open-zaak/open-zaak/issues/66