### PR TITLE
Fixed issue with get_serializer_class for EIO viewset without action

### DIFF
--- a/src/openzaak/components/documenten/api/viewsets.py
+++ b/src/openzaak/components/documenten/api/viewsets.py
@@ -214,7 +214,7 @@ class EnkelvoudigInformatieObjectViewSet(
         """
         To validate that a lock id is sent only with PUT and PATCH operations
         """
-        if self.action in ["update", "partial_update"]:
+        if getattr(self, "action", None) in ["update", "partial_update"]:
             return EnkelvoudigInformatieObjectWithLockSerializer
         return super().get_serializer_class()
 


### PR DESCRIPTION
because otherwise get_serializer_class that is called by notifications when creating i.e. `Gebruiksrechten` will fail