### PR TITLE
Bump vng-api-common to 1.0.22

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -61,4 +61,4 @@ unidecode==1.0.22         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via requests
 uwsgi==2.0.18
-vng-api-common==1.0.18
+vng-api-common==1.0.22

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -68,4 +68,4 @@ unidecode==1.0.22
 uritemplate==3.0.0
 urllib3==1.24.3
 uwsgi==2.0.18
-vng-api-common==1.0.18
+vng-api-common==1.0.22

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -95,7 +95,7 @@ unidecode==1.0.22
 uritemplate==3.0.0
 urllib3==1.24.3
 uwsgi==2.0.18
-vng-api-common==1.0.18
+vng-api-common==1.0.22
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools==41.4.0        # via sphinx


### PR DESCRIPTION
fixes https://github.com/open-zaak/open-zaak/issues/99 because https://github.com/VNG-Realisatie/vng-api-common/commit/bd9a716a5417469b8fb8f2dc61370466107cdc56 is in this version of vng-api-common