### PR TITLE
Fixes #128 -- Validate external informatieobjecten

### DIFF
--- a/src/openzaak/components/documenten/models.py
+++ b/src/openzaak/components/documenten/models.py
@@ -315,6 +315,8 @@ class EnkelvoudigInformatieObject(AuditTrailMixin, APIMixin, InformatieObject):
         db_index=True,
     )
 
+    _locked = False
+
     class Meta:
         unique_together = ("uuid", "versie")
         verbose_name = _("Enkelvoudige informatie object")
@@ -322,12 +324,15 @@ class EnkelvoudigInformatieObject(AuditTrailMixin, APIMixin, InformatieObject):
         indexes = [models.Index(fields=["canonical", "-versie"])]
         ordering = ["canonical", "-versie"]
 
-    @property
-    def locked(self) -> bool:
+    def _get_locked(self) -> bool:
         if self.pk:
             return bool(self.canonical.lock)
+        return self._locked
 
-        raise NotImplementedError
+    def _set_locked(self, value: bool) -> None:
+        self._locked = value
+
+    locked = property(_get_locked, _set_locked)
 
 
 class Gebruiksrechten(models.Model):

--- a/src/openzaak/components/documenten/models.py
+++ b/src/openzaak/components/documenten/models.py
@@ -322,6 +322,13 @@ class EnkelvoudigInformatieObject(AuditTrailMixin, APIMixin, InformatieObject):
         indexes = [models.Index(fields=["canonical", "-versie"])]
         ordering = ["canonical", "-versie"]
 
+    @property
+    def locked(self) -> bool:
+        if self.pk:
+            return bool(self.canonical.lock)
+
+        raise NotImplementedError
+
 
 class Gebruiksrechten(models.Model):
     uuid = models.UUIDField(

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -41,6 +41,7 @@ from openzaak.components.catalogi.models import (
     ZaakType,
 )
 from openzaak.components.documenten.api.fields import EnkelvoudigInformatieObjectField
+from openzaak.components.documenten.constants import Statussen
 from openzaak.components.documenten.models import (
     EnkelvoudigInformatieObject,
     EnkelvoudigInformatieObjectCanonical,
@@ -374,7 +375,7 @@ class ZaakSerializer(
 
             if (
                 EnkelvoudigInformatieObject.objects.filter(id__in=Subquery(io_ids))
-                .exclude(status="gearchiveerd")
+                .exclude(status=Statussen.gearchiveerd)
                 .exists()
             ):
 

--- a/src/openzaak/components/zaken/api/validators.py
+++ b/src/openzaak/components/zaken/api/validators.py
@@ -224,8 +224,17 @@ class ZaakArchiveIOsArchivedValidator:
     def validate_remote_eios_archived(
         self, attrs: dict, error: serializers.ValidationError
     ):
-        pass
-        # import bpdb; bpdb.set_trace()
+        remote_zios = self.instance.zaakinformatieobject_set.exclude(
+            _informatieobject_url=""
+        )
+        # This is a very naive approach to load all the remote objects - it happens
+        # sequentially, while futures.concurrent _could_ be used. Let's see first
+        # how performance is in this setup. Because we're looping and exiting as
+        # soon as an error condition is found, we can reduce unnecessary network
+        # calls.
+        for zio in remote_zios:
+            if zio.informatieobject.status != Statussen.gearchiveerd:
+                raise error
 
     def validate_extra_attributes(self, attrs: dict):
         for attr in ["archiefnominatie", "archiefactiedatum"]:

--- a/src/openzaak/components/zaken/api/validators.py
+++ b/src/openzaak/components/zaken/api/validators.py
@@ -1,15 +1,21 @@
 from datetime import date
 
 from django.db import models
+from django.db.models import Max, Subquery
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import serializers
+from vng_api_common.constants import Archiefstatus
 from vng_api_common.validators import (
     UniekeIdentificatieValidator as _UniekeIdentificatieValidator,
 )
 
-from openzaak.components.documenten.models import EnkelvoudigInformatieObject
+from openzaak.components.documenten.constants import Statussen
+from openzaak.components.documenten.models import (
+    EnkelvoudigInformatieObject,
+    EnkelvoudigInformatieObjectCanonical,
+)
 
 
 class RolOccurenceValidator:
@@ -154,3 +160,84 @@ class DateNotInFutureValidator:
 
         if value > now:
             raise serializers.ValidationError(self.message, code=self.code)
+
+
+class ZaakArchiveIOsArchivedValidator:
+    """
+    On archival of a zaak, validate that the related documents are archived.
+    """
+
+    def set_context(self, serializer: serializers.Serializer):
+        self.instance = serializer.instance
+
+    def __call__(self, attrs: dict):
+        default_archiefstatus = (
+            self.instance.archiefstatus
+            if self.instance
+            else Archiefstatus.nog_te_archiveren
+        )
+        archiefstatus = attrs.get("archiefstatus", default_archiefstatus)
+
+        # no archiving status set -> nothing to do
+        if archiefstatus == Archiefstatus.nog_te_archiveren:
+            return
+
+        documents_not_archived_error = serializers.ValidationError(
+            {
+                "archiefstatus",
+                _(
+                    "Er zijn gerelateerde informatieobjecten waarvan de `status` nog niet gelijk is aan "
+                    "`gearchiveerd`. Dit is een voorwaarde voor het zetten van de `archiefstatus` "
+                    "op een andere waarde dan `nog_te_archiveren`."
+                ),
+            },
+            code="documents-not-archived",
+        )
+
+        self.validate_local_eios_archived(attrs, documents_not_archived_error)
+        self.validate_remote_eios_archived(attrs, documents_not_archived_error)
+        self.validate_extra_attributes(attrs)
+
+    def validate_local_eios_archived(
+        self, attrs: dict, error: serializers.ValidationError
+    ):
+        # TODO: check remote ZIO.informatieobject
+        # search for related informatieobjects with status != 'gearchiveerd'
+        canonical_ids = self.instance.zaakinformatieobject_set.values(
+            "_informatieobject_id"
+        )
+        io_ids = (
+            EnkelvoudigInformatieObjectCanonical.objects.filter(
+                id__in=Subquery(canonical_ids)
+            )
+            .annotate(last=Max("enkelvoudiginformatieobject"))
+            .values("last")
+        )
+
+        if (
+            EnkelvoudigInformatieObject.objects.filter(id__in=Subquery(io_ids))
+            .exclude(status=Statussen.gearchiveerd)
+            .exists()
+        ):
+            raise error
+
+    def validate_remote_eios_archived(
+        self, attrs: dict, error: serializers.ValidationError
+    ):
+        pass
+        # import bpdb; bpdb.set_trace()
+
+    def validate_extra_attributes(self, attrs: dict):
+        for attr in ["archiefnominatie", "archiefactiedatum"]:
+            if not attrs.get(
+                attr, getattr(self.instance, attr) if self.instance else None
+            ):
+                raise serializers.ValidationError(
+                    {
+                        attr: _(
+                            "Moet van een waarde voorzien zijn als de 'Archiefstatus' een waarde heeft anders dan "
+                            f"'{Archiefstatus.nog_te_archiveren}'."
+                        )
+                    },
+                    code=f"{attr}-not-set",
+                )

--- a/src/openzaak/components/zaken/api/validators.py
+++ b/src/openzaak/components/zaken/api/validators.py
@@ -276,6 +276,13 @@ class EndStatusIOsUnlockedValidator:
         if not zaak:
             return
 
-        # TODO: check remote documents!
-        if zaak.zaakinformatieobject_set.exclude(_informatieobject__lock="").exists():
+        local_zios = zaak.zaakinformatieobject_set.filter(
+            _informatieobject__isnull=False,
+        )
+        if local_zios.exclude(_informatieobject__lock="").exists():
             raise serializers.ValidationError(self.message, code=self.code)
+
+        remote_zios = zaak.zaakinformatieobject_set.exclude(_informatieobject_url="")
+        for zio in remote_zios:
+            if zio.informatieobject.locked:
+                raise serializers.ValidationError(self.message, code=self.code)

--- a/src/openzaak/components/zaken/loaders.py
+++ b/src/openzaak/components/zaken/loaders.py
@@ -2,6 +2,7 @@ from urllib.parse import urlparse
 
 from django.db.models.base import ModelBase
 
+from django_loose_fk.virtual_models import ProxyMixin, get_model_instance
 from vng_api_common.utils import get_resource_for_path
 
 from openzaak.components.catalogi.models import InformatieObjectType
@@ -25,10 +26,26 @@ class EIOLoader(AuthorizedRequestsLoader):
         if model is InformatieObjectType:
             return self.resolve_io_type(url)
 
-        return super().load(url, model=model)
+        data = self.fetch_object(url)
+        model_instance = get_model_instance(model, data, loader=self)
+        self.add_missing_props(model, model_instance, data)
+        return model_instance
 
     def resolve_io_type(self, url: str):
         try:
             return get_resource_for_path(urlparse(url).path)
         except InformatieObjectType.DoesNotExist:
             return super().load(url, model=InformatieObjectType)
+
+    def add_missing_props(
+        self, model: ModelBase, model_instance: ProxyMixin, data: dict
+    ) -> None:
+        """
+        Translate JSON response properties to Python props that are not model fields.
+        """
+        from openzaak.components.documenten.models import EnkelvoudigInformatieObject
+
+        if not issubclass(model, EnkelvoudigInformatieObject):
+            return
+
+        model_instance.locked = data["locked"]

--- a/src/openzaak/components/zaken/tests/test_validation.py
+++ b/src/openzaak/components/zaken/tests/test_validation.py
@@ -1066,7 +1066,10 @@ class ExternalDocumentsAPITests(JWTAuthMixin, APITestCase):
     def test_eindstatus_with_informatieobject_unlocked(self, m):
         REMOTE_DOCUMENT = "https://external.nl/documenten/123"
         m.get(
-            REMOTE_DOCUMENT, json=get_eio_response(REMOTE_DOCUMENT, locked=False),
+            REMOTE_DOCUMENT,
+            json=get_eio_response(
+                REMOTE_DOCUMENT, locked=False, indicatieGebruiksrecht=False,
+            ),
         )
         zaak = ZaakFactory.create(zaaktype=self.zaaktype)
         zaak_url = reverse(zaak)

--- a/src/openzaak/loaders.py
+++ b/src/openzaak/loaders.py
@@ -2,6 +2,7 @@ import json
 
 import requests
 from django_loose_fk.loaders import BaseLoader, FetchError, FetchJsonError
+from djangorestframework_camel_case.util import underscoreize
 
 
 class AuthorizedRequestsLoader(BaseLoader):
@@ -31,4 +32,4 @@ class AuthorizedRequestsLoader(BaseLoader):
         except json.JSONDecodeError as exc:
             raise FetchJsonError(exc.args[0]) from exc
 
-        return data
+        return underscoreize(data)

--- a/src/openzaak/loaders.py
+++ b/src/openzaak/loaders.py
@@ -11,7 +11,7 @@ class AuthorizedRequestsLoader(BaseLoader):
     """
 
     @staticmethod
-    def fetch_object(url: str) -> dict:
+    def fetch_object(url: str, do_underscoreize=True) -> dict:
         from vng_api_common.models import APICredential
 
         client_auth = APICredential.get_auth(url)
@@ -31,5 +31,8 @@ class AuthorizedRequestsLoader(BaseLoader):
             data = response.json()
         except json.JSONDecodeError as exc:
             raise FetchJsonError(exc.args[0]) from exc
+
+        if not do_underscoreize:
+            return data
 
         return underscoreize(data)

--- a/src/openzaak/utils/validators.py
+++ b/src/openzaak/utils/validators.py
@@ -104,7 +104,7 @@ class LooseFkResourceValidator(FKOrURLValidator):
         if is_local:
             return
 
-        obj = AuthorizedRequestsLoader.fetch_object(value)
+        obj = AuthorizedRequestsLoader.fetch_object(value, do_underscoreize=False)
 
         # check if the shape matches
         schema = fetcher.fetch(self.oas_schema)


### PR DESCRIPTION
Given that an OpenZaak ZAAK is related with a document from somewhere else, the following validations now happen conform ZGW standard:

* when a case is being closed:
    * all documents must have `indicatieGebruiksrecht` set to either `false` or `true`
    * all documents must be unlocked
* when a ZAAK is being archived, all documents must be archived prior to that

The implementation has moved the validation code from the serializer level (`validate` method) into three validator classes.