### PR TITLE
optimize db queries - part 4 (catalogi component)

### DIFF
--- a/src/openzaak/components/catalogi/api/viewsets/besluittype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/besluittype.py
@@ -57,7 +57,12 @@ class BesluitTypeViewSet(
     Verwijder een BESLUITTYPE. Dit kan alleen als het een concept betreft.
     """
 
-    queryset = BesluitType.objects.all().order_by("-pk")
+    queryset = (
+        BesluitType.objects.all()
+        .select_related("catalogus")
+        .prefetch_related("informatieobjecttypen", "zaaktypes")
+        .order_by("-pk")
+    )
     serializer_class = BesluitTypeSerializer
     filterset_class = BesluitTypeFilter
     lookup_field = "uuid"

--- a/src/openzaak/components/catalogi/api/viewsets/catalogus.py
+++ b/src/openzaak/components/catalogi/api/viewsets/catalogus.py
@@ -51,7 +51,11 @@ class CatalogusViewSet(
     ZAAKTYPEn, INFORMATIEOBJECTTYPEn en BESLUITTYPEn zijn.
     """
 
-    queryset = Catalogus.objects.all().order_by("-pk")
+    queryset = (
+        Catalogus.objects.all()
+        .prefetch_related("besluittype_set", "zaaktype_set", "informatieobjecttype_set")
+        .order_by("-pk")
+    )
     serializer_class = CatalogusSerializer
     filter_class = CatalogusFilter
     lookup_field = "uuid"

--- a/src/openzaak/components/catalogi/api/viewsets/eigenschap.py
+++ b/src/openzaak/components/catalogi/api/viewsets/eigenschap.py
@@ -59,7 +59,11 @@ class EigenschapViewSet(
     concept betreft.
     """
 
-    queryset = Eigenschap.objects.all().order_by("-pk")
+    queryset = (
+        Eigenschap.objects.all()
+        .select_related("specificatie_van_eigenschap", "zaaktype")
+        .order_by("-pk")
+    )
     serializer_class = EigenschapSerializer
     filterset_class = EigenschapFilter
     lookup_field = "uuid"

--- a/src/openzaak/components/catalogi/api/viewsets/informatieobjecttype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/informatieobjecttype.py
@@ -59,7 +59,9 @@ class InformatieObjectTypeViewSet(
     betreft.
     """
 
-    queryset = InformatieObjectType.objects.all().order_by("-pk")
+    queryset = (
+        InformatieObjectType.objects.all().select_related("catalogus").order_by("-pk")
+    )
     serializer_class = InformatieObjectTypeSerializer
     filterset_class = InformatieObjectTypeFilter
     lookup_field = "uuid"

--- a/src/openzaak/components/catalogi/api/viewsets/relatieklassen.py
+++ b/src/openzaak/components/catalogi/api/viewsets/relatieklassen.py
@@ -66,7 +66,11 @@ class ZaakTypeInformatieObjectTypeViewSet(
     het bijbehorende ZAAKTYPE een concept betreft.
     """
 
-    queryset = ZaakInformatieobjectType.objects.all().order_by("-pk")
+    queryset = (
+        ZaakInformatieobjectType.objects.all()
+        .select_related("zaaktype", "informatieobjecttype")
+        .order_by("-pk")
+    )
     serializer_class = ZaakTypeInformatieObjectTypeSerializer
     filterset_class = ZaakInformatieobjectTypeFilter
     lookup_field = "uuid"

--- a/src/openzaak/components/catalogi/api/viewsets/resultaattype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/resultaattype.py
@@ -59,7 +59,7 @@ class ResultaatTypeViewSet(
     een concept betreft.
     """
 
-    queryset = ResultaatType.objects.all().order_by("-pk")
+    queryset = ResultaatType.objects.all().select_related("zaaktype").order_by("-pk")
     serializer_class = ResultaatTypeSerializer
     filter_class = ResultaatTypeFilter
     lookup_field = "uuid"

--- a/src/openzaak/components/catalogi/api/viewsets/roltype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/roltype.py
@@ -59,7 +59,7 @@ class RolTypeViewSet(
     concept betreft.
     """
 
-    queryset = RolType.objects.order_by("-pk")
+    queryset = RolType.objects.select_related("zaaktype").order_by("-pk")
     serializer_class = RolTypeSerializer
     filterset_class = RolTypeFilter
     lookup_field = "uuid"


### PR DESCRIPTION
Issue - #154

DB queries reduction (for 100 observations):

`Catalogi` component:
GET `/zaken/api/v1/besluittypen`
before: 306
after: 8

GET `/zaken/api/v1/catalogussen` (for 10 observations)
before: 36
after: 9

GET `/zaken/api/v1/eigenschappen`
before: 106
after: 6

GET `/zaken/api/v1/informatieobjecttypen`
before: 106
after: 6

GET `/zaken/api/v1/zaaktype-informatieobjecttypen`
before: 206
after: 6

GET `/zaken/api/v1/resultaattypen`
before: 106
after: 6

GET `/zaken/api/v1/roltypen`:
before: 106
after: 6