### PR TITLE
Fixes #360 -- Document how to upgrade Open Zaak

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = False
-current_version = 0.1.0
+current_version = 0.9.0
 
 [bumpversion:file:README.rst]
 
@@ -16,3 +16,4 @@ replace = openzaak_version: '{new_version}'
 [bumpversion:file:deployment/single-server/roles/openzaak/defaults/main.yml]
 search = openzaak_version: '{current_version}'
 replace = openzaak_version: '{new_version}'
+

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -9,3 +9,10 @@ current_version = 0.1.0
 search = "version": "{current_version}",
 replace = "version": "{new_version}",
 
+[bumpversion:file:deployment/kubernetes/roles/openzaak/defaults/main.yml]
+search = openzaak_version: '{current_version}'
+replace = openzaak_version: '{new_version}'
+
+[bumpversion:file:deployment/single-server/roles/openzaak/defaults/main.yml]
+search = openzaak_version: '{current_version}'
+replace = openzaak_version: '{new_version}'

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,8 @@ docker-compose*
 .git
 .vscode
 env/
+private-media/
+media/
+log/
 .env
 includes/local.py

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,6 @@ Changelog
 
 First release of Open Zaak.
 
-Requires manual intervention if you were using beta versions! See below.
-
 Features:
 
 * Zaken API implementation
@@ -19,79 +17,10 @@ Features:
 * Admin interface to manage Catalogi
 * Admin interface to manage Applicaties and Autorisaties
 * Admin interface to view data created via the APIs
-* NLX ready
-* Documentation
-* Performant
-* Maximal data integrity
-* Scalable
-* Kubernetes / VPS / DDS native
+* `NLX`_ ready (can be used with NLX)
+* Documentation on https://open-zaak.readthedocs.io/
+* Deployable on Kubernetes, single server and as VMware appliance
 * Automated test suite
 * Automated deployment
 
-Manual intervention: reset migrations
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-We've reset the migrations for the 1.0.0 migration. Run the reset script after pulling
-the new image/version::
-
-    ./bin/reset_migrations.sh
-
-**On Kubernetes**
-
-Create a job to run the one-time script::
-
-    apiVersion: batch/v1
-    kind: Job
-    metadata:
-      name: resetmigrations
-    spec:
-      template:
-        spec:
-          containers:
-          - name: resetmigrations
-            image: openzaak/open-zaak:latest
-            imagePullPolicy: Always
-            command: ["./bin/reset_migrations.sh"]
-            env:
-              - name: DJANGO_SETTINGS_MODULE
-                value: openzaak.conf.docker
-              - name: SECRET_KEY
-                valueFrom:
-                  secretKeyRef:
-                    name: openzaak-secrets
-                    key: SECRET_KEY
-
-              # Database settings
-              - name: DB_HOST
-                value: "db3.k8s.utrecht.fuga.cyso.net"
-              - name: DB_NAME
-                value: "openzaak"
-              - name: DB_PORT
-                value: "5432"
-              - name: DB_USER
-                value: "openzaak"
-              - name: DB_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: openzaak-secrets
-                    key: DB_PASSWORD
-          restartPolicy: OnFailure
-
-      backoffLimit: 4
-
-
-Make sure to fill out the template variables.
-
-Save this Job definition to ``job.yml`` and then apply it::
-
-    kubectl apply -f /tmp/job.yml
-
-**On Docker (appliance/vps/dds/single-server)**
-
-Run a container as a one-time thing::
-
-    docker run \
-        -v /home/openzaak/.env:/app/.env \
-        --rm \
-        openzaak/open-zaak:latest \
-        /app/bin/reset_migrations.sh
+.. _NLX: https://nlx.io/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 
 First release of Open Zaak.
 
+Requires manual intervention if you were using beta versions! See below.
+
 Features:
 
 * Zaken API implementation
@@ -25,3 +27,71 @@ Features:
 * Kubernetes / VPS / DDS native
 * Automated test suite
 * Automated deployment
+
+Manual intervention: reset migrations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We've reset the migrations for the 1.0.0 migration. Run the reset script after pulling
+the new image/version::
+
+    ./bin/reset_migrations.sh
+
+**On Kubernetes**
+
+Create a job to run the one-time script::
+
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: resetmigrations
+    spec:
+      template:
+        spec:
+          containers:
+          - name: resetmigrations
+            image: openzaak/open-zaak:latest
+            imagePullPolicy: Always
+            command: ["./bin/reset_migrations.sh"]
+            env:
+              - name: DJANGO_SETTINGS_MODULE
+                value: openzaak.conf.docker
+              - name: SECRET_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: openzaak-secrets
+                    key: SECRET_KEY
+
+              # Database settings
+              - name: DB_HOST
+                value: "db3.k8s.utrecht.fuga.cyso.net"
+              - name: DB_NAME
+                value: "openzaak"
+              - name: DB_PORT
+                value: "5432"
+              - name: DB_USER
+                value: "openzaak"
+              - name: DB_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: openzaak-secrets
+                    key: DB_PASSWORD
+          restartPolicy: OnFailure
+
+      backoffLimit: 4
+
+
+Make sure to fill out the template variables.
+
+Save this Job definition to ``job.yml`` and then apply it::
+
+    kubectl apply -f /tmp/job.yml
+
+**On Docker (appliance/vps/dds/single-server)**
+
+Run a container as a one-time thing::
+
+    docker run \
+        -v /home/openzaak/.env:/app/.env \
+        --rm \
+        openzaak/open-zaak:latest \
+        /app/bin/reset_migrations.sh

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,27 @@
+Changelog
+=========
+
+1.0.0 (TDB)
+-----------
+
+First release of Open Zaak.
+
+Features:
+
+* Zaken API implementation
+* Documenten API implementation
+* Catalogi API implementation
+* Besluiten API implementation
+* Autorisaties API implementation
+* Support for external APIs
+* Admin interface to manage Catalogi
+* Admin interface to manage Applicaties and Autorisaties
+* Admin interface to view data created via the APIs
+* NLX ready
+* Documentation
+* Performant
+* Maximal data integrity
+* Scalable
+* Kubernetes / VPS / DDS native
+* Automated test suite
+* Automated deployment

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN mkdir /app/log
 
 COPY --from=frontend-build /app/src/openzaak/static/css /app/src/openzaak/static/css
 COPY --from=frontend-build /app/src/openzaak/static/js /app/src/openzaak/static/js
+COPY bin/reset_migrations.sh /app/bin/reset_migrations.sh
 COPY ./src /app/src
 ARG COMMIT_HASH
 ENV GIT_SHA=${COMMIT_HASH}

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Open Zaak
 =========
 
-:Version: 1.0.0-alpha
+:Version: 0.1.0
 :Source: https://github.com/open-zaak/open-zaak
 :Keywords: zaken, zaakgericht werken, zaken-api, catalogi-api, besluiten-api, documenten-api
 :PythonVersion: 3.7

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Open Zaak
 =========
 
-:Version: 0.1.0
+:Version: 0.9.0
 :Source: https://github.com/open-zaak/open-zaak
 :Keywords: zaken, zaakgericht werken, zaken-api, catalogi-api, besluiten-api, documenten-api
 :PythonVersion: 3.7

--- a/deployment/kubernetes/apps.yml
+++ b/deployment/kubernetes/apps.yml
@@ -12,13 +12,10 @@
   roles:
     - role: openzaak
       vars:
-        openzaak_domain: gc-k8s-16cpu-64ram.openzaak.nl
+        openzaak_domain: test.openzaak.nl
         openzaak_db_host: "{{ db.privateIp }}"
         openzaak_db_port: "{{ db.port }}"
         openzaak_replicas: 3
-        # openzaak_extra_hosts:
-        #   - ingress-nginx-rsa4096.openzaak.nl
-        #   - ingress-nginx-ec256.openzaak.nl
       tags:
         - openzaak
 
@@ -33,33 +30,33 @@
         nlx_inway_self_address: inway.openzaak.nl
         nlx_inway_services:
           - name: openzaak-zaken
-            endpoint_url: http://nginx.openzaak-test/zaken/api/v1
-            documentation_url: https://test.openzaak.nl/zaken/
+            endpoint_url: https://{{ openzaak_domain }}/zaken/api/v1
+            documentation_url: https://{{ openzaak_domain }}/zaken/
             authorization_model: none
-            api_specification_document_url: https://test.openzaak.nl/zaken/api/v1/schema/openapi.json
+            api_specification_document_url: https://{{ openzaak_domain }}/zaken/api/v1/schema/openapi.json
 
-          # - name: openzaak-documenten
-          #   endpoint_url: https://test.openzaak.nl/documenten/api/v1
-          #   documentation_url: https://test.openzaak.nl/documenten/
-          #   authorization_model: none
-          #   api_specification_document_url: https://test.openzaak.nl/documenten/api/v1/schema/openapi.json
+          - name: openzaak-documenten
+            endpoint_url: https://{{ openzaak_domain }}/documenten/api/v1
+            documentation_url: https://{{ openzaak_domain }}/documenten/
+            authorization_model: none
+            api_specification_document_url: https://{{ openzaak_domain }}/documenten/api/v1/schema/openapi.json
 
-          # - name: openzaak-catalogi
-          #   endpoint_url: https://test.openzaak.nl/catalogi/api/v1
-          #   documentation_url: https://test.openzaak.nl/catalogi/
-          #   authorization_model: none
-          #   api_specification_document_url: https://test.openzaak.nl/catalogi/api/v1/schema/openapi.json
+          - name: openzaak-catalogi
+            endpoint_url: https://{{ openzaak_domain }}/catalogi/api/v1
+            documentation_url: https://{{ openzaak_domain }}/catalogi/
+            authorization_model: none
+            api_specification_document_url: https://{{ openzaak_domain }}/catalogi/api/v1/schema/openapi.json
 
-          # - name: openzaak-besluiten
-          #   endpoint_url: https://test.openzaak.nl/besluiten/api/v1
-          #   documentation_url: https://test.openzaak.nl/besluiten/
-          #   authorization_model: none
-          #   api_specification_document_url: https://test.openzaak.nl/besluiten/api/v1/schema/openapi.json
+          - name: openzaak-besluiten
+            endpoint_url: https://{{ openzaak_domain }}/besluiten/api/v1
+            documentation_url: https://{{ openzaak_domain }}/besluiten/
+            authorization_model: none
+            api_specification_document_url: https://{{ openzaak_domain }}/besluiten/api/v1/schema/openapi.json
 
-          # - name: openzaak-authorizations
-          #   endpoint_url: https://test.openzaak.nl/authorizations/api/v1
-          #   documentation_url: https://test.openzaak.nl/authorizations/
-          #   authorization_model: none
-          #   api_specification_document_url: https://test.openzaak.nl/authorizations/api/v1/schema/openapi.json
+          - name: openzaak-authorizations
+            endpoint_url: https://{{ openzaak_domain }}/authorizations/api/v1
+            documentation_url: https://{{ openzaak_domain }}/authorizations/
+            authorization_model: none
+            api_specification_document_url: https://{{ openzaak_domain }}/authorizations/api/v1/schema/openapi.json
       tags:
         - nlx

--- a/deployment/kubernetes/roles/openzaak/defaults/main.yml
+++ b/deployment/kubernetes/roles/openzaak/defaults/main.yml
@@ -20,7 +20,7 @@ cache_db: 0
 # Kubernetes namespace to run in
 namespace: openzaak-test
 
-openzaak_version: '0.1.0'
+openzaak_version: '0.9.0'
 openzaak_image: openzaak/open-zaak:{{ openzaak_version }}
 openzaak_replicas: 3
 openzaak_instance: test

--- a/deployment/kubernetes/roles/openzaak/defaults/main.yml
+++ b/deployment/kubernetes/roles/openzaak/defaults/main.yml
@@ -20,7 +20,7 @@ cache_db: 0
 # Kubernetes namespace to run in
 namespace: openzaak-test
 
-openzaak_version: latest
+openzaak_version: '0.1.0'
 openzaak_image: openzaak/open-zaak:{{ openzaak_version }}
 openzaak_replicas: 3
 openzaak_instance: test

--- a/deployment/single-server/roles/openzaak/defaults/main.yml
+++ b/deployment/single-server/roles/openzaak/defaults/main.yml
@@ -9,6 +9,9 @@ openzaak_db_password: openzaak
 openzaak_secret_key: override-me
 openzaak_env_file: /home/openzaak/.env
 
+openzaak_version: '0.1.0'
+openzaak_image: openzaak/open-zaak:{{ openzaak_version }}
+
 openzaak_replicas:
   - name: openzaak-0
     port: 8000

--- a/deployment/single-server/roles/openzaak/defaults/main.yml
+++ b/deployment/single-server/roles/openzaak/defaults/main.yml
@@ -9,7 +9,7 @@ openzaak_db_password: openzaak
 openzaak_secret_key: override-me
 openzaak_env_file: /home/openzaak/.env
 
-openzaak_version: '0.1.0'
+openzaak_version: '0.9.0'
 openzaak_image: openzaak/open-zaak:{{ openzaak_version }}
 
 openzaak_replicas:

--- a/deployment/single-server/roles/openzaak/tasks/containers.yml
+++ b/deployment/single-server/roles/openzaak/tasks/containers.yml
@@ -15,7 +15,7 @@
 - name: Run the OpenZaak backend service
   docker_container:
     name: "{{ item.name }}"
-    image: openzaak/open-zaak:latest
+    image: "{{ openzaak_image }}"
     pull: yes
     hostname: "{{ item.name }}"
     restart_policy: always

--- a/docs/development/changelog.rst
+++ b/docs/development/changelog.rst
@@ -1,0 +1,3 @@
+.. _development_changelog:
+
+.. include:: ../../CHANGELOG.rst

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -10,3 +10,4 @@ Open Zaak is open-source software. We’d love to have you contribute!
 
    contributing
    development-environment
+   release

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -11,3 +11,4 @@ Open Zaak is open-source software. We’d love to have you contribute!
    contributing
    development-environment
    release
+   changelog

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -17,7 +17,7 @@ Merges to the ``master`` branch are built on Travis, where:
 3. Compatibility with the *API's voor zaakgericht werken* standard spec is tested
 4. The Docker image is built and published
 
-If the built is for a Git tag on the ``master`` branch, then the image is built and
+If the build is for a Git tag on the ``master`` branch, then the image is built and
 publish with that version tag to Docker Hub.
 
 Releasing a new version

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -1,0 +1,66 @@
+
+Release process
+===============
+
+Open Zaak makes use of quite a bit of Continuous Integration tooling to set up a full
+release process, all driven by the Git repository.
+
+Travis CI
+---------
+
+Our pipeline is mostly implemented on Travis:
+
+Merges to the ``master`` branch are built on Travis, where:
+
+1. Tests are run
+2. Code quality checks are run
+3. Compatibility with the *API's voor zaakgericht werken* standard spec is tested
+4. The Docker image is built and published
+
+If the built is for a Git tag on the ``master`` branch, then the image is built and
+publish with that version tag to Docker Hub.
+
+Releasing a new version
+-----------------------
+
+Releasing a new version can only be done by people with merge permissions to the master
+branch belonging to the Open Zaak organisation on Github.
+
+Assuming a current version of ``0.9.0``:
+
+**Create a release branch**
+
+.. code-block:: bash
+
+    git checkout -b release/1.0.0
+
+**Update the changelog**
+
+Update ``CHANGELOG.rst`` in the root of the project, and make sure to commit the
+changes.
+
+**Bump the version**
+
+.. code-block:: bash
+
+    bumpversion minor
+
+and commit:
+
+.. code-block:: bash
+
+    git commit -am ":bookmark: Bump version to 1.0.0"
+
+Push the changes and make a pull request.
+
+**Tag the release**
+
+Once the PR is merged to master, check out the ``master`` branch and tag it:
+
+.. code-block:: bash
+
+    git checkout master
+    git pull
+    git tag 1.0.0
+
+Tagging will ensure that a Docker image ``openzaak/open-zaak:1.0.0`` is published.

--- a/docs/installation/deployment/kubernetes.rst
+++ b/docs/installation/deployment/kubernetes.rst
@@ -171,6 +171,8 @@ Before you begin, you will need:
 
       [user@host]$ gcloud compute disks create --size=10GB --zone=europe-west4-b gce-nfs-disk
 
+.. _deployment_kubernetes_tooling:
+
 Deployment requirements
 =======================
 
@@ -375,3 +377,52 @@ default setup should be sufficient to get started though.
 
 To be able to work with Open Zaak, a couple of things have to be configured first,
 see :ref:`installation_configuration` for more details.
+
+.. _deployment_kubernetes_updating:
+
+Updating an Open Zaak installation
+==================================
+
+Make sure you have the deployment tooling installed - see
+:ref:`deployment_kubernetes_tooling` for more details.
+
+If you have an existing environment (from the installation), make sure to update it:
+
+.. code-block:: shell
+
+    # fetch the updates from Github
+    [user@host]$ git fetch origin
+
+    # checkout the tag of the version you wish to update to, e.g. 1.0.0
+    [user@host]$ git checkout X.Y.z
+
+    # activate the virtualenv
+    [user@host]$ source env/bin/activate
+
+    # ensure all (correct versions of the) dependencies are installed
+    (env) [user@host]$ pip install -r requirements.txt
+
+Open Zaak deployment code defines variables to specify the Docker image tag to use. This
+is synchronized with the git tag you're checking out.
+
+.. warning::
+    Make sure you are aware of possible breaking changes or manual interventions by
+    reading the :ref:`development_changelog`!
+
+Next, to perform the upgrade, you run the ``apps.yml`` playbook just like with the
+installation:
+
+.. code-block:: shell
+
+    (env) [user@host]$ ./deploy.sh apps.yml
+
+.. note::
+
+    In the Kubernetes deployment setup, Open Zaak makes use of multiple replicas by
+    default, and is set up to perform rolling releases. This means that the old version
+    stays live until all new versions are running without errors.
+
+    We make use of health checks and liveness probes to achieve this.
+
+    This does mean that there's a brief window where clients may hit the old or new
+    version at the same time - usually this shouldn't pose a problem though.

--- a/docs/installation/deployment/single_server.rst
+++ b/docs/installation/deployment/single_server.rst
@@ -40,6 +40,8 @@ ssh to the machine as ``root`` user. If that's not the case, a user with
 are officially supported operating systems, though it is likely the
 installation also works on Ubuntu. CentOS/RedHat *might* work.
 
+.. _deployment_containers_tooling:
+
 A copy of the deployment configuration
 --------------------------------------
 
@@ -66,6 +68,7 @@ dependencies:
 .. code-block:: shell
 
     (env) [user@laptop]$ pip install -r deployment/requirements.txt
+    (env) [user@laptop]$ ansible-galaxy install -r requirements.yml
 
 Deployment
 ==========
@@ -112,6 +115,8 @@ server.
    will be generated for this domain and only this domain will be whitelisted
    by Open Zaak!
 
+.. _deployment_containers_playbook:
+
 Running the deployment
 ----------------------
 
@@ -119,7 +124,6 @@ Execute the playbook by running:
 
 .. code-block:: shell
 
-    (env) [user@laptop]$ ansible-galaxy install -r requirements.yml
     (env) [user@laptop]$ ansible-playbook open-zaak.yml
 
 .. hint::
@@ -191,16 +195,8 @@ A superuser allows you to perform all administrative tasks.
 
 **Configure Open Zaak Admin**
 
-1. Open ``https://open-zaak.gemeente.nl/admin/`` in your favourite browser and log
-   in with your superuser account.
-
-2. Navigate to **Configuratie** > **Websites** and edit ``example.com``. Fill in
-   your actual domain.
-
-3. Navigate to **Configuratie** > **Notificatiescomponentconfiguratie** and
-   specify the correct Notificaties API url.
-
-4. Configure the credentials via **API autorisaties**.
+See the :ref:`installation_configuration` on how to configure Open Zaak
+post-installation.
 
 .. _containers_config_params:
 
@@ -262,3 +258,47 @@ default setup should be sufficient to get started though.
 
 To be able to work with Open Zaak, a couple of things have to be configured first,
 see :ref:`installation_configuration` for more details.
+
+.. _deployment_containers_updating:
+
+Updating an Open Zaak installation
+==================================
+
+Make sure you have the deployment tooling installed - see
+:ref:`the installation steps<deployment_containers_tooling>` for more details.
+
+If you have an existing environment (from the installation), make sure to update it:
+
+.. code-block:: shell
+
+    # fetch the updates from Github
+    [user@host]$ git fetch origin
+
+    # checkout the tag of the version you wish to update to, e.g. 1.0.0
+    [user@host]$ git checkout X.Y.z
+
+    # activate the virtualenv
+    [user@host]$ source env/bin/activate
+
+    # ensure all (correct versions of the) dependencies are installed
+    (env) [user@host]$ pip install -r requirements.txt
+    (env) [user@host]$ ansible-galaxy install -r requirements.yml
+
+Open Zaak deployment code defines variables to specify the Docker image tag to use. This
+is synchronized with the git tag you're checking out.
+
+.. warning::
+    Make sure you are aware of possible breaking changes or manual interventions by
+    reading the :ref:`development_changelog`!
+
+Next, to perform the upgrade, you run the ``open-zaak.yml`` playbook just like with the
+installation in :ref:`deployment_containers_playbook`:
+
+.. code-block:: shell
+
+    (env) [user@laptop]$ ansible-playbook open-zaak.yml
+
+.. note::
+    This will instruct the docker containers to restart using a new image. You may
+    notice some brief downtime (order of seconds to minutes) while the new image is
+    being downloaded and containers are being restarted.

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -42,5 +42,6 @@ Guides
    deployment/single_server
    configuration
    logging
+   updating
    performance/index
    linux

--- a/docs/installation/updating.rst
+++ b/docs/installation/updating.rst
@@ -1,0 +1,28 @@
+.. _installation_updating:
+
+Updating an Open Zaak installation
+==================================
+
+Software receives new features and bugfixes all the time, and Open Zaak is no different.
+At some point, you'll want to update to a newer version of Open Zaak - be it a patch
+version with bugfixes or a feature release to upgrade to.
+
+Before you actually upgrade, we strongly advise you to take a look at the
+:ref:`development_changelog` to spot any breaking changes or required manual
+interventions.
+
+.. note::
+    We always recommend you to have taken and tested your backups in case something
+    goes wrong, BEFORE performing any updates.
+
+The update instructions are split per target environment.
+
+Updating on Kubernetes
+----------------------
+
+See :ref:`deployment_kubernetes_updating` for the update instructions on Kubernetes.
+
+Updating a single server installation
+-------------------------------------
+
+TODO

--- a/docs/installation/updating.rst
+++ b/docs/installation/updating.rst
@@ -15,6 +15,11 @@ interventions.
     We always recommend you to have taken and tested your backups in case something
     goes wrong, BEFORE performing any updates.
 
+.. note::
+    We encourage having multiple environments such as staging and production, completely
+    isolated from each other. This allows you to test out the update on a staging
+    environment to check if anything goes wrong, without affecting production.
+
 The update instructions are split per target environment.
 
 Updating on Kubernetes
@@ -25,4 +30,5 @@ See :ref:`deployment_kubernetes_updating` for the update instructions on Kuberne
 Updating a single server installation
 -------------------------------------
 
-TODO
+See the steps on how to
+:ref:`update a single server installation<deployment_containers_updating>`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openzaak",
-  "version": "0.1.0",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openzaak",
-  "version": "0.1.0",
+  "version": "0.9.0",
   "description": "Open Zaak",
   "main": "src/index.js",
   "directories": {

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,4 +1,5 @@
 # Helpers
+bumpversion
 pip-tools
 
 # Code formatting

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,6 +10,7 @@ attrs==19.1.0             # via black
 babel==2.7.0              # via sphinx
 beautifulsoup4==4.8.1
 black==19.10b0
+bumpversion==0.5.3
 certifi==2018.4.16
 chardet==3.0.4
 click==7.0                # via black, pip-tools
@@ -69,7 +70,7 @@ mccabe==0.6.1             # via flake8
 oyaml==0.7
 packaging==19.2           # via sphinx
 pathspec==0.6.0           # via black
-pip-tools==4.2.0
+pip-tools==4.4.0
 psycopg2==2.8.3
 pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,16 +7,16 @@ multi_line_output = 3
 skip = env,node_modules
 skip_glob = **/migrations/**
 not_skip = __init__.py
-known_django=django
-known_first_party=openzaak
-sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+known_django = django
+known_first_party = openzaak
+sections = FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
 ; black compatible settings
 [flake8]
 ; absolute maximum - more lenient than black's 88
 max-line-length = 119
 ignore = E121,E123,E126,E226,E24,E704,W503,W504,E231,F405,E203
-exclude=migrations,static,media
+exclude = migrations,static,media
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
* Document upgrade on K8s and single server
* Applied Docker image/git tag versioning
* Added bumpversion & synced version numbers everywhere
* Documented release process w/r to versioning