### PR TITLE
optimize db queries - part 3 (zaken component)

### DIFF
--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -530,7 +530,7 @@ class ZaakEigenschapViewSet(
     Een specifieke ZAAKEIGENSCHAP opvragen.
     """
 
-    queryset = ZaakEigenschap.objects.all()
+    queryset = ZaakEigenschap.objects.select_related("zaak", "eigenschap").all()
     serializer_class = ZaakEigenschapSerializer
     permission_classes = (ZaakNestedAuthRequired,)
     lookup_field = "uuid"
@@ -579,7 +579,7 @@ class KlantContactViewSet(
     Een specifiek KLANTCONTACT bij een ZAAK opvragen.
     """
 
-    queryset = KlantContact.objects.all()
+    queryset = KlantContact.objects.select_related("zaak").all()
     serializer_class = KlantContactSerializer
     lookup_field = "uuid"
     pagination_class = PageNumberPagination


### PR DESCRIPTION
Issue - #154

DB queries reduction:
1. Zaken component 

* GET `/zaken/api/v1/zaakeigenschappen` (for 5 observations)
before: 22
after: 12

* GET `/zaken/api/v1/klantcontacten` (for 100 observations)
before: 107
after: 7