### PR TITLE
Feature/resource validation for internal fk

### DIFF
--- a/src/openzaak/components/documenten/tests/test_validation.py
+++ b/src/openzaak/components/documenten/tests/test_validation.py
@@ -53,6 +53,17 @@ class EnkelvoudigInformatieObjectTests(JWTAuthMixin, APITestCase):
         error = get_validation_errors(response, "informatieobjecttype")
         self.assertEqual(error["code"], "bad-url")
 
+    def test_validate_informatieobjecttype_invalid_resource(self):
+        url = reverse("enkelvoudiginformatieobject-list")
+
+        response = self.client.post(
+            url, {"informatieobjecttype": "https://example.com"}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "informatieobjecttype")
+        self.assertEqual(error["code"], "invalid-resource")
+
     def test_validate_informatieobjecttype_unpublished(self):
         informatieobjecttype = InformatieObjectTypeFactory.create()
         informatieobjecttype_url = reverse(informatieobjecttype)

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -280,7 +280,7 @@ class ZaakSerializer(
                         "Resultaat",
                         settings.REFERENTIELIJSTEN_API_SPEC,
                         get_auth=get_auth,
-                    ),
+                    )
                 ]
             },
             "hoofdzaak": {

--- a/src/openzaak/utils/serializer_fields.py
+++ b/src/openzaak/utils/serializer_fields.py
@@ -1,13 +1,15 @@
 from django.utils.translation import ugettext_lazy as _
-
+from vng_api_common.validators import URLValidator
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 
 
 class LengthValidationMixin:
     default_error_messages = {
         "max_length": _("Ensure this field has no more than {max_length} characters."),
         "min_length": _("Ensure this field has at least {min_length} characters."),
-        "bad-url": "Please provide a valid URL.",
+        "bad-url": "The URL {url} could not be fetched. Exception: {exc}",
+        "invalid-resource": "Please provide a valid URL. Exception: {exc}",
     }
 
     def __init__(self, **kwargs):
@@ -16,15 +18,6 @@ class LengthValidationMixin:
 
         super().__init__(**kwargs)
 
-    def fail(self, key, **kwargs):
-        """
-        Replace build-in 'no_match' error code with `bad-url` to make it consistent with
-        reference implementation
-        """
-        if key == "no_match":
-            key = "bad-url"
-        super().fail(key, **kwargs)
-
     def to_internal_value(self, data):
         if self.max_length and len(data) > self.max_length:
             self.fail("max_length", max_length=self.max_length, length=len(data))
@@ -32,7 +25,20 @@ class LengthValidationMixin:
         if self.min_length and len(data) < self.min_length:
             self.fail("min_length", max_length=self.min_length, length=len(data))
 
-        return super().to_internal_value(data)
+        # check if url is valid
+        try:
+            value = super().to_internal_value(data)
+        except ValidationError as field_exc:
+            # rewrite validation code to make it fit reference implementation
+            # if url is not valid
+            try:
+                URLValidator()(data)
+            except ValidationError as exc:
+                self.fail("bad-url", url=data, exc=exc)
+
+            # if the url is not bad -> then the problem is that it doesn't fit resource
+            self.fail("invalid-resource", exc=field_exc)
+        return value
 
 
 class LengthHyperlinkedRelatedField(

--- a/src/openzaak/utils/serializer_fields.py
+++ b/src/openzaak/utils/serializer_fields.py
@@ -1,7 +1,8 @@
 from django.utils.translation import ugettext_lazy as _
-from vng_api_common.validators import URLValidator
+
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
+from vng_api_common.validators import URLValidator
 
 
 class LengthValidationMixin:


### PR DESCRIPTION
Issue - https://github.com/open-zaak/open-zaak/issues/119

Changes:
1. For internal FK fields add the division on "bad-url" and "invalid-resource" errors if the url is not resolved