### PR TITLE
Another attempt at fixing the Travis deploy step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,9 +92,8 @@ jobs:
       before_install: skip
       install: skip
       before_script: skip
-      script:
-        - exit 0
-      after_success: skip
+      script: echo "noop"
+      after_success: echo "trigger deploy?"
       deploy:
         - provider: script
           script: bin/docker_push.sh latest

--- a/src/openzaak/components/documenten/models.py
+++ b/src/openzaak/components/documenten/models.py
@@ -399,7 +399,7 @@ class Gebruiksrechten(models.Model):
 
     def unique_representation(self):
         informatieobject = self.informatieobject.latest_version
-        return f"({informatieobject.unique_representation()}) - {self.omschrijving_voorwaarden}"
+        return f"({informatieobject.unique_representation()}) - {self.omschrijving_voorwaarden[:50]}"
 
 
 class ObjectInformatieObject(models.Model):

--- a/src/openzaak/components/documenten/tests/admin/test_eiocanonical_inline_audittrail.py
+++ b/src/openzaak/components/documenten/tests/admin/test_eiocanonical_inline_audittrail.py
@@ -137,7 +137,9 @@ class EioAdminInlineTests(WebTest):
         self.assertEqual(new_data["identificatie"], "12345")
 
     def test_gebruiksrechten_delete(self):
-        eio = EnkelvoudigInformatieObjectFactory.create(canonical=self.canonical)
+        eio = EnkelvoudigInformatieObjectFactory.create(
+            canonical=self.canonical, identificatie="short",
+        )
         eio_url = get_operation_url("enkelvoudiginformatieobject_read", uuid=eio.uuid)
         gebruiksrechten = GebruiksrechtenFactory.create(informatieobject=self.canonical)
         gebruiksrechten_url = get_operation_url(


### PR DESCRIPTION
Saw some examples with `script` empty for a no-op, and Travis docs explicitly mention you're not allowed to use `exit`