### PR TITLE
Bump waitress to 1.4.2

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -74,6 +74,6 @@ uritemplate==3.0.0
 urllib3==1.24.3
 uwsgi==2.0.18
 vng-api-common==1.0.35
-waitress==1.4.1           # via webtest
+waitress==1.4.2           # via webtest
 webob==1.8.5              # via webtest
 webtest==2.0.33           # via django-webtest

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -109,7 +109,7 @@ uritemplate==3.0.0
 urllib3==1.24.3
 uwsgi==2.0.18
 vng-api-common==1.0.35
-waitress==1.4.1
+waitress==1.4.2
 webob==1.8.5
 webtest==2.0.33
 


### PR DESCRIPTION
Replaces #376 -- bumps waitress in dev/CI environment.

This is not really critical since waitress is not used for production
usage, but dependabot will probably keep sending PRs for it.