### PR TITLE
Fix broken link to license.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Copyright © Maykin Media 2019
 
 Licensed under the EUPL_
 
-.. _EUPL: LICENCE.md
+.. _EUPL: LICENSE.md
 
 .. |build-status| image:: https://travis-ci.org/open-zaak/open-zaak.svg?branch=master
     :alt: Build status


### PR DESCRIPTION
Switched from British to American spelling to match filename.