### PR TITLE
Feature/query parameter validation

### DIFF
--- a/src/openzaak/components/authorizations/api/viewsets.py
+++ b/src/openzaak/components/authorizations/api/viewsets.py
@@ -8,6 +8,7 @@ from rest_framework.pagination import PageNumberPagination
 from vng_api_common.authorizations.models import Applicatie
 from vng_api_common.authorizations.serializers import ApplicatieSerializer
 from vng_api_common.notifications.viewsets import NotificationViewSetMixin
+from vng_api_common.viewsets import CheckQueryParamsMixin
 
 from openzaak.utils.permissions import AuthRequired
 
@@ -19,7 +20,9 @@ from .scopes import SCOPE_AUTORISATIES_BIJWERKEN, SCOPE_AUTORISATIES_LEZEN
 logger = logging.getLogger(__name__)
 
 
-class ApplicatieViewSet(NotificationViewSetMixin, viewsets.ModelViewSet):
+class ApplicatieViewSet(
+    CheckQueryParamsMixin, NotificationViewSetMixin, viewsets.ModelViewSet
+):
     """
     Uitlezen en configureren van autorisaties voor applicaties.
 

--- a/src/openzaak/components/authorizations/tests/test_authorizations_api.py
+++ b/src/openzaak/components/authorizations/tests/test_authorizations_api.py
@@ -287,7 +287,7 @@ class ReadAuthorizationsTests(JWTAuthMixin, APITestCase):
     def test_filter_client_id_hit(self):
         url = get_operation_url("applicatie_list")
 
-        response = self.client.get(url, {"client_ids": "id2"})
+        response = self.client.get(url, {"clientIds": "id2"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
@@ -295,7 +295,7 @@ class ReadAuthorizationsTests(JWTAuthMixin, APITestCase):
     def test_filter_client_id_miss(self):
         url = get_operation_url("applicatie_list")
 
-        response = self.client.get(url, {"client_ids": "id3"})
+        response = self.client.get(url, {"clientIds": "id3"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 0)

--- a/src/openzaak/components/authorizations/tests/test_authorizations_api.py
+++ b/src/openzaak/components/authorizations/tests/test_authorizations_api.py
@@ -312,6 +312,17 @@ class ReadAuthorizationsTests(JWTAuthMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["url"], f"http://testserver{reverse(app)}")
 
+    def test_validate_unknown_query_params(self):
+        ApplicatieFactory.create_batch(2)
+        url = reverse(Applicatie)
+
+        response = self.client.get(url, {"someparam": "somevalue"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "unknown-parameters")
+
 
 class UpdateAuthorizationsTests(JWTAuthMixin, APITestCase):
     scopes = [str(SCOPE_AUTORISATIES_BIJWERKEN)]

--- a/src/openzaak/components/besluiten/api/viewsets.py
+++ b/src/openzaak/components/besluiten/api/viewsets.py
@@ -24,6 +24,7 @@ from .serializers import BesluitInformatieObjectSerializer, BesluitSerializer
 
 
 class BesluitViewSet(
+    CheckQueryParamsMixin,
     NotificationViewSetMixin,
     AuditTrailViewsetMixin,
     ListFilterByAuthorizationsMixin,

--- a/src/openzaak/components/besluiten/tests/test_filters.py
+++ b/src/openzaak/components/besluiten/tests/test_filters.py
@@ -2,6 +2,7 @@ from django.test import tag
 
 from rest_framework import status
 from rest_framework.test import APITestCase
+from vng_api_common.tests import get_validation_errors, reverse
 
 from openzaak.components.catalogi.tests.factories import BesluitTypeFactory
 from openzaak.components.catalogi.tests.utils import (
@@ -9,7 +10,8 @@ from openzaak.components.catalogi.tests.utils import (
 )
 from openzaak.utils.tests import JWTAuthMixin
 
-from .factories import BesluitFactory
+from ..models import Besluit, BesluitInformatieObject
+from .factories import BesluitFactory, BesluitInformatieObjectFactory
 from .utils import get_operation_url
 
 
@@ -32,3 +34,33 @@ class ListFilterLocalFKTests(JWTAuthMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.assertEqual(response.data["count"], 3)
+
+
+class BesluitAPIFilterTests(JWTAuthMixin, APITestCase):
+    heeft_alle_autorisaties = True
+
+    def test_validate_unknown_query_params(self):
+        BesluitFactory.create_batch(2)
+        url = reverse(Besluit)
+
+        response = self.client.get(url, {"someparam": "somevalue"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "unknown-parameters")
+
+
+class BesluitInformatieObjectAPIFilterTests(JWTAuthMixin, APITestCase):
+    heeft_alle_autorisaties = True
+
+    def test_validate_unknown_query_params(self):
+        BesluitInformatieObjectFactory.create_batch(2)
+        url = reverse(BesluitInformatieObject)
+
+        response = self.client.get(url, {"someparam": "somevalue"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "unknown-parameters")

--- a/src/openzaak/components/catalogi/api/viewsets/besluittype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/besluittype.py
@@ -1,5 +1,6 @@
 from rest_framework import mixins, viewsets
 from rest_framework.pagination import PageNumberPagination
+from vng_api_common.viewsets import CheckQueryParamsMixin
 
 from openzaak.utils.permissions import AuthRequired
 
@@ -11,6 +12,7 @@ from .mixins import ConceptMixin, M2MConceptCreateMixin
 
 
 class BesluitTypeViewSet(
+    CheckQueryParamsMixin,
     ConceptMixin,
     M2MConceptCreateMixin,
     mixins.CreateModelMixin,

--- a/src/openzaak/components/catalogi/api/viewsets/catalogus.py
+++ b/src/openzaak/components/catalogi/api/viewsets/catalogus.py
@@ -1,5 +1,6 @@
 from rest_framework import mixins, viewsets
 from rest_framework.pagination import PageNumberPagination
+from vng_api_common.viewsets import CheckQueryParamsMixin
 
 from openzaak.utils.permissions import AuthRequired
 
@@ -9,7 +10,9 @@ from ..scopes import SCOPE_ZAAKTYPES_READ, SCOPE_ZAAKTYPES_WRITE
 from ..serializers import CatalogusSerializer
 
 
-class CatalogusViewSet(mixins.CreateModelMixin, viewsets.ReadOnlyModelViewSet):
+class CatalogusViewSet(
+    CheckQueryParamsMixin, mixins.CreateModelMixin, viewsets.ReadOnlyModelViewSet
+):
     """
     Opvragen en bewerken van CATALOGUSsen.
 

--- a/src/openzaak/components/catalogi/api/viewsets/eigenschap.py
+++ b/src/openzaak/components/catalogi/api/viewsets/eigenschap.py
@@ -1,5 +1,6 @@
 from rest_framework import mixins, viewsets
 from rest_framework.pagination import PageNumberPagination
+from vng_api_common.viewsets import CheckQueryParamsMixin
 
 from openzaak.components.catalogi.models import Eigenschap
 from openzaak.utils.permissions import AuthRequired
@@ -11,6 +12,7 @@ from .mixins import ZaakTypeConceptMixin
 
 
 class EigenschapViewSet(
+    CheckQueryParamsMixin,
     ZaakTypeConceptMixin,
     mixins.CreateModelMixin,
     mixins.DestroyModelMixin,

--- a/src/openzaak/components/catalogi/api/viewsets/informatieobjecttype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/informatieobjecttype.py
@@ -1,5 +1,6 @@
 from rest_framework import mixins, viewsets
 from rest_framework.pagination import PageNumberPagination
+from vng_api_common.viewsets import CheckQueryParamsMixin
 
 from openzaak.utils.permissions import AuthRequired
 
@@ -11,6 +12,7 @@ from .mixins import ConceptMixin
 
 
 class InformatieObjectTypeViewSet(
+    CheckQueryParamsMixin,
     ConceptMixin,
     mixins.CreateModelMixin,
     mixins.DestroyModelMixin,

--- a/src/openzaak/components/catalogi/api/viewsets/relatieklassen.py
+++ b/src/openzaak/components/catalogi/api/viewsets/relatieklassen.py
@@ -3,6 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 from rest_framework import mixins, viewsets
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.pagination import PageNumberPagination
+from vng_api_common.viewsets import CheckQueryParamsMixin
 
 from openzaak.utils.permissions import AuthRequired
 
@@ -14,6 +15,7 @@ from .mixins import ConceptDestroyMixin, ConceptFilterMixin
 
 
 class ZaakTypeInformatieObjectTypeViewSet(
+    CheckQueryParamsMixin,
     ConceptFilterMixin,
     ConceptDestroyMixin,
     mixins.CreateModelMixin,

--- a/src/openzaak/components/catalogi/api/viewsets/resultaattype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/resultaattype.py
@@ -1,5 +1,6 @@
 from rest_framework import mixins, viewsets
 from rest_framework.pagination import PageNumberPagination
+from vng_api_common.viewsets import CheckQueryParamsMixin
 
 from openzaak.utils.permissions import AuthRequired
 
@@ -11,6 +12,7 @@ from .mixins import ZaakTypeConceptMixin
 
 
 class ResultaatTypeViewSet(
+    CheckQueryParamsMixin,
     ZaakTypeConceptMixin,
     mixins.CreateModelMixin,
     mixins.DestroyModelMixin,

--- a/src/openzaak/components/catalogi/api/viewsets/statustype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/statustype.py
@@ -1,5 +1,6 @@
 from rest_framework import mixins, viewsets
 from rest_framework.pagination import PageNumberPagination
+from vng_api_common.viewsets import CheckQueryParamsMixin
 
 from openzaak.utils.permissions import AuthRequired
 
@@ -11,6 +12,7 @@ from .mixins import ZaakTypeConceptMixin
 
 
 class StatusTypeViewSet(
+    CheckQueryParamsMixin,
     ZaakTypeConceptMixin,
     mixins.CreateModelMixin,
     mixins.DestroyModelMixin,

--- a/src/openzaak/components/catalogi/api/viewsets/zaaktype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/zaaktype.py
@@ -1,5 +1,6 @@
 from rest_framework import mixins, viewsets
 from rest_framework.pagination import PageNumberPagination
+from vng_api_common.viewsets import CheckQueryParamsMixin
 
 from openzaak.utils.permissions import AuthRequired
 
@@ -11,6 +12,7 @@ from .mixins import ConceptMixin, M2MConceptCreateMixin
 
 
 class ZaakTypeViewSet(
+    CheckQueryParamsMixin,
     ConceptMixin,
     M2MConceptCreateMixin,
     mixins.CreateModelMixin,

--- a/src/openzaak/components/catalogi/tests/test_besluittype.py
+++ b/src/openzaak/components/catalogi/tests/test_besluittype.py
@@ -1,5 +1,5 @@
 from rest_framework import status
-from vng_api_common.tests import get_validation_errors, reverse
+from vng_api_common.tests import get_operation_url, get_validation_errors, reverse
 
 from ..models import BesluitType
 from .base import APITestCase
@@ -405,6 +405,17 @@ class BesluitTypeFilterAPITests(APITestCase):
 
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["url"], f"http://testserver{besluittype1_url}")
+
+    def test_validate_unknown_query_params(self):
+        BesluitTypeFactory.create_batch(2)
+        url = reverse(BesluitType)
+
+        response = self.client.get(url, {"someparam": "somevalue"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "unknown-parameters")
 
 
 class BesluitTypePaginationTestCase(APITestCase):

--- a/src/openzaak/components/catalogi/tests/test_catalogus.py
+++ b/src/openzaak/components/catalogi/tests/test_catalogus.py
@@ -1,5 +1,5 @@
 from rest_framework import status
-from vng_api_common.tests import reverse
+from vng_api_common.tests import get_validation_errors, reverse
 
 from ..models import Catalogus
 from .base import APITestCase
@@ -110,6 +110,17 @@ class CatalogusFilterAPITests(APITestCase):
 
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["url"], f"http://testserver{reverse(catalogus1)}")
+
+    def test_validate_unknown_query_params(self):
+        CatalogusFactory.create_batch(2)
+        url = reverse(Catalogus)
+
+        response = self.client.get(url, {"someparam": "somevalue"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "unknown-parameters")
 
 
 class CatalogusPaginationTestCase(APITestCase):

--- a/src/openzaak/components/catalogi/tests/test_eigenschap.py
+++ b/src/openzaak/components/catalogi/tests/test_eigenschap.py
@@ -1,5 +1,5 @@
 from rest_framework import status
-from vng_api_common.tests import TypeCheckMixin, reverse
+from vng_api_common.tests import TypeCheckMixin, get_validation_errors, reverse
 
 from ..constants import FormaatChoices
 from ..models import Eigenschap
@@ -261,6 +261,17 @@ class EigenschapFilterAPITests(APITestCase):
 
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["url"], f"http://testserver{eigenschap2_url}")
+
+    def test_validate_unknown_query_params(self):
+        EigenschapFactory.create_batch(2)
+        url = reverse(Eigenschap)
+
+        response = self.client.get(url, {"someparam": "somevalue"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "unknown-parameters")
 
 
 class EigenschapPaginationTestCase(APITestCase):

--- a/src/openzaak/components/catalogi/tests/test_informatieobjecttype.py
+++ b/src/openzaak/components/catalogi/tests/test_informatieobjecttype.py
@@ -1,9 +1,8 @@
 from unittest import skip
 
-from django.urls import reverse
-
 from rest_framework import status
 from vng_api_common.constants import VertrouwelijkheidsAanduiding
+from vng_api_common.tests import get_validation_errors, reverse
 
 from ..models import InformatieObjectType
 from .base import APITestCase
@@ -225,6 +224,17 @@ class InformatieObjectTypeFilterAPITests(APITestCase):
         self.assertEqual(
             data[0]["url"], f"http://testserver{informatieobjecttype2_url}"
         )
+
+    def test_validate_unknown_query_params(self):
+        InformatieObjectTypeFactory.create_batch(2)
+        url = reverse(InformatieObjectType)
+
+        response = self.client.get(url, {"someparam": "somevalue"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "unknown-parameters")
 
 
 class InformatieObjectTypePaginationTestCase(APITestCase):

--- a/src/openzaak/components/catalogi/tests/test_relatieklassen.py
+++ b/src/openzaak/components/catalogi/tests/test_relatieklassen.py
@@ -1,7 +1,7 @@
 from unittest import skip
 
 from rest_framework import status
-from vng_api_common.tests import reverse, reverse_lazy
+from vng_api_common.tests import get_validation_errors, reverse, reverse_lazy
 
 from ..constants import RichtingChoices
 from ..models import ZaakInformatieobjectType
@@ -272,6 +272,17 @@ class ZaakInformatieobjectTypeFilterAPITests(APITestCase):
 
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["url"], f"http://testserver{ziot4_url}")
+
+    def test_validate_unknown_query_params(self):
+        ZaakInformatieobjectTypeFactory.create_batch(2)
+        url = reverse(ZaakInformatieobjectType)
+
+        response = self.client.get(url, {"someparam": "somevalue"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "unknown-parameters")
 
 
 class ZaakInformatieobjectTypePaginationTestCase(APITestCase):

--- a/src/openzaak/components/catalogi/tests/test_resultaattype.py
+++ b/src/openzaak/components/catalogi/tests/test_resultaattype.py
@@ -386,6 +386,17 @@ class ResultaatTypeFilterAPITests(APITestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["url"], f"http://testserver{resultaattype2_url}")
 
+    def test_validate_unknown_query_params(self):
+        ResultaatTypeFactory.create_batch(2)
+        url = reverse(ResultaatType)
+
+        response = self.client.get(url, {"someparam": "somevalue"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "unknown-parameters")
+
 
 class ResultaatTypePaginationTestCase(APITestCase):
     maxDiff = None

--- a/src/openzaak/components/catalogi/tests/test_statustype.py
+++ b/src/openzaak/components/catalogi/tests/test_statustype.py
@@ -1,5 +1,5 @@
 from rest_framework import status
-from vng_api_common.tests import reverse
+from vng_api_common.tests import get_validation_errors, reverse
 
 from ..models import StatusType
 from .base import APITestCase
@@ -204,6 +204,17 @@ class StatusTypeFilterAPITests(APITestCase):
 
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["url"], f"http://testserver{statustype2_url}")
+
+    def test_validate_unknown_query_params(self):
+        StatusTypeFactory.create_batch(2)
+        url = reverse(StatusType)
+
+        response = self.client.get(url, {"someparam": "somevalue"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "unknown-parameters")
 
 
 class StatusTypePaginationTestCase(APITestCase):

--- a/src/openzaak/components/catalogi/tests/test_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/test_zaaktype.py
@@ -522,6 +522,17 @@ class ZaakTypeFilterAPITests(APITestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["url"], f"http://testserver{zaaktype1_url}")
 
+    def test_validate_unknown_query_params(self):
+        ZaakTypeFactory.create_batch(2)
+        url = reverse(ZaakType)
+
+        response = self.client.get(url, {"someparam": "somevalue"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "unknown-parameters")
+
 
 @skip("Not in current MVP")
 class ZaakObjectTypeAPITests(APITestCase):

--- a/src/openzaak/components/documenten/api/viewsets.py
+++ b/src/openzaak/components/documenten/api/viewsets.py
@@ -76,6 +76,7 @@ REGISTRATIE_QUERY_PARAM = openapi.Parameter(
 
 
 class EnkelvoudigInformatieObjectViewSet(
+    CheckQueryParamsMixin,
     NotificationViewSetMixin,
     ListFilterByAuthorizationsMixin,
     AuditTrailViewsetMixin,
@@ -368,6 +369,7 @@ class EnkelvoudigInformatieObjectViewSet(
 
 
 class GebruiksrechtenViewSet(
+    CheckQueryParamsMixin,
     NotificationViewSetMixin,
     ListFilterByAuthorizationsMixin,
     AuditTrailViewsetMixin,

--- a/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject.py
+++ b/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject.py
@@ -310,6 +310,17 @@ class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APITestCase):
         error = get_validation_errors(response, "nonFieldErrors")
         self.assertEqual(error["code"], "pending-relations")
 
+    def test_validate_unknown_query_params(self):
+        EnkelvoudigInformatieObjectFactory.create_batch(2)
+        url = reverse(EnkelvoudigInformatieObject)
+
+        response = self.client.get(url, {"someparam": "somevalue"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "unknown-parameters")
+
 
 @override_settings(SENDFILE_BACKEND="sendfile.backends.simple")
 class EnkelvoudigInformatieObjectVersionHistoryAPITests(JWTAuthMixin, APITestCase):

--- a/src/openzaak/components/documenten/tests/test_gebruiksrechten.py
+++ b/src/openzaak/components/documenten/tests/test_gebruiksrechten.py
@@ -4,6 +4,7 @@ from vng_api_common.tests import get_validation_errors, reverse
 
 from openzaak.utils.tests import JWTAuthMixin
 
+from ..models import Gebruiksrechten
 from .factories import (
     EnkelvoudigInformatieObjectCanonicalFactory,
     EnkelvoudigInformatieObjectFactory,
@@ -91,3 +92,14 @@ class GebruiksrechtenTests(JWTAuthMixin, APITestCase):
 
         eio_data = self.client.get(eio_url).json()
         self.assertIsNone(eio_data["indicatieGebruiksrecht"])
+
+    def test_validate_unknown_query_params(self):
+        GebruiksrechtenFactory.create_batch(2)
+        url = reverse(Gebruiksrechten)
+
+        response = self.client.get(url, {"someparam": "somevalue"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "unknown-parameters")

--- a/src/openzaak/components/documenten/tests/test_objectinformatieobject.py
+++ b/src/openzaak/components/documenten/tests/test_objectinformatieobject.py
@@ -261,6 +261,16 @@ class ObjectInformatieObjectTests(JWTAuthMixin, APITestCase):
         error = get_validation_errors(response, "object")
         self.assertEqual(error["code"], "invalid")
 
+    def test_validate_unknown_query_params(self):
+        url = reverse(ObjectInformatieObject)
+
+        response = self.client.get(url, {"someparam": "somevalue"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "unknown-parameters")
+
 
 class ObjectInformatieObjectDestroyTests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True

--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -353,6 +353,7 @@ class StatusViewSet(
 
 
 class ZaakObjectViewSet(
+    CheckQueryParamsMixin,
     NotificationCreateMixin,
     ListFilterByAuthorizationsMixin,
     AuditTrailCreateMixin,
@@ -532,6 +533,7 @@ class ZaakEigenschapViewSet(
 
 
 class KlantContactViewSet(
+    CheckQueryParamsMixin,
     NotificationCreateMixin,
     ListFilterByAuthorizationsMixin,
     AuditTrailCreateMixin,

--- a/src/openzaak/components/zaken/tests/test_validation.py
+++ b/src/openzaak/components/zaken/tests/test_validation.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest import skip
 from unittest.mock import patch
 
 from django.test import override_settings
@@ -32,12 +33,14 @@ from openzaak.components.documenten.tests.factories import (
 from openzaak.utils.tests import JWTAuthMixin
 
 from ..constants import AardZaakRelatie, BetalingsIndicatie
-from ..models import ZaakInformatieObject
+from ..models import KlantContact, Resultaat, ZaakInformatieObject, ZaakObject
 from .factories import (
+    KlantContactFactory,
     ResultaatFactory,
     StatusFactory,
     ZaakFactory,
     ZaakInformatieObjectFactory,
+    ZaakObjectFactory,
 )
 from .utils import ZAAK_WRITE_KWARGS, isodatetime
 
@@ -556,6 +559,51 @@ class FilterValidationTests(JWTAuthMixin, APITestCase):
             with self.subTest(query_param=key, value=value):
                 response = self.client.get(url, {key: value})
                 self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @skip("Enable when klantcontact has pagination")
+    def test_validate_klantcontact_unknown_query_params(self):
+        KlantContactFactory.create_batch(2)
+        url = reverse(KlantContact)
+
+        response = self.client.get(url, {"someparam": "somevalue"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "unknown-parameters")
+
+    def test_validate_resultaat_unknown_query_params(self):
+        ResultaatFactory.create_batch(2)
+        url = reverse(Resultaat)
+
+        response = self.client.get(url, {"someparam": "somevalue"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "unknown-parameters")
+
+    def test_validate_zaakinformatieobject_unknown_query_params(self):
+        ZaakInformatieObjectFactory.create_batch(2)
+        url = reverse(ZaakInformatieObject)
+
+        response = self.client.get(url, {"someparam": "somevalue"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "unknown-parameters")
+
+    def test_validate_zaakobject_unknown_query_params(self):
+        ZaakObjectFactory.create_batch(2)
+        url = reverse(ZaakObject)
+
+        response = self.client.get(url, {"someparam": "somevalue"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "unknown-parameters")
 
 
 class StatusValidationTests(JWTAuthMixin, APITestCase):


### PR DESCRIPTION
fixes https://github.com/open-zaak/open-zaak/issues/139

The test I added for query parameter validation on `KlantContact` is currently being skipped, and the skip should be removed once https://github.com/open-zaak/open-zaak/issues/141 is fixed and the viewset has pagination