### PR TITLE
Make Newman/Docker stages conditional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,12 @@ before_script:
   # https://github.com/travis-ci/travis-ci/issues/8982#issuecomment-354357640
   - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
 
+stages:
+  - name: Newman tests
+    if: fork = false
+  - name: Push Docker image(s)
+    if: fork = false
+
 jobs:
   include:
     # Run jobs in parallel in stage Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,6 @@ before_script:
   # https://github.com/travis-ci/travis-ci/issues/8982#issuecomment-354357640
   - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
 
-stages:
-  - name: Newman tests
-    if: fork = false
-  - name: Push Docker image(s)
-    if: fork = false
-
 jobs:
   include:
     # Run jobs in parallel in stage Tests
@@ -102,6 +96,7 @@ jobs:
         - docker-compose rm -f
 
     - stage: Push Docker image(s)
+      if: fork = false
       before_install: skip
       install: skip
       before_script: skip

--- a/bin/postman_tests.sh
+++ b/bin/postman_tests.sh
@@ -2,6 +2,13 @@
 
 set -x
 
+# These client IDs and secrets are dummy variables that are only used by
+# the Docker build in Travis, so they can be public
+client_id=zgw_api_tests
+secret=secret
+client_id_limited=zgw_api_tests_limited
+secret_limited=secret_limited
+
 openzaak_url=localhost:8000
 nrc_url=localhost:8001
 


### PR DESCRIPTION
Via #379 it became clear that forks (untrusted) do not have access
to the necessary environment variables to:
* run Newman tests
* publish docker images

This should disable the relevant stages for forks, keeping the Django
tests and code style checks stage. Newman tests and docker builds/push
will happen once the branch is merged into master.

Note that this introduces a small regression risk - changes could be
introduced that break the API tests from the ATP and we'd only
realize _after_ the merge to master.