### PR TITLE
Replace 'no_match' to 'bad-url'

### DIFF
--- a/src/openzaak/components/besluiten/tests/test_validation.py
+++ b/src/openzaak/components/besluiten/tests/test_validation.py
@@ -123,7 +123,7 @@ class BesluitValidationTests(JWTAuthMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         error = get_validation_errors(response, "besluittype")
-        self.assertEqual(error["code"], "no_match")
+        self.assertEqual(error["code"], "bad-url")
 
     def test_zaaktype_besluittype_relation(self):
         besluittype = BesluitTypeFactory.create()
@@ -220,7 +220,7 @@ class BesluitInformatieObjectTests(JWTAuthMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         error = get_validation_errors(response, "informatieobject")
-        self.assertEqual(error["code"], "no_match")
+        self.assertEqual(error["code"], "bad-url")
 
     def test_validate_no_informatieobjecttype_zaaktype_relation(self):
         zaak = ZaakFactory.create()

--- a/src/openzaak/components/documenten/tests/test_validation.py
+++ b/src/openzaak/components/documenten/tests/test_validation.py
@@ -50,7 +50,7 @@ class EnkelvoudigInformatieObjectTests(JWTAuthMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         error = get_validation_errors(response, "informatieobjecttype")
-        self.assertEqual(error["code"], "no_match")
+        self.assertEqual(error["code"], "bad-url")
 
     def test_integriteit(self):
         url = reverse("enkelvoudiginformatieobject-list")

--- a/src/openzaak/components/zaken/tests/test_validation.py
+++ b/src/openzaak/components/zaken/tests/test_validation.py
@@ -75,7 +75,7 @@ class ZaakValidationTests(JWTAuthMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         validation_error = get_validation_errors(response, "zaaktype")
-        self.assertEqual(validation_error["code"], "no_match")
+        self.assertEqual(validation_error["code"], "bad-url")
         self.assertEqual(validation_error["name"], "zaaktype")
 
     def test_validate_zaaktype_valid(self, *mocks):
@@ -168,7 +168,7 @@ class ZaakValidationTests(JWTAuthMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         validation_error = get_validation_errors(response, "relevanteAndereZaken.0.url")
-        self.assertEqual(validation_error["code"], "no_match")
+        self.assertEqual(validation_error["code"], "bad-url")
 
     def test_relevante_andere_zaken_valid_zaak_resource(self):
         url = reverse("zaak-list")
@@ -460,7 +460,7 @@ class ZaakInformatieObjectValidationTests(JWTAuthMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         validation_error = get_validation_errors(response, "informatieobject")
-        self.assertEqual(validation_error["code"], "no_match")
+        self.assertEqual(validation_error["code"], "bad-url")
         self.assertEqual(validation_error["name"], "informatieobject")
 
     def test_informatieobject_no_zaaktype_informatieobjecttype_relation(self):
@@ -615,7 +615,7 @@ class StatusValidationTests(JWTAuthMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         error = get_validation_errors(response, "statustype")
-        self.assertEqual(error["code"], "no_match")
+        self.assertEqual(error["code"], "bad-url")
 
     def test_statustype_zaaktype_mismatch(self):
         zaak = ZaakFactory.create()
@@ -743,7 +743,7 @@ class ResultaatValidationTests(JWTAuthMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         validation_error = get_validation_errors(response, "resultaattype")
-        self.assertEqual(validation_error["code"], "no_match")
+        self.assertEqual(validation_error["code"], "bad-url")
 
     def test_resultaattype_incorrect_zaaktype(self):
         zaak = ZaakFactory.create()
@@ -817,7 +817,6 @@ class ZaakEigenschapValidationTests(JWTAuthMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-    @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_404")
     def test_eigenschap_invalid_url(self):
         zaak = ZaakFactory.create()
         zaak_url = reverse(zaak)
@@ -831,7 +830,7 @@ class ZaakEigenschapValidationTests(JWTAuthMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         validation_error = get_validation_errors(response, "eigenschap")
-        self.assertEqual(validation_error["code"], "no_match")
+        self.assertEqual(validation_error["code"], "bad-url")
 
 
 class ZaakObjectValidationTests(JWTAuthMixin, APITestCase):

--- a/src/openzaak/utils/serializer_fields.py
+++ b/src/openzaak/utils/serializer_fields.py
@@ -8,10 +8,11 @@ class LengthHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
     replace build-in 'no_match' error code with `bad-url` to make it consistent with
     reference implementation
     """
+
     default_error_messages = {
         "max_length": _("Ensure this field has no more than {max_length} characters."),
         "min_length": _("Ensure this field has at least {min_length} characters."),
-        "bad-url": "Please provide a valid URL."
+        "bad-url": "Please provide a valid URL.",
     }
 
     def __init__(self, **kwargs):
@@ -30,6 +31,6 @@ class LengthHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
         return super().to_internal_value(data)
 
     def fail(self, key, **kwargs):
-        if key == 'no_match':
-            key = 'bad-url'
+        if key == "no_match":
+            key = "bad-url"
         super().fail(key, **kwargs)

--- a/src/openzaak/utils/serializer_fields.py
+++ b/src/openzaak/utils/serializer_fields.py
@@ -4,9 +4,14 @@ from rest_framework import serializers
 
 
 class LengthHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
+    """
+    replace build-in 'no_match' error code with `bad-url` to make it consistent with
+    reference implementation
+    """
     default_error_messages = {
         "max_length": _("Ensure this field has no more than {max_length} characters."),
         "min_length": _("Ensure this field has at least {min_length} characters."),
+        "bad-url": "Please provide a valid URL."
     }
 
     def __init__(self, **kwargs):
@@ -23,3 +28,8 @@ class LengthHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
             self.fail("min_length", max_length=self.min_length, length=len(data))
 
         return super().to_internal_value(data)
+
+    def fail(self, key, **kwargs):
+        if key == 'no_match':
+            key = 'bad-url'
+        super().fail(key, **kwargs)


### PR DESCRIPTION
... for urls linked to the resources of other internal APIs (components)

Issue - https://github.com/open-zaak/open-zaak/issues/77