### PR TITLE
Clean up unused imports/variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,13 @@ jobs:
       before_script: skip
       script: black --check src
 
+    - name: flake8
+      before_install: skip
+      install:
+        - pip install flake8
+      before_script: skip
+      script: flake8 src
+
     - name: Test docker image build
       before_install: skip
       install: skip

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -4,6 +4,7 @@ pip-tools
 # Code formatting
 black
 isort
+flake8
 
 # Debug tooling
 django-debug-toolbar

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -46,8 +46,10 @@ drf-flex-fields==0.5.0
 drf-nested-routers==0.90.2
 drf-writable-nested==0.4.3
 drf-yasg==1.16.0
+entrypoints==0.3          # via flake8
 factory-boy==2.12.0
 faker==2.0.1
+flake8==3.7.9
 freezegun==0.3.12
 gemma-zds-client==0.13.0
 humanize==0.5.1
@@ -62,11 +64,14 @@ jinja2==2.10.1
 markdown==3.0.1
 markupsafe==1.0
 maykin-django-better-admin-arrayfield==1.0.5
+mccabe==0.6.1             # via flake8
 oyaml==0.7
 packaging==19.2           # via sphinx
 pathspec==0.6.0           # via black
 pip-tools==4.2.0
 psycopg2==2.8.3
+pycodestyle==2.5.0        # via flake8
+pyflakes==2.1.1           # via flake8
 pygments==2.4.2           # via sphinx
 pyjwt==1.6.4
 pyparsing==2.4.2          # via packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 [flake8]
 ; absolute maximum - more lenient than black's 88
 max-line-length = 119
-ignore = E121,E123,E126,E226,E24,E704,W503,W504,E231,F405
+ignore = E121,E123,E126,E226,E24,E704,W503,W504,E231,F405,E203
 exclude=migrations,static,media
 
 [coverage:run]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,3 @@
-[pycodestyle]
-[pep8]
-ignore=W293,W291,E501,E261
-max-line-length=120
-exclude=migrations,static,media
-
 [isort]
 combine_as_imports = true
 default_section = THIRDPARTY
@@ -16,6 +10,13 @@ not_skip = __init__.py
 known_django=django
 known_first_party=openzaak
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+
+; black compatible settings
+[flake8]
+; absolute maximum - more lenient than black's 88
+max-line-length = 119
+ignore = E121,E123,E126,E226,E24,E704,W503,W504,E231,F405
+exclude=migrations,static,media
 
 [coverage:run]
 branch = True

--- a/src/openzaak/components/besluiten/tests/admin/test_besluit_inline_audittrail.py
+++ b/src/openzaak/components/besluiten/tests/admin/test_besluit_inline_audittrail.py
@@ -1,4 +1,3 @@
-from django.test import TestCase
 from django.urls import reverse
 
 from django_webtest import WebTest

--- a/src/openzaak/components/besluiten/tests/test_audittrails.py
+++ b/src/openzaak/components/besluiten/tests/test_audittrails.py
@@ -130,6 +130,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Delete the Besluit
         response = self.client.delete(besluit_data["url"])
 
+        self.assertEqual(response.status_code, 204)
         # Verify that deleting the Besluit deletes all related AuditTrails
         audittrails = AuditTrail.objects.filter(hoofd_object=besluit_data["url"])
         self.assertFalse(audittrails.exists())

--- a/src/openzaak/components/besluiten/tests/test_auth.py
+++ b/src/openzaak/components/besluiten/tests/test_auth.py
@@ -124,7 +124,7 @@ class BioReadTests(JWTAuthMixin, APITestCase):
         # must show up
         bio1 = BesluitInformatieObjectFactory.create(besluit=besluit1)
         # must not show up
-        bio2 = BesluitInformatieObjectFactory.create(besluit=besluit2)
+        BesluitInformatieObjectFactory.create(besluit=besluit2)
 
         response = self.client.get(url)
 

--- a/src/openzaak/components/catalogi/api/viewsets/informatieobjecttype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/informatieobjecttype.py
@@ -1,4 +1,4 @@
-from rest_framework import mixins, viewsets
+from rest_framework import viewsets
 from rest_framework.pagination import PageNumberPagination
 from vng_api_common.notifications.viewsets import NotificationViewSetMixin
 from vng_api_common.viewsets import CheckQueryParamsMixin

--- a/src/openzaak/components/catalogi/api/viewsets/relatieklassen.py
+++ b/src/openzaak/components/catalogi/api/viewsets/relatieklassen.py
@@ -22,7 +22,6 @@ from .mixins import ConceptDestroyMixin, ConceptFilterMixin
 
 class ZaakTypeInformatieObjectTypeSchema(AutoSchema):
     def get_operation_id(self, operation_keys=None):
-        operation_id = super().get_operation_id(operation_keys=operation_keys)
         return f"zaakinformatieobjecttype_{operation_keys[-1]}"
 
 

--- a/src/openzaak/components/catalogi/management/commands/export.py
+++ b/src/openzaak/components/catalogi/management/commands/export.py
@@ -3,7 +3,6 @@ import json
 import zipfile
 
 from django.apps import apps
-from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand, CommandError
 from django.http import HttpResponse

--- a/src/openzaak/components/catalogi/management/commands/import.py
+++ b/src/openzaak/components/catalogi/management/commands/import.py
@@ -2,8 +2,6 @@ import io
 import json
 import zipfile
 
-from django.apps import apps
-from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from django.utils.translation import ugettext_lazy as _
@@ -71,7 +69,6 @@ class Command(BaseCommand):
 
                     data = json.loads(data)
 
-                    model = apps.get_model("catalogi", resource)
                     serializer = getattr(serializers, f"{resource}Serializer")
 
                     for entry in data:

--- a/src/openzaak/components/catalogi/models/eigenschap.py
+++ b/src/openzaak/components/catalogi/models/eigenschap.py
@@ -12,9 +12,10 @@ from .validators import validate_kardinaliteit, validate_letters_numbers_undersc
 
 class EigenschapSpecificatie(models.Model):
     """
-    Met de ‘subattributen’ (van deze groepattribuutsoort) Groep, Formaat, Lengte, Kardinaliteit en Waardenverzameling
-    wordt een eigenschap gedetailleerd gespecificeerd. Dit vindt alleen plaats als de eigenschap niet gespecificeerd is
-    door middel van het groepattribuutsoort ‘Referentie naar eigenschap’.
+    Met de ‘subattributen’ (van deze groepattribuutsoort) Groep, Formaat, Lengte, Kardinaliteit en
+    Waardenverzameling wordt een eigenschap gedetailleerd gespecificeerd. Dit vindt alleen plaats
+    als de eigenschap niet gespecificeerd is door middel van het groepattribuutsoort
+    ‘Referentie naar eigenschap’.
     """
 
     groep = models.CharField(  # waardenverzameling Letters, cijfers en liggende streepjes
@@ -88,7 +89,8 @@ class EigenschapSpecificatie(models.Model):
                 )
 
         elif self.formaat == FormaatChoices.getal:
-            try:  # specificatie spreekt over kommagescheiden decimaal, wij nemen echter aan dat het punt gescheiden is
+            # specificatie spreekt over kommagescheiden decimaal, wij nemen echter aan dat het punt gescheiden is
+            try:
                 Decimal(self.lengte)
             except (InvalidOperation, TypeError):
                 raise ValidationError(
@@ -118,28 +120,30 @@ class EigenschapSpecificatie(models.Model):
 
 class Eigenschap(models.Model):
     """
-    Een relevant inhoudelijk gegeven dat bij ZAAKen van dit ZAAKTYPE geregistreerd moet kunnen worden en geen standaard
-    kenmerk is van een zaak.
+    Een relevant inhoudelijk gegeven dat bij ZAAKen van dit ZAAKTYPE geregistreerd
+    moet kunnen worden en geen standaard kenmerk is van een zaak.
 
     **Toelichting objecttype**
-    Met standaard kenmerken van een zaak worden bedoeld de attributen die in het RGBZ gespecificeerd zijn bij ZAAK en
-    bij de andere daarin opgenomen objecttypen. Deze kenmerken zijn generiek d.w.z. van toepassing op elke zaak,
-    ongeacht het zaaktype. Niet voor elke zaak van elk zaaktype is dit voldoende informatie voor de behandeling van de
-    zaak, de besturing daarvan en om daarover informatie uit te kunnen wisselen. Zo is voor het behandelen van een
-    aanvraag voor een kapvergunning informatie nodig over de locatie, het type en de diameter van de te kappen boom. Het
-    RGBZ bevat reeds de locatie-kenmerken. Boomtype en Stamdiameter zijn gegevens die specifiek zijn voor zaken van dit
-    zaaktype, de zaaktypespecifieke eigenschappen. Een ander voorbeeld is de evenementdatum bij de behandeling van een
-    aanvraag voor een evenementenvergunning. Met het specificeren van eigenschappen wordt ten eerste beoogd
-    duidelijkheid te geven over de voor een zaaktype relevante eigenschappen en wordt ten tweede beoogd die
-    eigenschappen zodanig te specificeren dat waarden van deze eigenschappen in StUF-ZKN- berichten uitgewisseld kunnen
-    worden. Met de attributen van het objecttype EIGENSCHAP wordt een zaaktypespecifieke eigenschap gespecificeerd. De
-    attributen Eigenschapnaam en Definitie duiden de eigenschap. De eigenschap wordt gegevenstechnisch gespecificeerd
+    Met standaard kenmerken van een zaak worden bedoeld de attributen die in het RGBZ gespecificeerd zijn bij
+    ZAAK en bij de andere daarin opgenomen objecttypen. Deze kenmerken zijn generiek d.w.z. van toepassing
+    op elke zaak, ongeacht het zaaktype. Niet voor elke zaak van elk zaaktype is dit voldoende informatie
+    voor de behandeling van de zaak, de besturing daarvan en om daarover informatie uit te kunnen wisselen.
+    Zo is voor het behandelen van een aanvraag voor een kapvergunning informatie nodig over de locatie,
+    het type en de diameter van de te kappen boom. Het RGBZ bevat reeds de locatie-kenmerken. Boomtype
+    en Stamdiameter zijn gegevens die specifiek zijn voor zaken van dit zaaktype, de zaaktypespecifieke
+    eigenschappen. Een ander voorbeeld is de evenementdatum bij de behandeling van een aanvraag voor
+    een evenementenvergunning. Met het specificeren van eigenschappen wordt ten eerste beoogd duidelijkheid
+    te geven over de voor een zaaktype relevante eigenschappen en wordt ten tweede beoogd die
+    eigenschappen zodanig te specificeren dat waarden van deze eigenschappen in StUF-ZKN-
+    berichten uitgewisseld kunnen worden. Met de attributen van het objecttype EIGENSCHAP
+    wordt een zaaktypespecifieke eigenschap gespecificeerd. De attributen Eigenschapnaam
+    en Definitie duiden de eigenschap. De eigenschap wordt gegevenstechnisch gespecificeerd
     met één van twee groepen attributen:
 
     a) Groep, Formaat, Lengte, Kardinaliteit en Waardenverzameling. Het attribuut ‘Groep’ maakt het mogelijk om
-    eigenschappen te groeperen naar een object of een groepattribuut en, met een StUF-ZKN-bericht, de waarden van de bij
-    een groep behorende eigenschappen voor meerdere objecten uit te wisselen (bijvoorbeeld een ‘kapvergunning’ voor
-    meerdere bomen die ieder apart geduid worden).
+    eigenschappen te groeperen naar een object of een groepattribuut en, met een StUF-ZKN-bericht, de waarden
+    van de bij een groep behorende eigenschappen voor meerdere objecten uit te wisselen (bijvoorbeeld een
+    ‘kapvergunning’ voor meerdere bomen die ieder apart geduid worden).
 
     b) Objecttype, Informatiemodel, Namespace, Schemalocatie, X-path element en Entiteittype. Deze specificeren een
     eigenschap door te refereren naar een berichtenmodel en, bij voorkeur ook, een informatiemodel. De eigenschap wordt
@@ -150,8 +154,8 @@ class Eigenschap(models.Model):
     gespecificeerd worden en op basis waarvan het XML-schema is vervaardigd.
 
     De specificatie ad. a ondersteunt de mogelijkheid om waarden van deze eigenschappen, bij 14een specifieke zaak, uit
-    te wisselen tussen applicaties ten behoeve van gebruik van deze gegevens door de gebruikers van deze applicaties. De
-    gebruikers kunnen deze gegevens interpreteren, de uitwisselende applicaties kennen deze gegevens, zonder
+    te wisselen tussen applicaties ten behoeve van gebruik van deze gegevens door de gebruikers van deze applicaties.
+    De gebruikers kunnen deze gegevens interpreteren, de uitwisselende applicaties kennen deze gegevens, zonder
     voorafgaande afspraken, niet zodanig dat zij daar betrouwbaar bewerkingen op kunnen baseren anders dan tonen en
     eventueel wijzigen en opslaan. De specificatie ad. b ondersteunt de mogelijkheid om waarden van deze eigenschappen,
     bij een specifieke zaak, uit te wisselen tussen applicaties die deze gegevens (willen) kennen teneinde daarop

--- a/src/openzaak/components/catalogi/models/informatieobjecttype.py
+++ b/src/openzaak/components/catalogi/models/informatieobjecttype.py
@@ -1,6 +1,5 @@
 import uuid as _uuid
 
-from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 

--- a/src/openzaak/components/catalogi/models/resultaattype.py
+++ b/src/openzaak/components/catalogi/models/resultaattype.py
@@ -52,7 +52,8 @@ class ResultaatType(models.Model):
         on_delete=models.CASCADE,
         related_name="resultaattypen",
         help_text=_(
-            "URL-referentie naar het ZAAKTYPE van ZAAKen waarin resultaten van dit RESULTAATTYPE bereikt kunnen worden."
+            "URL-referentie naar het ZAAKTYPE van ZAAKen waarin resultaten van "
+            "dit RESULTAATTYPE bereikt kunnen worden."
         ),
     )
 

--- a/src/openzaak/components/catalogi/models/roltype.py
+++ b/src/openzaak/components/catalogi/models/roltype.py
@@ -1,6 +1,5 @@
 import uuid
 
-from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 

--- a/src/openzaak/components/catalogi/models/zaaktype.py
+++ b/src/openzaak/components/catalogi/models/zaaktype.py
@@ -65,8 +65,9 @@ class ZaakObjectType(GeldigheidMixin, models.Model):
         on_delete=models.CASCADE,
         related_name="heeft_verplichte_zaakobjecttype",
         help_text=_(
-            "TODO: dit is de related helptext: De ZAAKOBJECTTYPEn die verplicht gerelateerd moeten zijn aan ZAAKen van "
-            "het ZAAKTYPE voordat een STATUS van dit STATUSTYPE kan worden gezet"
+            "TODO: dit is de related helptext: De ZAAKOBJECTTYPEn die verplicht "
+            "gerelateerd moeten zijn aan ZAAKen van het ZAAKTYPE voordat een "
+            "STATUS van dit STATUSTYPE kan worden gezet"
         ),
     )
 

--- a/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
@@ -549,7 +549,7 @@ class ZaakTypeAdminImportExportTests(WebTest):
             omschrijving="export",
         )
         informatieobjecttype_uuid = informatieobjecttype.uuid
-        ziot = ZaakTypeInformatieObjectTypeFactory.create(
+        ZaakTypeInformatieObjectTypeFactory.create(
             zaaktype=zaaktype, informatieobjecttype=informatieobjecttype
         )
         besluittype = BesluitTypeFactory.create(catalogus=catalogus)
@@ -664,7 +664,7 @@ class ZaakTypeAdminImportExportTests(WebTest):
 
         response = response.form.submit("_select")
 
-        imported_catalogus = Catalogus.objects.get()
+        Catalogus.objects.get()
         zaaktype = ZaakType.objects.get()
 
         self.assertEqual(zaaktype.zaaktype_omschrijving, "zaaktype1")
@@ -842,7 +842,7 @@ class ZaakTypeAdminImportExportTransactionTests(TransactionWebTest):
             vertrouwelijkheidaanduiding="openbaar",
             omschrijving="export",
         )
-        ziot = ZaakTypeInformatieObjectTypeFactory.create(
+        ZaakTypeInformatieObjectTypeFactory.create(
             zaaktype=zaaktype, informatieobjecttype=informatieobjecttype
         )
         ZaakType.objects.exclude(pk=zaaktype.pk).delete()

--- a/src/openzaak/components/catalogi/tests/factories/besluittype.py
+++ b/src/openzaak/components/catalogi/tests/factories/besluittype.py
@@ -4,7 +4,6 @@ import factory
 
 from ...models import BesluitType
 from .catalogus import CatalogusFactory
-from .resultaattype import ResultaatTypeFactory
 from .zaaktype import ZaakTypeFactory
 
 

--- a/src/openzaak/components/catalogi/tests/factories/statustype.py
+++ b/src/openzaak/components/catalogi/tests/factories/statustype.py
@@ -1,7 +1,6 @@
 import factory
 
 from ...models import StatusType
-from .roltype import RolTypeFactory
 from .zaaktype import ZaakTypeFactory
 
 

--- a/src/openzaak/components/catalogi/tests/factories/zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/factories/zaaktype.py
@@ -48,7 +48,8 @@ class ZaakTypeFactory(factory.django.DjangoModelFactory):
     datum_begin_geldigheid = date(2018, 1, 1)
     versiedatum = date(2018, 1, 1)
 
-    # this one is optional, if its added as below, it will keep adding related ZaakTypes (and reach max recursion depth)
+    # this one is optional, if its added as below, it will keep adding related
+    # ZaakTypes (and reach max recursion depth)
     # heeft_gerelateerd = factory.RelatedFactory(ZaakTypenRelatieFactory, 'zaaktype_van')
 
     class Meta:

--- a/src/openzaak/components/catalogi/tests/test_auth.py
+++ b/src/openzaak/components/catalogi/tests/test_auth.py
@@ -8,7 +8,7 @@ from rest_framework.test import APITestCase as _APITestCase
 from vng_api_common.constants import ComponentTypes
 from vng_api_common.tests import AuthCheckMixin, reverse
 
-from ..api.scopes import SCOPE_CATALOGI_FORCED_DELETE, SCOPE_CATALOGI_WRITE
+from ..api.scopes import SCOPE_CATALOGI_FORCED_DELETE
 from ..models import (
     BesluitType,
     Eigenschap,
@@ -125,7 +125,7 @@ class PublishedTypesForcedDeletionTests(APITestCase):
     def test_force_delete_informatieobjecttype_related_to_non_concept_besluittype(self):
         informatieobjecttype = InformatieObjectTypeFactory.create()
 
-        besluittype = BesluitTypeFactory.create(
+        BesluitTypeFactory.create(
             informatieobjecttypen=[informatieobjecttype], concept=False
         )
 
@@ -198,7 +198,7 @@ class PublishedTypesForcedDeletionTests(APITestCase):
         zaaktype = ZaakTypeFactory.create(catalogus=catalogus)
         zaaktype_url = reverse(zaaktype)
 
-        besluittype = BesluitTypeFactory.create(
+        BesluitTypeFactory.create(
             catalogus=catalogus, zaaktypen=[zaaktype], concept=False
         )
 

--- a/src/openzaak/components/catalogi/tests/test_besluittype.py
+++ b/src/openzaak/components/catalogi/tests/test_besluittype.py
@@ -25,7 +25,7 @@ class BesluitTypeAPITests(APITestCase):
     component = ComponentTypes.ztc
 
     def test_get_list_default_definitief(self):
-        besluittype1 = BesluitTypeFactory.create(concept=True)
+        BesluitTypeFactory.create(concept=True)
         besluittype2 = BesluitTypeFactory.create(concept=False)
         besluittype_list_url = reverse("besluittype-list")
         besluittype2_url = reverse(
@@ -86,7 +86,7 @@ class BesluitTypeAPITests(APITestCase):
             catalogus=self.catalogus, publicatie_indicatie=True
         )
         iot1 = InformatieObjectTypeFactory.create(catalogus=self.catalogus)
-        iot2 = InformatieObjectTypeFactory.create(catalogus=self.catalogus)
+        InformatieObjectTypeFactory.create(catalogus=self.catalogus)
         besluittype.informatieobjecttypen.add(iot1)
 
         besluittype_detail_url = reverse(
@@ -110,7 +110,7 @@ class BesluitTypeAPITests(APITestCase):
             catalogus=self.catalogus, publicatie_indicatie=True
         )
         zaaktype1 = ZaakTypeFactory.create(catalogus=self.catalogus)
-        zaaktype2 = ZaakTypeFactory.create(catalogus=self.catalogus)
+        ZaakTypeFactory.create(catalogus=self.catalogus)
         besluittype.zaaktypen.clear()
         besluittype.zaaktypen.add(zaaktype1)
 
@@ -695,7 +695,7 @@ class BesluitTypeFilterAPITests(APITestCase):
 
     def test_filter_besluittype_status_concept(self):
         besluittype1 = BesluitTypeFactory.create(concept=True)
-        besluittype2 = BesluitTypeFactory.create(concept=False)
+        BesluitTypeFactory.create(concept=False)
         besluittype_list_url = reverse("besluittype-list")
         besluittype1_url = reverse(
             "besluittype-detail", kwargs={"uuid": besluittype1.uuid}
@@ -710,7 +710,7 @@ class BesluitTypeFilterAPITests(APITestCase):
         self.assertEqual(data[0]["url"], f"http://testserver{besluittype1_url}")
 
     def test_filter_besluittype_status_definitief(self):
-        besluittype1 = BesluitTypeFactory.create(concept=True)
+        BesluitTypeFactory.create(concept=True)
         besluittype2 = BesluitTypeFactory.create(concept=False)
         besluittype_list_url = reverse("besluittype-list")
         besluittype2_url = reverse(
@@ -727,7 +727,7 @@ class BesluitTypeFilterAPITests(APITestCase):
 
     def test_filter_zaaktypen(self):
         besluittype1 = BesluitTypeFactory.create(concept=False)
-        besluittype2 = BesluitTypeFactory.create(concept=False)
+        BesluitTypeFactory.create(concept=False)
         zaaktype1 = besluittype1.zaaktypen.get()
         zaaktype1_url = f"http://openzaak.nl{reverse(zaaktype1)}"
         besluittype_list_url = reverse("besluittype-list")
@@ -744,7 +744,7 @@ class BesluitTypeFilterAPITests(APITestCase):
 
     def test_filter_informatieobjecttypen(self):
         besluittype1 = BesluitTypeFactory.create(concept=False)
-        besluittype2 = BesluitTypeFactory.create(concept=False)
+        BesluitTypeFactory.create(concept=False)
         iot1 = InformatieObjectTypeFactory.create(catalogus=self.catalogus)
         besluittype1.informatieobjecttypen.add(iot1)
         besluittype_list_url = reverse("besluittype-list")
@@ -808,7 +808,7 @@ class BesluitTypeValidationTests(APITestCase):
     maxDiff = None
 
     def test_besluittype_unique_catalogus_omschrijving_combination(self):
-        besluittype1 = BesluitTypeFactory(catalogus=self.catalogus, omschrijving="test")
+        BesluitTypeFactory(catalogus=self.catalogus, omschrijving="test")
         besluittype_list_url = reverse("besluittype-list")
         data = {
             "catalogus": f"http://testserver{self.catalogus_detail_url}",

--- a/src/openzaak/components/catalogi/tests/test_catalogus.py
+++ b/src/openzaak/components/catalogi/tests/test_catalogus.py
@@ -59,7 +59,7 @@ class CatalogusFilterAPITests(APITestCase):
 
     def test_filter_domein_exact(self):
         catalogus1 = CatalogusFactory.create(domein="ABC")
-        catalogus2 = CatalogusFactory.create(domein="DEF")
+        CatalogusFactory.create(domein="DEF")
 
         response = self.client.get(self.catalogus_list_url, {"domein": "ABC"})
 
@@ -72,7 +72,7 @@ class CatalogusFilterAPITests(APITestCase):
 
     def test_filter_domein_in(self):
         catalogus1 = CatalogusFactory.create(domein="ABC")
-        catalogus2 = CatalogusFactory.create(domein="DEF")
+        CatalogusFactory.create(domein="DEF")
 
         response = self.client.get(self.catalogus_list_url, {"domein__in": "ABC,AAA"})
 
@@ -85,7 +85,7 @@ class CatalogusFilterAPITests(APITestCase):
 
     def test_filter_rsin_exact(self):
         catalogus1 = CatalogusFactory.create(rsin="100000009")
-        catalogus2 = CatalogusFactory.create(rsin="100000020")
+        CatalogusFactory.create(rsin="100000020")
 
         response = self.client.get(self.catalogus_list_url, {"rsin": "100000009"})
 
@@ -98,7 +98,7 @@ class CatalogusFilterAPITests(APITestCase):
 
     def test_filter_rsin_in(self):
         catalogus1 = CatalogusFactory.create(rsin="100000009")
-        catalogus2 = CatalogusFactory.create(rsin="100000022")
+        CatalogusFactory.create(rsin="100000022")
 
         response = self.client.get(
             self.catalogus_list_url, {"rsin__in": "100000009,100000010"}

--- a/src/openzaak/components/catalogi/tests/test_eigenschap.py
+++ b/src/openzaak/components/catalogi/tests/test_eigenschap.py
@@ -107,7 +107,7 @@ class EigenschapAPITests(TypeCheckMixin, APITestCase):
         )
 
     def test_get_list_default_definitief(self):
-        eigenschap1 = EigenschapFactory.create(zaaktype__concept=True)
+        EigenschapFactory.create(zaaktype__concept=True)
         eigenschap2 = EigenschapFactory.create(zaaktype__concept=False)
         eigenschap_list_url = reverse("eigenschap-list")
         eigenschap2_url = reverse(
@@ -333,7 +333,7 @@ class EigenschapFilterAPITests(APITestCase):
 
     def test_filter_eigenschap_status_concept(self):
         eigenschap1 = EigenschapFactory.create(zaaktype__concept=True)
-        eigenschap2 = EigenschapFactory.create(zaaktype__concept=False)
+        EigenschapFactory.create(zaaktype__concept=False)
         eigenschap_list_url = reverse("eigenschap-list")
         eigenschap1_url = reverse(
             "eigenschap-detail", kwargs={"uuid": eigenschap1.uuid}
@@ -348,7 +348,7 @@ class EigenschapFilterAPITests(APITestCase):
         self.assertEqual(data[0]["url"], f"http://testserver{eigenschap1_url}")
 
     def test_filter_eigenschap_status_definitief(self):
-        eigenschap1 = EigenschapFactory.create(zaaktype__concept=True)
+        EigenschapFactory.create(zaaktype__concept=True)
         eigenschap2 = EigenschapFactory.create(zaaktype__concept=False)
         eigenschap_list_url = reverse("eigenschap-list")
         eigenschap2_url = reverse(

--- a/src/openzaak/components/catalogi/tests/test_informatieobjecttype.py
+++ b/src/openzaak/components/catalogi/tests/test_informatieobjecttype.py
@@ -25,7 +25,7 @@ class InformatieObjectTypeAPITests(APITestCase):
     component = ComponentTypes.ztc
 
     def test_get_list_default_definitief(self):
-        informatieobjecttype1 = InformatieObjectTypeFactory.create(concept=True)
+        InformatieObjectTypeFactory.create(concept=True)
         informatieobjecttype2 = InformatieObjectTypeFactory.create(concept=False)
         informatieobjecttype_list_url = get_operation_url("informatieobjecttype_list")
         informatieobjecttype2_url = get_operation_url(
@@ -273,9 +273,7 @@ class InformatieObjectTypeAPITests(APITestCase):
     def test_delete_informatieobjecttype_not_related_to_non_concept_besluittype(self):
         informatieobjecttype = InformatieObjectTypeFactory.create()
 
-        besluittype = BesluitTypeFactory.create(
-            informatieobjecttypen=[informatieobjecttype]
-        )
+        BesluitTypeFactory.create(informatieobjecttypen=[informatieobjecttype])
 
         informatieobjecttype_url = reverse(informatieobjecttype)
 
@@ -304,7 +302,7 @@ class InformatieObjectTypeAPITests(APITestCase):
     def test_delete_informatieobjecttype_related_to_non_concept_besluittype_fails(self):
         informatieobjecttype = InformatieObjectTypeFactory.create()
 
-        besluittype = BesluitTypeFactory.create(
+        BesluitTypeFactory.create(
             informatieobjecttypen=[informatieobjecttype], concept=False
         )
 
@@ -345,7 +343,7 @@ class InformatieObjectTypeAPITests(APITestCase):
         catalogus = CatalogusFactory.create()
         informatieobjecttype = InformatieObjectTypeFactory.create(catalogus=catalogus)
 
-        besluittype = BesluitTypeFactory.create(
+        BesluitTypeFactory.create(
             informatieobjecttypen=[informatieobjecttype], catalogus=catalogus
         )
 
@@ -394,7 +392,7 @@ class InformatieObjectTypeAPITests(APITestCase):
         catalogus = CatalogusFactory.create()
         informatieobjecttype = InformatieObjectTypeFactory.create(catalogus=catalogus)
 
-        besluittype = BesluitTypeFactory.create(
+        BesluitTypeFactory.create(
             informatieobjecttypen=[informatieobjecttype],
             concept=False,
             catalogus=catalogus,
@@ -442,7 +440,7 @@ class InformatieObjectTypeAPITests(APITestCase):
         catalogus = CatalogusFactory.create()
 
         informatieobjecttype = InformatieObjectTypeFactory.create(catalogus=catalogus)
-        besluittype = BesluitTypeFactory.create(
+        BesluitTypeFactory.create(
             informatieobjecttypen=[informatieobjecttype], catalogus=catalogus
         )
 
@@ -481,7 +479,7 @@ class InformatieObjectTypeAPITests(APITestCase):
     ):
         catalogus = CatalogusFactory.create()
         informatieobjecttype = InformatieObjectTypeFactory.create(catalogus=catalogus)
-        besluittype = BesluitTypeFactory.create(
+        BesluitTypeFactory.create(
             informatieobjecttypen=[informatieobjecttype],
             catalogus=catalogus,
             concept=False,
@@ -535,7 +533,7 @@ class InformatieObjectTypeAPITests(APITestCase):
     ):
         catalogus = CatalogusFactory.create()
         informatieobjecttype = InformatieObjectTypeFactory.create(catalogus=catalogus)
-        besluittype = BesluitTypeFactory.create(
+        BesluitTypeFactory.create(
             informatieobjecttypen=[informatieobjecttype],
             catalogus=catalogus,
             concept=False,
@@ -569,7 +567,7 @@ class InformatieObjectTypeFilterAPITests(APITestCase):
 
     def test_filter_informatieobjecttype_status_concept(self):
         informatieobjecttype1 = InformatieObjectTypeFactory.create(concept=True)
-        informatieobjecttype2 = InformatieObjectTypeFactory.create(concept=False)
+        InformatieObjectTypeFactory.create(concept=False)
         informatieobjecttype_list_url = get_operation_url("informatieobjecttype_list")
         informatieobjecttype1_url = get_operation_url(
             "informatieobjecttype_read", uuid=informatieobjecttype1.uuid
@@ -586,7 +584,7 @@ class InformatieObjectTypeFilterAPITests(APITestCase):
         )
 
     def test_filter_informatieobjecttype_status_definitief(self):
-        informatieobjecttype1 = InformatieObjectTypeFactory.create(concept=True)
+        InformatieObjectTypeFactory.create(concept=True)
         informatieobjecttype2 = InformatieObjectTypeFactory.create(concept=False)
         informatieobjecttype_list_url = get_operation_url("informatieobjecttype_list")
         informatieobjecttype2_url = get_operation_url(

--- a/src/openzaak/components/catalogi/tests/test_relatieklassen.py
+++ b/src/openzaak/components/catalogi/tests/test_relatieklassen.py
@@ -27,13 +27,13 @@ class ZaakTypeInformatieObjectTypeAPITests(APITestCase):
     list_url = reverse_lazy(ZaakTypeInformatieObjectType)
 
     def test_get_list_default_definitief(self):
-        ziot1 = ZaakTypeInformatieObjectTypeFactory.create(
+        ZaakTypeInformatieObjectTypeFactory.create(
             zaaktype__concept=True, informatieobjecttype__concept=True
         )
-        ziot2 = ZaakTypeInformatieObjectTypeFactory.create(
+        ZaakTypeInformatieObjectTypeFactory.create(
             zaaktype__concept=False, informatieobjecttype__concept=True
         )
-        ziot3 = ZaakTypeInformatieObjectTypeFactory.create(
+        ZaakTypeInformatieObjectTypeFactory.create(
             zaaktype__concept=True, informatieobjecttype__concept=False
         )
         ziot4 = ZaakTypeInformatieObjectTypeFactory.create(
@@ -238,11 +238,9 @@ class ZaakTypeInformatieObjectTypeAPITests(APITestCase):
 
     def test_partial_update_ziot(self):
         zaaktype = ZaakTypeFactory.create()
-        zaaktype_url = reverse(zaaktype)
         informatieobjecttype = InformatieObjectTypeFactory.create(
             catalogus=zaaktype.catalogus
         )
-        informatieobjecttype_url = reverse(informatieobjecttype)
         ziot = ZaakTypeInformatieObjectTypeFactory.create(
             zaaktype=zaaktype, informatieobjecttype=informatieobjecttype
         )
@@ -338,11 +336,9 @@ class ZaakTypeInformatieObjectTypeAPITests(APITestCase):
 
     def test_partial_update_ziot_not_concept_zaaktype(self):
         zaaktype = ZaakTypeFactory.create(concept=False)
-        zaaktype_url = reverse(zaaktype)
         informatieobjecttype = InformatieObjectTypeFactory.create(
             catalogus=zaaktype.catalogus
         )
-        informatieobjecttype_url = reverse(informatieobjecttype)
         ziot = ZaakTypeInformatieObjectTypeFactory.create(
             zaaktype=zaaktype, informatieobjecttype=informatieobjecttype
         )
@@ -358,11 +354,9 @@ class ZaakTypeInformatieObjectTypeAPITests(APITestCase):
 
     def test_partial_update_ziot_not_concept_informatieobjecttype(self):
         zaaktype = ZaakTypeFactory.create()
-        zaaktype_url = reverse(zaaktype)
         informatieobjecttype = InformatieObjectTypeFactory.create(
             catalogus=zaaktype.catalogus, concept=False
         )
-        informatieobjecttype_url = reverse(informatieobjecttype)
         ziot = ZaakTypeInformatieObjectTypeFactory.create(
             zaaktype=zaaktype, informatieobjecttype=informatieobjecttype
         )
@@ -380,11 +374,9 @@ class ZaakTypeInformatieObjectTypeAPITests(APITestCase):
         self,
     ):
         zaaktype = ZaakTypeFactory.create(concept=False)
-        zaaktype_url = reverse(zaaktype)
         informatieobjecttype = InformatieObjectTypeFactory.create(
             catalogus=zaaktype.catalogus, concept=False
         )
-        informatieobjecttype_url = reverse(informatieobjecttype)
         ziot = ZaakTypeInformatieObjectTypeFactory.create(
             zaaktype=zaaktype, informatieobjecttype=informatieobjecttype
         )
@@ -510,13 +502,13 @@ class ZaakTypeInformatieObjectTypeFilterAPITests(APITestCase):
         )
 
     def test_filter_ziot_status_definitief(self):
-        ziot1 = ZaakTypeInformatieObjectTypeFactory.create(
+        ZaakTypeInformatieObjectTypeFactory.create(
             zaaktype__concept=True, informatieobjecttype__concept=True
         )
-        ziot2 = ZaakTypeInformatieObjectTypeFactory.create(
+        ZaakTypeInformatieObjectTypeFactory.create(
             zaaktype__concept=False, informatieobjecttype__concept=True
         )
-        ziot3 = ZaakTypeInformatieObjectTypeFactory.create(
+        ZaakTypeInformatieObjectTypeFactory.create(
             zaaktype__concept=True, informatieobjecttype__concept=False
         )
         ziot4 = ZaakTypeInformatieObjectTypeFactory.create(

--- a/src/openzaak/components/catalogi/tests/test_resultaattype.py
+++ b/src/openzaak/components/catalogi/tests/test_resultaattype.py
@@ -67,7 +67,7 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         )
 
     def test_get_list_default_definitief(self):
-        resultaattype1 = ResultaatTypeFactory.create(zaaktype__concept=True)
+        ResultaatTypeFactory.create(zaaktype__concept=True)
         resultaattype2 = ResultaatTypeFactory.create(zaaktype__concept=False)
         resultaattype_list_url = reverse("resultaattype-list")
         resultaattype2_url = reverse(
@@ -464,7 +464,6 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
 
     def test_partial_update_resultaattype(self):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
-        zaaktype_url = reverse(zaaktype)
         resultaattype = ResultaatTypeFactory.create(zaaktype=zaaktype)
         resultaattype_url = reverse(resultaattype)
 
@@ -477,7 +476,6 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=False
         )
-        zaaktype_url = reverse(zaaktype)
         resultaattype = ResultaatTypeFactory.create(zaaktype=zaaktype)
         resultaattype_url = reverse(resultaattype)
 
@@ -500,8 +498,6 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         zaaktype_url = reverse(zaaktype)
         resultaattype = ResultaatTypeFactory.create()
         resultaattype_url = reverse(resultaattype)
-
-        resultaattypeomschrijving_url = "http://example.com/omschrijving/1"
 
         responses = {
             SELECTIELIJSTKLASSE_URL: {
@@ -531,13 +527,10 @@ class ResultaatTypeFilterAPITests(APITestCase):
 
         rt1_uri = reverse(rt1)
         rt2_uri = reverse(rt2)
-        rt1_url = f"http://openzaak.nl{rt1_uri}"
-        rt2_url = f"http://openzaak.nl{rt2_uri}"
 
         zt1_uri = reverse("zaaktype-detail", kwargs={"uuid": zt1.uuid})
         zt2_uri = reverse("zaaktype-detail", kwargs={"uuid": zt2.uuid})
         zt1_url = "http://openzaak.nl{}".format(zt1_uri)
-        zt2_url = "http://openzaak.nl{}".format(zt2_uri)
         list_url = reverse("resultaattype-list")
 
         response = self.client.get(
@@ -568,7 +561,7 @@ class ResultaatTypeFilterAPITests(APITestCase):
 
     def test_filter_resultaattype_status_concept(self):
         resultaattype1 = ResultaatTypeFactory.create(zaaktype__concept=True)
-        resultaattype2 = ResultaatTypeFactory.create(zaaktype__concept=False)
+        ResultaatTypeFactory.create(zaaktype__concept=False)
         resultaattype_list_url = reverse("resultaattype-list")
         resultaattype1_url = reverse(
             "resultaattype-detail", kwargs={"uuid": resultaattype1.uuid}
@@ -583,7 +576,7 @@ class ResultaatTypeFilterAPITests(APITestCase):
         self.assertEqual(data[0]["url"], f"http://testserver{resultaattype1_url}")
 
     def test_filter_resultaattype_status_definitief(self):
-        resultaattype1 = ResultaatTypeFactory.create(zaaktype__concept=True)
+        ResultaatTypeFactory.create(zaaktype__concept=True)
         resultaattype2 = ResultaatTypeFactory.create(zaaktype__concept=False)
         resultaattype_list_url = reverse("resultaattype-list")
         resultaattype2_url = reverse(

--- a/src/openzaak/components/catalogi/tests/test_roltype.py
+++ b/src/openzaak/components/catalogi/tests/test_roltype.py
@@ -18,7 +18,7 @@ class RolTypeAPITests(APITestCase):
     component = ComponentTypes.ztc
 
     def test_get_list_default_definitief(self):
-        roltype1 = RolTypeFactory.create(zaaktype__concept=True)
+        RolTypeFactory.create(zaaktype__concept=True)
         roltype2 = RolTypeFactory.create(zaaktype__concept=False)
         roltype_list_url = reverse("roltype-list")
         roltype2_url = reverse("roltype-detail", kwargs={"uuid": roltype2.uuid})
@@ -173,7 +173,6 @@ class RolTypeAPITests(APITestCase):
 
     def test_partial_update_roltype(self):
         zaaktype = ZaakTypeFactory.create()
-        zaaktype_url = reverse(zaaktype)
         roltype = RolTypeFactory.create(zaaktype=zaaktype)
         roltype_url = reverse(roltype)
 
@@ -187,7 +186,6 @@ class RolTypeAPITests(APITestCase):
 
     def test_partial_update_roltype_fail_not_concept_zaaktype(self):
         zaaktype = ZaakTypeFactory.create(concept=False)
-        zaaktype_url = reverse(zaaktype)
         roltype = RolTypeFactory.create(zaaktype=zaaktype)
         roltype_url = reverse(roltype)
 
@@ -244,7 +242,7 @@ class RolTypeFilterAPITests(APITestCase):
 
     def test_filter_roltype_status_concept(self):
         roltype1 = RolTypeFactory.create(zaaktype__concept=True)
-        roltype2 = RolTypeFactory.create(zaaktype__concept=False)
+        RolTypeFactory.create(zaaktype__concept=False)
         roltype_list_url = reverse("roltype-list")
         roltype1_url = reverse("roltype-detail", kwargs={"uuid": roltype1.uuid})
 
@@ -257,7 +255,7 @@ class RolTypeFilterAPITests(APITestCase):
         self.assertEqual(data[0]["url"], f"http://testserver{roltype1_url}")
 
     def test_filter_roltype_status_definitief(self):
-        roltype1 = RolTypeFactory.create(zaaktype__concept=True)
+        RolTypeFactory.create(zaaktype__concept=True)
         roltype2 = RolTypeFactory.create(zaaktype__concept=False)
         roltype_list_url = reverse("roltype-list")
         roltype2_url = reverse("roltype-detail", kwargs={"uuid": roltype2.uuid})
@@ -273,7 +271,7 @@ class RolTypeFilterAPITests(APITestCase):
     @override_settings(ALLOWED_HOSTS=["openzaak.nl"])
     def test_filter_zaaktype(self):
         roltype1 = RolTypeFactory.create(zaaktype__concept=False)
-        roltype2 = RolTypeFactory.create(zaaktype__concept=False)
+        RolTypeFactory.create(zaaktype__concept=False)
         zaaktype1 = roltype1.zaaktype
         roltype_list_url = reverse("roltype-list")
         roltype1_url = reverse(roltype1)

--- a/src/openzaak/components/catalogi/tests/test_statustype.py
+++ b/src/openzaak/components/catalogi/tests/test_statustype.py
@@ -17,7 +17,7 @@ class StatusTypeAPITests(APITestCase):
     component = ComponentTypes.ztc
 
     def test_get_list_default_definitief(self):
-        statustype1 = StatusTypeFactory.create(zaaktype__concept=True)
+        StatusTypeFactory.create(zaaktype__concept=True)
         statustype2 = StatusTypeFactory.create(zaaktype__concept=False)
         statustype_list_url = reverse("statustype-list")
         statustype2_url = reverse(
@@ -121,7 +121,7 @@ class StatusTypeAPITests(APITestCase):
     def test_is_eindstatus(self):
         zaaktype = ZaakTypeFactory.create()
 
-        rol_type = RolTypeFactory.create(zaaktype=zaaktype)
+        RolTypeFactory.create(zaaktype=zaaktype)
 
         statustype_1 = StatusTypeFactory.create(
             zaaktype=zaaktype, statustypevolgnummer=1
@@ -226,7 +226,6 @@ class StatusTypeAPITests(APITestCase):
 
     def test_partial_update_statustype(self):
         zaaktype = ZaakTypeFactory.create()
-        zaaktype_url = reverse(zaaktype)
         statustype = StatusTypeFactory.create(zaaktype=zaaktype)
         statustype_url = reverse(statustype)
 
@@ -240,7 +239,6 @@ class StatusTypeAPITests(APITestCase):
 
     def test_partial_update_statustype_fail_not_concept_zaaktype(self):
         zaaktype = ZaakTypeFactory.create(concept=False)
-        zaaktype_url = reverse(zaaktype)
         statustype = StatusTypeFactory.create(zaaktype=zaaktype)
         statustype_url = reverse(statustype)
 
@@ -282,7 +280,7 @@ class StatusTypeFilterAPITests(APITestCase):
 
     def test_filter_statustype_status_concept(self):
         statustype1 = StatusTypeFactory.create(zaaktype__concept=True)
-        statustype2 = StatusTypeFactory.create(zaaktype__concept=False)
+        StatusTypeFactory.create(zaaktype__concept=False)
         statustype_list_url = reverse("statustype-list")
         statustype1_url = reverse(
             "statustype-detail", kwargs={"uuid": statustype1.uuid}
@@ -297,7 +295,7 @@ class StatusTypeFilterAPITests(APITestCase):
         self.assertEqual(data[0]["url"], f"http://testserver{statustype1_url}")
 
     def test_filter_statustype_status_definitief(self):
-        statustype1 = StatusTypeFactory.create(zaaktype__concept=True)
+        StatusTypeFactory.create(zaaktype__concept=True)
         statustype2 = StatusTypeFactory.create(zaaktype__concept=False)
         statustype_list_url = reverse("statustype-list")
         statustype2_url = reverse(

--- a/src/openzaak/components/catalogi/tests/test_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/test_zaaktype.py
@@ -10,11 +10,7 @@ from vng_api_common.constants import ComponentTypes, VertrouwelijkheidsAanduidin
 from vng_api_common.tests import TypeCheckMixin, get_validation_errors, reverse
 from zds_client.tests.mocks import mock_client
 
-from ..api.scopes import (
-    SCOPE_CATALOGI_FORCED_DELETE,
-    SCOPE_CATALOGI_READ,
-    SCOPE_CATALOGI_WRITE,
-)
+from ..api.scopes import SCOPE_CATALOGI_READ, SCOPE_CATALOGI_WRITE
 from ..api.validators import (
     ConceptUpdateValidator,
     M2MConceptCreateValidator,
@@ -511,9 +507,7 @@ class ZaakTypeAPITests(TypeCheckMixin, APITestCase):
         zaaktype = ZaakTypeFactory.create(catalogus=catalogus)
         zaaktype_url = reverse(zaaktype)
 
-        besluittype = BesluitTypeFactory.create(
-            catalogus=catalogus, zaaktypen=[zaaktype]
-        )
+        BesluitTypeFactory.create(catalogus=catalogus, zaaktypen=[zaaktype])
 
         response = self.client.delete(zaaktype_url)
 
@@ -558,7 +552,7 @@ class ZaakTypeAPITests(TypeCheckMixin, APITestCase):
         zaaktype = ZaakTypeFactory.create(catalogus=catalogus)
         zaaktype_url = reverse(zaaktype)
 
-        besluittype = BesluitTypeFactory.create(
+        BesluitTypeFactory.create(
             catalogus=catalogus, zaaktypen=[zaaktype], concept=False
         )
 
@@ -595,9 +589,7 @@ class ZaakTypeAPITests(TypeCheckMixin, APITestCase):
         zaaktype = ZaakTypeFactory.create(catalogus=catalogus)
         zaaktype_url = reverse(zaaktype)
 
-        besluittype = BesluitTypeFactory.create(
-            catalogus=catalogus, zaaktypen=[zaaktype]
-        )
+        BesluitTypeFactory.create(catalogus=catalogus, zaaktypen=[zaaktype])
 
         data = {
             "identificatie": 0,
@@ -741,7 +733,7 @@ class ZaakTypeAPITests(TypeCheckMixin, APITestCase):
         zaaktype = ZaakTypeFactory.create(catalogus=catalogus)
         zaaktype_url = reverse(zaaktype)
 
-        besluittype = BesluitTypeFactory.create(
+        BesluitTypeFactory.create(
             catalogus=catalogus, zaaktypen=[zaaktype], concept=False
         )
 
@@ -895,9 +887,7 @@ class ZaakTypeAPITests(TypeCheckMixin, APITestCase):
         )
         zaaktype_url = reverse(zaaktype)
 
-        besluittype = BesluitTypeFactory.create(
-            catalogus=catalogus, zaaktypen=[zaaktype]
-        )
+        BesluitTypeFactory.create(catalogus=catalogus, zaaktypen=[zaaktype])
 
         response = self.client.patch(zaaktype_url, {"aanleiding": "aangepast"})
 
@@ -945,29 +935,6 @@ class ZaakTypeAPITests(TypeCheckMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.assertEqual(response.data["aanleiding"], "aangepast")
-        zaaktype.delete()
-
-    def test_partial_update_zaaktype_related_to_non_concept_informatieobjecttype_fails(
-        self,
-    ):
-        catalogus = CatalogusFactory.create()
-
-        zaaktype = ZaakTypeFactory.create(catalogus=catalogus)
-        zaaktype_url = reverse(zaaktype)
-
-        besluittype = BesluitTypeFactory.create(
-            catalogus=catalogus, zaaktypen=[zaaktype], concept=False
-        )
-
-        response = self.client.patch(zaaktype_url, {"aanleiding": "aangepast"})
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-        data = response.json()
-        self.assertEqual(
-            data["detail"],
-            "Objects related to non-concept {} can't be updated".format("besluittypen"),
-        )
         zaaktype.delete()
 
     def test_partial_update_zaaktype_related_to_non_concept_informatieobjecttype_fails(
@@ -1042,7 +1009,7 @@ class ZaakTypeAPITests(TypeCheckMixin, APITestCase):
         zaaktype = ZaakTypeFactory.create(catalogus=catalogus)
         zaaktype_url = reverse(zaaktype)
 
-        besluittype = BesluitTypeFactory.create(
+        BesluitTypeFactory.create(
             catalogus=catalogus, zaaktypen=[zaaktype], concept=False
         )
 
@@ -1224,7 +1191,7 @@ class ZaakTypeFilterAPITests(APITestCase):
 
     def test_filter_zaaktype_status_concept(self):
         zaaktype1 = ZaakTypeFactory.create(concept=True)
-        zaaktype2 = ZaakTypeFactory.create(concept=False)
+        ZaakTypeFactory.create(concept=False)
         zaaktype_list_url = get_operation_url("zaaktype_list")
         zaaktype1_url = get_operation_url("zaaktype_read", uuid=zaaktype1.uuid)
 
@@ -1237,7 +1204,7 @@ class ZaakTypeFilterAPITests(APITestCase):
         self.assertEqual(data[0]["url"], f"http://testserver{zaaktype1_url}")
 
     def test_filter_zaaktype_status_definitief(self):
-        zaaktype1 = ZaakTypeFactory.create(concept=True)
+        ZaakTypeFactory.create(concept=True)
         zaaktype2 = ZaakTypeFactory.create(concept=False)
         zaaktype_list_url = get_operation_url("zaaktype_list")
         zaaktype2_url = get_operation_url("zaaktype_read", uuid=zaaktype2.uuid)
@@ -1252,7 +1219,7 @@ class ZaakTypeFilterAPITests(APITestCase):
 
     def test_filter_identificatie(self):
         zaaktype1 = ZaakTypeFactory.create(concept=False, identificatie=123)
-        zaaktype2 = ZaakTypeFactory.create(concept=False, identificatie=456)
+        ZaakTypeFactory.create(concept=False, identificatie=456)
         zaaktype_list_url = get_operation_url("zaaktype_list")
         zaaktype1_url = get_operation_url("zaaktype_read", uuid=zaaktype1.uuid)
 
@@ -1268,9 +1235,7 @@ class ZaakTypeFilterAPITests(APITestCase):
         zaaktype1 = ZaakTypeFactory.create(
             concept=False, trefwoorden=["some", "key", "words"]
         )
-        zaaktype2 = ZaakTypeFactory.create(
-            concept=False, trefwoorden=["other", "words"]
-        )
+        ZaakTypeFactory.create(concept=False, trefwoorden=["other", "words"])
         zaaktype_list_url = get_operation_url("zaaktype_list")
         zaaktype1_url = get_operation_url("zaaktype_read", uuid=zaaktype1.uuid)
 

--- a/src/openzaak/components/documenten/api/viewsets.py
+++ b/src/openzaak/components/documenten/api/viewsets.py
@@ -11,16 +11,10 @@ from rest_framework.serializers import ValidationError
 from rest_framework.settings import api_settings
 from sendfile import sendfile
 from vng_api_common.audittrails.viewsets import (
-    AuditTrailCreateMixin,
-    AuditTrailDestroyMixin,
     AuditTrailViewSet,
     AuditTrailViewsetMixin,
 )
-from vng_api_common.notifications.viewsets import (
-    NotificationCreateMixin,
-    NotificationDestroyMixin,
-    NotificationViewSetMixin,
-)
+from vng_api_common.notifications.viewsets import NotificationViewSetMixin
 from vng_api_common.serializers import FoutSerializer
 from vng_api_common.viewsets import CheckQueryParamsMixin
 

--- a/src/openzaak/components/documenten/tests/models/test_last_version.py
+++ b/src/openzaak/components/documenten/tests/models/test_last_version.py
@@ -9,8 +9,8 @@ from ..factories import (
 class LastVersionTests(TestCase):
     def test_canonical_last_version(self):
         canonical = EnkelvoudigInformatieObjectCanonicalFactory()
-        eio1 = EnkelvoudigInformatieObjectFactory.create(canonical=canonical, versie=1)
-        eio2 = EnkelvoudigInformatieObjectFactory.create(canonical=canonical, versie=2)
+        EnkelvoudigInformatieObjectFactory.create(canonical=canonical, versie=1)
+        EnkelvoudigInformatieObjectFactory.create(canonical=canonical, versie=2)
         eio3 = EnkelvoudigInformatieObjectFactory.create(canonical=canonical, versie=3)
 
         self.assertEqual(canonical.latest_version, eio3)

--- a/src/openzaak/components/documenten/tests/test_audittrails.py
+++ b/src/openzaak/components/documenten/tests/test_audittrails.py
@@ -2,18 +2,14 @@ import uuid
 from base64 import b64encode
 from datetime import datetime
 
-from django.test import tag
-
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.test import APITestCase
 from vng_api_common.audittrails.models import AuditTrail
-from vng_api_common.constants import ObjectTypes
 from vng_api_common.tests import reverse, reverse_lazy
 from vng_api_common.utils import get_uuid_from_path
 
 from openzaak.components.catalogi.tests.factories import InformatieObjectTypeFactory
-from openzaak.components.zaken.tests.factories import ZaakInformatieObjectFactory
 from openzaak.utils.tests import JWTAuthMixin
 
 from ..models import (

--- a/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject.py
+++ b/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject.py
@@ -617,7 +617,10 @@ class InformatieobjectCreateExternalURLsTests(JWTAuthMixin, APITestCase):
 
     def test_create_external_informatieobjecttype(self):
         catalogus = "https://externe.catalogus.nl/api/v1/catalogussen/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
-        informatieobjecttype = "https://externe.catalogus.nl/api/v1/informatieobjecttypen/b71f72ef-198d-44d8-af64-ae1932df830a"
+        informatieobjecttype = (
+            "https://externe.catalogus.nl/api/v1/informatieobjecttypen/"
+            "b71f72ef-198d-44d8-af64-ae1932df830a"
+        )
 
         with requests_mock.Mocker(real_http=True) as m:
             m.register_uri(
@@ -705,7 +708,10 @@ class InformatieobjectCreateExternalURLsTests(JWTAuthMixin, APITestCase):
 
     def test_create_external_informatieobjecttype_fail_invalid_schema(self):
         catalogus = "https://externe.catalogus.nl/api/v1/catalogussen/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
-        informatieobjecttype = "https://externe.catalogus.nl/api/v1/informatieobjecttypen/b71f72ef-198d-44d8-af64-ae1932df830a"
+        informatieobjecttype = (
+            "https://externe.catalogus.nl/api/v1/informatieobjecttypen/"
+            "b71f72ef-198d-44d8-af64-ae1932df830a"
+        )
 
         with requests_mock.Mocker(real_http=True) as m:
             m.register_uri(
@@ -745,7 +751,10 @@ class InformatieobjectCreateExternalURLsTests(JWTAuthMixin, APITestCase):
 
     def test_create_external_informatieobjecttype_fail_non_pulish(self):
         catalogus = "https://externe.catalogus.nl/api/v1/catalogussen/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
-        informatieobjecttype = "https://externe.catalogus.nl/api/v1/informatieobjecttypen/b71f72ef-198d-44d8-af64-ae1932df830a"
+        informatieobjecttype = (
+            "https://externe.catalogus.nl/api/v1/informatieobjecttypen/"
+            "b71f72ef-198d-44d8-af64-ae1932df830a"
+        )
         informatieobjecttype_data = get_informatieobjecttype_response(
             catalogus, informatieobjecttype
         )

--- a/src/openzaak/components/documenten/tests/test_objectinformatieobject.py
+++ b/src/openzaak/components/documenten/tests/test_objectinformatieobject.py
@@ -35,7 +35,7 @@ class ObjectInformatieObjectTests(JWTAuthMixin, APITestCase):
         ZaakInformatieObjectFactory.create(zaak=zaak, informatieobject=eio.canonical)
 
         # get OIO created via signals
-        oio = ObjectInformatieObject.objects.get()
+        ObjectInformatieObject.objects.get()
 
         zaak_url = reverse(zaak)
         eio_url = reverse(eio)
@@ -65,11 +65,10 @@ class ObjectInformatieObjectTests(JWTAuthMixin, APITestCase):
         )
 
         # get OIO created via signals
-        oio = ObjectInformatieObject.objects.get()
+        ObjectInformatieObject.objects.get()
 
         besluit_url = reverse(besluit)
         eio_url = reverse(eio)
-        oio_url = reverse("objectinformatieobject-detail", kwargs={"uuid": oio.uuid})
 
         response = self.client.post(
             self.list_url,

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -32,13 +32,10 @@ from vng_api_common.validators import (
     UntilNowValidator,
 )
 
-from openzaak.components.besluiten.models import Besluit
-from openzaak.components.catalogi.models import Eigenschap, ResultaatType, RolType
 from openzaak.components.documenten.api.fields import EnkelvoudigInformatieObjectField
 from openzaak.components.documenten.api.utils import create_remote_oio
 from openzaak.utils.auth import get_auth
 from openzaak.utils.exceptions import DetermineProcessEndDateException
-from openzaak.utils.serializer_fields import LengthHyperlinkedRelatedField
 from openzaak.utils.validators import (
     LooseFkIsImmutableValidator,
     LooseFkResourceValidator,

--- a/src/openzaak/components/zaken/brondatum.py
+++ b/src/openzaak/components/zaken/brondatum.py
@@ -184,10 +184,10 @@ def get_brondatum(
             )
         try:
             return zaak.einddatum + procestermijn
-        except (ValueError, TypeError) as e:
+        except (ValueError, TypeError) as exc:
             raise DetermineProcessEndDateException(
                 _("Geen geldige periode in procestermijn: {}").format(procestermijn)
-            )
+            ) from exc
 
     elif afleidingswijze == BrondatumArchiefprocedureAfleidingswijze.gerelateerde_zaak:
         relevante_zaken = zaak.relevante_andere_zaken

--- a/src/openzaak/components/zaken/models/betrokkenen.py
+++ b/src/openzaak/components/zaken/models/betrokkenen.py
@@ -71,7 +71,10 @@ class AbstractRolZaakobjectZakelijkRechtRelation(models.Model):
 class NatuurlijkPersoon(AbstractRolZaakobjectZakelijkRechtRelation):
     inp_bsn = BSNField(
         blank=True,
-        help_text="Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet algemene bepalingen burgerservicenummer.",
+        help_text=(
+            "Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet algemene "
+            "bepalingen burgerservicenummer."
+        ),
         db_index=True,
     )
     anp_identificatie = models.CharField(

--- a/src/openzaak/components/zaken/models/zaken.py
+++ b/src/openzaak/components/zaken/models/zaken.py
@@ -643,7 +643,7 @@ class ZaakObject(models.Model):
     object_type_overige = models.CharField(
         max_length=100,
         blank=True,
-        validators=[RegexValidator("[a-z\_]+")],
+        validators=[RegexValidator("[a-z_]+")],
         help_text="Beschrijft het type OBJECT als `objectType` de waarde "
         '"overige" heeft.',
     )

--- a/src/openzaak/components/zaken/tests/admin/test_klantcontact_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/test_klantcontact_audittrail.py
@@ -31,6 +31,7 @@ class KlantContactAdminTests(AdminTestMixin, TestCase):
 
         response = self.client.post(add_url, data)
 
+        self.assertEqual(response.status_code, 302)
         self.assertEqual(KlantContact.objects.count(), 1)
 
         klantcontact = KlantContact.objects.get()

--- a/src/openzaak/components/zaken/tests/admin/test_rol_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/test_rol_audittrail.py
@@ -33,6 +33,7 @@ class RolAdminTests(AdminTestMixin, TestCase):
 
         response = self.client.post(add_url, data)
 
+        self.assertEqual(response.status_code, 302)
         self.assertEqual(Rol.objects.count(), 1)
 
         rol = Rol.objects.get()

--- a/src/openzaak/components/zaken/tests/admin/test_zaak_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/test_zaak_audittrail.py
@@ -1,6 +1,5 @@
 import uuid
 
-from django.test import TestCase
 from django.urls import reverse
 
 from django_webtest import WebTest

--- a/src/openzaak/components/zaken/tests/test_auth.py
+++ b/src/openzaak/components/zaken/tests/test_auth.py
@@ -318,11 +318,11 @@ class ZaakInformatieObjectTests(JWTAuthMixin, APITestCase):
             zaak__vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.openbaar,
         )
         # must not show up
-        zio2 = ZaakInformatieObjectFactory.create(
+        ZaakInformatieObjectFactory.create(
             zaak__vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.openbaar
         )
         # must not show up
-        zio3 = ZaakInformatieObjectFactory.create(
+        ZaakInformatieObjectFactory.create(
             zaak__zaaktype=self.zaaktype,
             zaak__vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.vertrouwelijk,
         )

--- a/src/openzaak/components/zaken/tests/test_rol.py
+++ b/src/openzaak/components/zaken/tests/test_rol.py
@@ -20,12 +20,7 @@ from ..models import (
     Vestiging,
 )
 from .factories import RolFactory, ZaakFactory
-from .utils import (
-    get_catalogus_response,
-    get_operation_url,
-    get_roltype_response,
-    get_zaaktype_response,
-)
+from .utils import get_operation_url, get_roltype_response, get_zaaktype_response
 
 BETROKKENE = (
     "http://www.zamora-silva.org/api/betrokkene/8768c581-2817-4fe5-933d-37af92d819dd"

--- a/src/openzaak/components/zaken/tests/test_zaak_archive.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_archive.py
@@ -139,9 +139,7 @@ class US345TestCase(JWTAuthMixin, APITestCase):
             archiefactiedatum=date.today(),
         )
         io = EnkelvoudigInformatieObjectFactory.create(status="gearchiveerd")
-        zio = ZaakInformatieObjectFactory.create(
-            zaak=zaak, informatieobject=io.canonical
-        )
+        ZaakInformatieObjectFactory.create(zaak=zaak, informatieobject=io.canonical)
         zaak_patch_url = get_operation_url("zaak_partial_update", uuid=zaak.uuid)
         data = {"archiefstatus": Archiefstatus.gearchiveerd}
 
@@ -155,9 +153,7 @@ class US345TestCase(JWTAuthMixin, APITestCase):
             archiefactiedatum=date.today(),
         )
         io = EnkelvoudigInformatieObjectFactory.create(status="in_bewerking")
-        zio = ZaakInformatieObjectFactory.create(
-            zaak=zaak, informatieobject=io.canonical
-        )
+        ZaakInformatieObjectFactory.create(zaak=zaak, informatieobject=io.canonical)
         zaak_patch_url = get_operation_url("zaak_partial_update", uuid=zaak.uuid)
         data = {"archiefstatus": Archiefstatus.gearchiveerd}
 
@@ -553,12 +549,8 @@ class US345TestCase(JWTAuthMixin, APITestCase):
         zaak_object2 = ZaakObjectFactory.create(
             zaak=zaak, object="", object_type="woz_waarde"
         )
-        woz_waarde1 = WozWaardeFactory.create(
-            zaakobject=zaak_object1, waardepeildatum="2010-1-1"
-        )
-        woz_waarde2 = WozWaardeFactory.create(
-            zaakobject=zaak_object2, waardepeildatum="2013-1-1"
-        )
+        WozWaardeFactory.create(zaakobject=zaak_object1, waardepeildatum="2010-1-1")
+        WozWaardeFactory.create(zaakobject=zaak_object2, waardepeildatum="2013-1-1")
         resultaattype = ResultaatTypeFactory.create(
             archiefactietermijn="P10Y",
             archiefnominatie=Archiefnominatie.blijvend_bewaren,

--- a/src/openzaak/components/zaken/tests/test_zaak_filter_on_archief_data.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_filter_on_archief_data.py
@@ -24,7 +24,7 @@ class US345TestCase(JWTAuthMixin, APITestCase):
             archiefactiedatum=date(2010, 1, 1),
             archiefstatus=Archiefstatus.nog_te_archiveren,
         )
-        zaak_2 = ZaakFactory.create(
+        ZaakFactory.create(
             archiefnominatie=Archiefnominatie.vernietigen,
             archiefactiedatum=date(2010, 1, 1),
             archiefstatus=Archiefstatus.nog_te_archiveren,

--- a/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten.py
+++ b/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten.py
@@ -313,7 +313,7 @@ class ZaakInformatieObjectAPITests(JWTAuthMixin, APITestCase):
         io = EnkelvoudigInformatieObjectFactory.create()
         io_url = reverse(io)
 
-        ziot = ZaakTypeInformatieObjectTypeFactory.create(
+        ZaakTypeInformatieObjectTypeFactory.create(
             zaaktype=zaak.zaaktype, informatieobjecttype=io.informatieobjecttype
         )
 
@@ -343,11 +343,9 @@ class ZaakInformatieObjectAPITests(JWTAuthMixin, APITestCase):
 
     def test_partial_update_zio_metadata(self):
         zaak = ZaakFactory.create()
-        zaak_url = reverse(zaak)
         io = EnkelvoudigInformatieObjectFactory.create()
-        io_url = reverse(io)
 
-        ziot = ZaakTypeInformatieObjectTypeFactory.create(
+        ZaakTypeInformatieObjectTypeFactory.create(
             zaaktype=zaak.zaaktype, informatieobjecttype=io.informatieobjecttype
         )
 

--- a/src/openzaak/components/zaken/tests/test_zaakobject_filter.py
+++ b/src/openzaak/components/zaken/tests/test_zaakobject_filter.py
@@ -14,7 +14,7 @@ class ZaakObjectFilterTestCase(JWTAuthMixin, APITestCase):
 
     def test_filter_type(self):
         zaakobject1 = ZaakObjectFactory.create(object_type=ZaakobjectTypes.besluit)
-        zaakobject2 = ZaakObjectFactory.create(object_type=ZaakobjectTypes.adres)
+        ZaakObjectFactory.create(object_type=ZaakobjectTypes.adres)
         zaakobject1_url = get_operation_url("zaakobject_read", uuid=zaakobject1.uuid)
         url = get_operation_url("zaakobject_list")
 
@@ -29,7 +29,7 @@ class ZaakObjectFilterTestCase(JWTAuthMixin, APITestCase):
 
     def test_filter_zaak(self):
         zaakobject1 = ZaakObjectFactory.create()
-        zaakobject2 = ZaakObjectFactory.create()
+        ZaakObjectFactory.create()
         zaak = zaakobject1.zaak
         zaak_url = get_operation_url("zaak_read", uuid=zaak.uuid)
         zaakobject1_url = get_operation_url("zaakobject_read", uuid=zaakobject1.uuid)
@@ -48,7 +48,7 @@ class ZaakObjectFilterTestCase(JWTAuthMixin, APITestCase):
 
     def test_filter_object(self):
         zaakobject1 = ZaakObjectFactory.create(object="http://example.com/objects/1")
-        zaakobject2 = ZaakObjectFactory.create(object="http://example.com/objects/2")
+        ZaakObjectFactory.create(object="http://example.com/objects/2")
         zaakobject1_url = get_operation_url("zaakobject_read", uuid=zaakobject1.uuid)
         url = get_operation_url("zaakobject_list")
 

--- a/src/openzaak/components/zaken/tests/utils.py
+++ b/src/openzaak/components/zaken/tests/utils.py
@@ -49,7 +49,10 @@ def get_zaaktype_response(catalogus: str, zaaktype: str) -> dict:
         "publicatietekst": "",
         "verantwoordingsrelatie": ["qwerty"],
         "productenOfDiensten": ["https://example.com/product/123"],
-        "selectielijstProcestype": "https://referentielijsten-api.vng.cloud/api/v1/procestypen/e1b73b12-b2f6-4c4e-8929-94f84dd2a57d",
+        "selectielijstProcestype": (
+            "https://referentielijsten-api.vng.cloud/api/v1/"
+            "procestypen/e1b73b12-b2f6-4c4e-8929-94f84dd2a57d"
+        ),
         "referentieproces": {},
         "statustypen": [],
         "resultaattypen": [],
@@ -120,9 +123,15 @@ def get_resultaattype_response(resultaattype: str, zaaktype: str) -> dict:
         "url": resultaattype,
         "zaaktype": zaaktype,
         "omschrijving": "some role",
-        "resultaattypeomschrijving": "https://referentielijsten-api.vng.cloud/api/v1/resultaattypeomschrijvingen/e6a0c939-3404-45b0-88e3-76c94fb80ea7",
+        "resultaattypeomschrijving": (
+            "https://referentielijsten-api.vng.cloud/api/v1/"
+            "resultaattypeomschrijvingen/e6a0c939-3404-45b0-88e3-76c94fb80ea7"
+        ),
         "omschrijvingGeneriek": "Afgewezen",
-        "selectielijstklasse": "https://referentielijsten-api.vng.cloud/api/v1/resultaten/cc5ae4e3-a9e6-4386-bcee-46be4986a829",
+        "selectielijstklasse": (
+            "https://referentielijsten-api.vng.cloud/api/v1/"
+            "resultaten/cc5ae4e3-a9e6-4386-bcee-46be4986a829"
+        ),
         "toelichting": "",
         "archiefnominatie": "vernietigen",
         "archiefactietermijn": "P10Y",

--- a/src/openzaak/management/commands/generate_swagger_component.py
+++ b/src/openzaak/management/commands/generate_swagger_component.py
@@ -1,7 +1,3 @@
-import os
-
-from django.conf import settings
-
 from vng_api_common.management.commands import generate_swagger
 
 SCHEMA_MAPPING = {

--- a/src/openzaak/utils/inspectors.py
+++ b/src/openzaak/utils/inspectors.py
@@ -3,11 +3,7 @@ import logging
 from django_loose_fk.drf import FKOrURLField
 from drf_yasg import openapi
 from drf_yasg.inspectors.base import NotHandled
-from drf_yasg.inspectors.field import (
-    FieldInspector,
-    SimpleFieldInspector,
-    get_basic_type_info,
-)
+from drf_yasg.inspectors.field import FieldInspector
 
 from .serializer_fields import LengthHyperlinkedRelatedField
 

--- a/src/openzaak/utils/views.py
+++ b/src/openzaak/utils/views.py
@@ -2,7 +2,6 @@ from django import http
 from django.template import TemplateDoesNotExist, loader
 from django.views.decorators.csrf import requires_csrf_token
 from django.views.defaults import ERROR_500_TEMPLATE_NAME
-from django.views.generic import TemplateView
 
 
 @requires_csrf_token


### PR DESCRIPTION
Adds flake8 for code style checking/linting.

I don't like having to point out unused imports during code review, this automates it :-)