### PR TITLE
Remove added help text

### DIFF
--- a/src/openzaak/components/catalogi/admin/forms.py
+++ b/src/openzaak/components/catalogi/admin/forms.py
@@ -35,13 +35,6 @@ class ZaakTypeForm(forms.ModelForm):
         self.fields["verlenging_mogelijk"].widget.required = True
         self.fields["publicatie_indicatie"].widget.required = True
 
-        self.fields[
-            "trefwoorden"
-        ].help_text += " Gebruik een komma om waarden van elkaar te onderscheiden."
-        self.fields[
-            "verantwoordingsrelatie"
-        ].help_text += " Gebruik een komma om waarden van elkaar te onderscheiden."
-
     def clean(self):
         super().clean()
 


### PR DESCRIPTION
The field is a dynamic-arrayfield in the admin, so no need to use
comma's for value-separation. Removed the help text to remove confusion.