### PR TITLE
Ensure admin doesn't crash if you have readonly permissions

### DIFF
--- a/src/openzaak/components/catalogi/admin/forms.py
+++ b/src/openzaak/components/catalogi/admin/forms.py
@@ -31,9 +31,15 @@ class ZaakTypeForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["opschorting_en_aanhouding_mogelijk"].widget.required = True
-        self.fields["verlenging_mogelijk"].widget.required = True
-        self.fields["publicatie_indicatie"].widget.required = True
+
+        self._make_required("opschorting_en_aanhouding_mogelijk")
+        self._make_required("verlenging_mogelijk")
+        self._make_required("publicatie_indicatie")
+
+    def _make_required(self, field: str):
+        if field not in self.fields:
+            return
+        self.fields[field].widget.required = True
 
     def clean(self):
         super().clean()


### PR DESCRIPTION
The field is not present on the model form if you only have read-only permissions, which crashes with:

```
2020-01-07 10:52:14,177 ERROR django.request log 10 140085638494080  Internal Server Error: /admin/catalogi/zaaktype/12/change/
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/contrib/admin/options.py", line 606, in wrapper
    return self.admin_site.admin_view(view)(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/utils/decorators.py", line 142, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/views/decorators/cache.py", line 44, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/contrib/admin/sites.py", line 223, in inner
    return view(request, *args, **kwargs)
  File "./openzaak/utils/admin.py", line 361, in change_view
    extra_context=self._get_extra_context(request, extra_context, object_id),
  File "/usr/local/lib/python3.7/site-packages/django/contrib/admin/options.py", line 1637, in change_view
    return self.changeform_view(request, object_id, form_url, extra_context)
  File "/usr/local/lib/python3.7/site-packages/django/utils/decorators.py", line 45, in _wrapper
    return bound_method(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/utils/decorators.py", line 142, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/contrib/admin/options.py", line 1522, in changeform_view
    return self._changeform_view(request, object_id, form_url, extra_context)
  File "/usr/local/lib/python3.7/site-packages/django/contrib/admin/options.py", line 1578, in _changeform_view
    form = ModelForm(instance=obj)
  File "./openzaak/components/catalogi/admin/forms.py", line 34, in __init__
    self.fields["opschorting_en_aanhouding_mogelijk"].widget.required = True
KeyError: 'opschorting_en_aanhouding_mogelijk'
```