### PR TITLE
Fixes #298 -- block zaak data mutations if the zaak is closed

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "gulp build",
     "watch": "gulp watch",
+    "convert": "swagger2openapi $SCHEMA_PATH/swagger2.0.json -o $SCHEMA_PATH/openapi.yaml",
     "appliance:serve-config": "http-server deployment/appliance/debian-config"
   },
   "repository": {

--- a/src/openzaak/components/besluiten/api/viewsets.py
+++ b/src/openzaak/components/besluiten/api/viewsets.py
@@ -19,6 +19,7 @@ from vng_api_common.notifications.viewsets import (
 from vng_api_common.viewsets import CheckQueryParamsMixin
 
 from openzaak.components.documenten.api.utils import delete_remote_oio
+from openzaak.components.zaken.api.mixins import ClosedZaakMixin
 from openzaak.components.zaken.api.utils import delete_remote_zaakbesluit
 from openzaak.utils.data_filtering import ListFilterByAuthorizationsMixin
 
@@ -41,6 +42,7 @@ class BesluitViewSet(
     NotificationViewSetMixin,
     AuditTrailViewsetMixin,
     ListFilterByAuthorizationsMixin,
+    ClosedZaakMixin,
     viewsets.ModelViewSet,
 ):
     """

--- a/src/openzaak/components/zaken/api/exceptions.py
+++ b/src/openzaak/components/zaken/api/exceptions.py
@@ -1,0 +1,7 @@
+from django.utils.translation import ugettext_lazy as _
+
+from rest_framework.exceptions import PermissionDenied
+
+
+class ZaakClosed(PermissionDenied):
+    default_detail = _("You are not allowed to modify closed zaak data.")

--- a/src/openzaak/components/zaken/api/mixins.py
+++ b/src/openzaak/components/zaken/api/mixins.py
@@ -1,0 +1,42 @@
+from django.db import models
+
+from rest_framework import serializers
+
+from .exceptions import ZaakClosed
+
+
+class ClosedZaakMixin:
+    def perform_create(self, serializer: serializers.ModelSerializer) -> None:
+        """
+        Block the create if the related zaak is closed.
+
+        :raises: PermissionDenied if the related Zaak is closed.
+        """
+        zaak = serializer.validated_data.get("zaak")
+        if zaak and zaak.is_closed:
+            raise ZaakClosed()
+
+        super().perform_create(serializer)
+
+    def perform_update(self, serializer: serializers.ModelSerializer) -> None:
+        """
+        Block the update if the related zaak is closed.
+
+        :raises: PermissionDenied if the related Zaak is closed.
+        """
+        zaak = serializer.instance.zaak
+        if zaak and zaak.is_closed:
+            raise ZaakClosed()
+
+        super().perform_update(serializer)
+
+    def perform_destroy(self, instance: models.Model) -> None:
+        """
+        Block the destroy if the related zaak is closed.
+
+        :raises: PermissionDenied if the related Zaak is closed.
+        """
+        if instance.zaak and instance.zaak.is_closed:
+            raise ZaakClosed()
+
+        super().perform_destroy(instance)

--- a/src/openzaak/components/zaken/api/mixins.py
+++ b/src/openzaak/components/zaken/api/mixins.py
@@ -1,11 +1,48 @@
+from typing import Optional
+
 from django.db import models
 
 from rest_framework import serializers
 
+from openzaak.components.zaken.api.scopes import SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN
+from openzaak.components.zaken.models import Zaak
+
 from .exceptions import ZaakClosed
+from .serializers import ZaakSerializer
 
 
 class ClosedZaakMixin:
+    def _has_override(self, zaak: Zaak) -> bool:
+        jwt_auth = self.request.jwt_auth
+        zaak_data = ZaakSerializer(zaak, context={"request": self.request}).data
+        return jwt_auth.has_auth(
+            scopes=SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
+            zaaktype=zaak_data["zaaktype"],
+            vertrouwelijkheidaanduiding=zaak_data["vertrouwelijkheidaanduiding"],
+            init_component=self.queryset.model._meta.app_label,
+        )
+
+    def _check_zaak_closed(self, zaak: Optional[Zaak] = None) -> None:
+        """
+        Raise ZaakClosed if an attempt is made to modify a closed zaak.
+
+        Unless you have the scope SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN, an application
+        is not allowed to mutate a closed zaak.
+        """
+        # if there is no zaak involved, nothing to do
+        if not zaak:
+            return
+
+        # zaak open -> don't raise exceptions
+        if not zaak.is_closed:
+            return
+
+        # zaak is closed - do we have the special i-can-do-anything permission?
+        if self._has_override(zaak):
+            return
+
+        raise ZaakClosed()
+
     def perform_create(self, serializer: serializers.ModelSerializer) -> None:
         """
         Block the create if the related zaak is closed.
@@ -13,9 +50,7 @@ class ClosedZaakMixin:
         :raises: PermissionDenied if the related Zaak is closed.
         """
         zaak = serializer.validated_data.get("zaak")
-        if zaak and zaak.is_closed:
-            raise ZaakClosed()
-
+        self._check_zaak_closed(zaak)
         super().perform_create(serializer)
 
     def perform_update(self, serializer: serializers.ModelSerializer) -> None:
@@ -25,9 +60,7 @@ class ClosedZaakMixin:
         :raises: PermissionDenied if the related Zaak is closed.
         """
         zaak = serializer.instance.zaak
-        if zaak and zaak.is_closed:
-            raise ZaakClosed()
-
+        self._check_zaak_closed(zaak)
         super().perform_update(serializer)
 
     def perform_destroy(self, instance: models.Model) -> None:
@@ -36,7 +69,6 @@ class ClosedZaakMixin:
 
         :raises: PermissionDenied if the related Zaak is closed.
         """
-        if instance.zaak and instance.zaak.is_closed:
-            raise ZaakClosed()
-
+        zaak = instance.zaak
+        self._check_zaak_closed(zaak)
         super().perform_destroy(instance)

--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -272,7 +272,7 @@ class ZaakViewSet(
             vertrouwelijkheidaanduiding=zaak_data["vertrouwelijkheidaanduiding"],
             init_component=self.queryset.model._meta.app_label,
         ):
-            if zaak.einddatum:
+            if zaak.is_closed:
                 msg = "Modifying a closed case with current scope is forbidden"
                 raise PermissionDenied(detail=msg)
         super().perform_update(serializer)
@@ -380,7 +380,7 @@ class StatusViewSet(
             vertrouwelijkheidaanduiding=zaak_data["vertrouwelijkheidaanduiding"],
             init_component=component,
         ):
-            if zaak.einddatum:
+            if zaak.is_closed:
                 msg = "Reopening a closed case with current scope is forbidden"
                 raise PermissionDenied(detail=msg)
 

--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -55,6 +55,7 @@ from .filters import (
     ZaakObjectFilter,
 )
 from .kanalen import KANAAL_ZAKEN
+from .mixins import ClosedZaakMixin
 from .permissions import ZaakAuthRequired, ZaakNestedAuthRequired
 from .scopes import (
     SCOPE_STATUSSEN_TOEVOEGEN,
@@ -392,6 +393,7 @@ class ZaakObjectViewSet(
     NotificationCreateMixin,
     ListFilterByAuthorizationsMixin,
     AuditTrailCreateMixin,
+    ClosedZaakMixin,
     mixins.CreateModelMixin,
     viewsets.ReadOnlyModelViewSet,
 ):
@@ -436,6 +438,7 @@ class ZaakInformatieObjectViewSet(
     AuditTrailViewsetMixin,
     CheckQueryParamsMixin,
     ListFilterByAuthorizationsMixin,
+    ClosedZaakMixin,
     viewsets.ModelViewSet,
 ):
 
@@ -549,6 +552,7 @@ class ZaakEigenschapViewSet(
     NotificationCreateMixin,
     AuditTrailCreateMixin,
     NestedViewSetMixin,
+    ClosedZaakMixin,
     mixins.CreateModelMixin,
     viewsets.ReadOnlyModelViewSet,
 ):
@@ -599,6 +603,7 @@ class KlantContactViewSet(
     NotificationCreateMixin,
     ListFilterByAuthorizationsMixin,
     AuditTrailCreateMixin,
+    ClosedZaakMixin,
     mixins.CreateModelMixin,
     viewsets.ReadOnlyModelViewSet,
 ):
@@ -646,6 +651,7 @@ class RolViewSet(
     AuditTrailDestroyMixin,
     CheckQueryParamsMixin,
     ListFilterByAuthorizationsMixin,
+    ClosedZaakMixin,
     mixins.CreateModelMixin,
     mixins.DestroyModelMixin,
     viewsets.ReadOnlyModelViewSet,
@@ -708,6 +714,7 @@ class ResultaatViewSet(
     AuditTrailViewsetMixin,
     CheckQueryParamsMixin,
     ListFilterByAuthorizationsMixin,
+    ClosedZaakMixin,
     viewsets.ModelViewSet,
 ):
     """
@@ -796,6 +803,7 @@ class ZaakBesluitViewSet(
     AuditTrailCreateMixin,
     AuditTrailDestroyMixin,
     NestedViewSetMixin,
+    ClosedZaakMixin,
     mixins.CreateModelMixin,
     mixins.DestroyModelMixin,
     viewsets.ReadOnlyModelViewSet,

--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -427,7 +427,9 @@ class ZaakObjectViewSet(
     required_scopes = {
         "list": SCOPE_ZAKEN_ALLES_LEZEN,
         "retrieve": SCOPE_ZAKEN_ALLES_LEZEN,
-        "create": SCOPE_ZAKEN_CREATE | SCOPE_ZAKEN_BIJWERKEN,
+        "create": SCOPE_ZAKEN_CREATE
+        | SCOPE_ZAKEN_BIJWERKEN
+        | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
     }
     notifications_kanaal = KANAAL_ZAKEN
     audit = AUDIT_ZRC
@@ -518,7 +520,9 @@ class ZaakInformatieObjectViewSet(
     required_scopes = {
         "list": SCOPE_ZAKEN_ALLES_LEZEN,
         "retrieve": SCOPE_ZAKEN_ALLES_LEZEN,
-        "create": SCOPE_ZAKEN_CREATE | SCOPE_ZAKEN_BIJWERKEN,
+        "create": SCOPE_ZAKEN_CREATE
+        | SCOPE_ZAKEN_BIJWERKEN
+        | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
         "update": SCOPE_ZAKEN_BIJWERKEN | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
         "partial_update": SCOPE_ZAKEN_BIJWERKEN | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
         "destroy": SCOPE_ZAKEN_BIJWERKEN
@@ -584,8 +588,8 @@ class ZaakEigenschapViewSet(
     required_scopes = {
         "list": SCOPE_ZAKEN_ALLES_LEZEN,
         "retrieve": SCOPE_ZAKEN_ALLES_LEZEN,
-        "create": SCOPE_ZAKEN_BIJWERKEN,
-        "destroy": SCOPE_ZAKEN_BIJWERKEN,
+        "create": SCOPE_ZAKEN_BIJWERKEN | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
+        "destroy": SCOPE_ZAKEN_BIJWERKEN | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
     }
     parent_retrieve_kwargs = {"zaak_uuid": "uuid"}
     notifications_kanaal = KANAAL_ZAKEN
@@ -638,7 +642,7 @@ class KlantContactViewSet(
     required_scopes = {
         "list": SCOPE_ZAKEN_ALLES_LEZEN,
         "retrieve": SCOPE_ZAKEN_ALLES_LEZEN,
-        "create": SCOPE_ZAKEN_BIJWERKEN,
+        "create": SCOPE_ZAKEN_BIJWERKEN | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
     }
     notifications_kanaal = KANAAL_ZAKEN
     audit = AUDIT_ZRC
@@ -702,8 +706,8 @@ class RolViewSet(
     required_scopes = {
         "list": SCOPE_ZAKEN_ALLES_LEZEN,
         "retrieve": SCOPE_ZAKEN_ALLES_LEZEN,
-        "create": SCOPE_ZAKEN_BIJWERKEN,
-        "destroy": SCOPE_ZAKEN_BIJWERKEN,
+        "create": SCOPE_ZAKEN_BIJWERKEN | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
+        "destroy": SCOPE_ZAKEN_BIJWERKEN | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
     }
     notifications_kanaal = KANAAL_ZAKEN
     audit = AUDIT_ZRC
@@ -771,10 +775,10 @@ class ResultaatViewSet(
     required_scopes = {
         "list": SCOPE_ZAKEN_ALLES_LEZEN,
         "retrieve": SCOPE_ZAKEN_ALLES_LEZEN,
-        "create": SCOPE_ZAKEN_BIJWERKEN,
-        "destroy": SCOPE_ZAKEN_BIJWERKEN,
-        "update": SCOPE_ZAKEN_BIJWERKEN,
-        "partial_update": SCOPE_ZAKEN_BIJWERKEN,
+        "create": SCOPE_ZAKEN_BIJWERKEN | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
+        "destroy": SCOPE_ZAKEN_BIJWERKEN | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
+        "update": SCOPE_ZAKEN_BIJWERKEN | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
+        "partial_update": SCOPE_ZAKEN_BIJWERKEN | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
     }
     notifications_kanaal = KANAAL_ZAKEN
     audit = AUDIT_ZRC

--- a/src/openzaak/components/zaken/models/zaken.py
+++ b/src/openzaak/components/zaken/models/zaken.py
@@ -340,6 +340,10 @@ class Zaak(AuditTrailMixin, APIMixin, models.Model):
         status = self.status_set.first()
         return status.uuid if status else None
 
+    @property
+    def is_closed(self) -> bool:
+        return self.einddatum is not None
+
     def unique_representation(self):
         return f"{self.bronorganisatie} - {self.identificatie}"
 

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -364,7 +364,7 @@ paths:
       - klantcontacten
       security:
       - JWT-Claims:
-        - zaken.bijwerken
+        - (zaken.bijwerken | zaken.geforceerd-bijwerken)
     parameters: []
   /klantcontacten/{uuid}:
     get:
@@ -836,7 +836,7 @@ paths:
       - resultaten
       security:
       - JWT-Claims:
-        - zaken.bijwerken
+        - (zaken.bijwerken | zaken.geforceerd-bijwerken)
     parameters: []
   /resultaten/{uuid}:
     get:
@@ -1137,7 +1137,7 @@ paths:
       - resultaten
       security:
       - JWT-Claims:
-        - zaken.bijwerken
+        - (zaken.bijwerken | zaken.geforceerd-bijwerken)
     patch:
       operationId: resultaat_partial_update
       summary: Werk een RESULTAAT deels bij.
@@ -1306,7 +1306,7 @@ paths:
       - resultaten
       security:
       - JWT-Claims:
-        - zaken.bijwerken
+        - (zaken.bijwerken | zaken.geforceerd-bijwerken)
     delete:
       operationId: resultaat_delete
       summary: Verwijder een RESULTAAT van een ZAAK.
@@ -1453,7 +1453,7 @@ paths:
       - resultaten
       security:
       - JWT-Claims:
-        - zaken.bijwerken
+        - (zaken.bijwerken | zaken.geforceerd-bijwerken)
     parameters:
     - name: uuid
       in: path
@@ -1886,7 +1886,7 @@ paths:
       - rollen
       security:
       - JWT-Claims:
-        - zaken.bijwerken
+        - (zaken.bijwerken | zaken.geforceerd-bijwerken)
     parameters: []
   /rollen/{uuid}:
     get:
@@ -2023,6 +2023,27 @@ paths:
       operationId: rol_delete
       summary: Verwijder een ROL van een ZAAK.
       description: Verwijder een ROL van een ZAAK.
+      parameters:
+      - name: X-NLX-Request-Application-Id
+        in: header
+        description: Identificatie van de applicatie die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-NLX-Request-User-Id
+        in: header
+        description: Identificatie van de gebruiker die het verzoek stuurt (indien
+          NLX wordt gebruikt).
+        required: false
+        schema:
+          type: string
+      - name: X-Audit-Toelichting
+        in: header
+        description: Toelichting waarom een bepaald verzoek wordt gedaan
+        required: false
+        schema:
+          type: string
       responses:
         '204':
           description: No content
@@ -2144,7 +2165,7 @@ paths:
       - rollen
       security:
       - JWT-Claims:
-        - zaken.bijwerken
+        - (zaken.bijwerken | zaken.geforceerd-bijwerken)
     parameters:
     - name: uuid
       in: path
@@ -2943,7 +2964,7 @@ paths:
       - zaakinformatieobjecten
       security:
       - JWT-Claims:
-        - (zaken.aanmaken | zaken.bijwerken)
+        - (zaken.aanmaken | zaken.bijwerken | zaken.geforceerd-bijwerken)
     parameters: []
   /zaakinformatieobjecten/{uuid}:
     get:
@@ -3948,7 +3969,7 @@ paths:
       - zaakobjecten
       security:
       - JWT-Claims:
-        - (zaken.aanmaken | zaken.bijwerken)
+        - (zaken.aanmaken | zaken.bijwerken | zaken.geforceerd-bijwerken)
     parameters: []
   /zaakobjecten/{uuid}:
     get:
@@ -6751,7 +6772,7 @@ paths:
       - zaken
       security:
       - JWT-Claims:
-        - zaken.bijwerken
+        - (zaken.bijwerken | zaken.geforceerd-bijwerken)
     parameters:
     - name: zaak_uuid
       in: path
@@ -6930,9 +6951,9 @@ components:
       required: true
   securitySchemes:
     JWT-Claims:
-      bearerFormat: JWT
-      scheme: bearer
       type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     KlantContact:
       required:
@@ -7812,7 +7833,7 @@ components:
           description: Beschrijft het type OBJECT als `objectType` de waarde "overige"
             heeft.
           type: string
-          pattern: '[a-z\_]+'
+          pattern: '[a-z_]+'
           maxLength: 100
         relatieomschrijving:
           title: Relatieomschrijving
@@ -9625,8 +9646,7 @@ components:
           readOnly: true
         besluit:
           title: Besluit
-          description: URL-referentie naar het BESLUIT (in de Besluiten API), waar
-            ook de relatieinformatie opgevraagd kan worden.
+          description: URL-referentie naar het BESLUIT (in de Besluiten API).
           type: string
           format: uri
           maxLength: 1000

--- a/src/openzaak/components/zaken/resources.md
+++ b/src/openzaak/components/zaken/resources.md
@@ -284,7 +284,7 @@ Objecttype op [GEMMA Online](https://www.gemmaonline.nl/index.php/Rgbz_1.0/doc/o
 | --- | --- | --- | --- | --- |
 | url |  | string | nee | ~~C~~​R​~~U~~​~~D~~ |
 | uuid | Unieke resource identifier (UUID4) | string | nee | ~~C~~​R​~~U~~​~~D~~ |
-| besluit | URL-referentie naar het BESLUIT (in de Besluiten API), waar ook de relatieinformatie opgevraagd kan worden. | string | ja | C​R​U​D |
+| besluit | URL-referentie naar het BESLUIT (in de Besluiten API). | string | ja | C​R​U​D |
 
 ## ZaakEigenschap
 

--- a/src/openzaak/components/zaken/swagger2.0.json
+++ b/src/openzaak/components/zaken/swagger2.0.json
@@ -22,9 +22,9 @@
     ],
     "securityDefinitions": {
         "JWT-Claims": {
-            "bearerFormat": "JWT",
+            "type": "http",
             "scheme": "bearer",
-            "type": "http"
+            "bearerFormat": "JWT"
         }
     },
     "security": [
@@ -423,7 +423,7 @@
                 "security": [
                     {
                         "JWT-Claims": [
-                            "zaken.bijwerken"
+                            "(zaken.bijwerken | zaken.geforceerd-bijwerken)"
                         ]
                     }
                 ]
@@ -998,7 +998,7 @@
                 "security": [
                     {
                         "JWT-Claims": [
-                            "zaken.bijwerken"
+                            "(zaken.bijwerken | zaken.geforceerd-bijwerken)"
                         ]
                     }
                 ]
@@ -1361,7 +1361,7 @@
                 "security": [
                     {
                         "JWT-Claims": [
-                            "zaken.bijwerken"
+                            "(zaken.bijwerken | zaken.geforceerd-bijwerken)"
                         ]
                     }
                 ]
@@ -1563,7 +1563,7 @@
                 "security": [
                     {
                         "JWT-Claims": [
-                            "zaken.bijwerken"
+                            "(zaken.bijwerken | zaken.geforceerd-bijwerken)"
                         ]
                     }
                 ]
@@ -1740,7 +1740,7 @@
                 "security": [
                     {
                         "JWT-Claims": [
-                            "zaken.bijwerken"
+                            "(zaken.bijwerken | zaken.geforceerd-bijwerken)"
                         ]
                     }
                 ]
@@ -2256,7 +2256,7 @@
                 "security": [
                     {
                         "JWT-Claims": [
-                            "zaken.bijwerken"
+                            "(zaken.bijwerken | zaken.geforceerd-bijwerken)"
                         ]
                     }
                 ]
@@ -2426,7 +2426,29 @@
                 "operationId": "rol_delete",
                 "summary": "Verwijder een ROL van een ZAAK.",
                 "description": "Verwijder een ROL van een ZAAK.",
-                "parameters": [],
+                "parameters": [
+                    {
+                        "name": "X-NLX-Request-Application-Id",
+                        "in": "header",
+                        "description": "Identificatie van de applicatie die het verzoek stuurt (indien NLX wordt gebruikt).",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "X-NLX-Request-User-Id",
+                        "in": "header",
+                        "description": "Identificatie van de gebruiker die het verzoek stuurt (indien NLX wordt gebruikt).",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "X-Audit-Toelichting",
+                        "in": "header",
+                        "description": "Toelichting waarom een bepaald verzoek wordt gedaan",
+                        "required": false,
+                        "type": "string"
+                    }
+                ],
                 "responses": {
                     "204": {
                         "description": "No content",
@@ -2572,7 +2594,7 @@
                 "security": [
                     {
                         "JWT-Claims": [
-                            "zaken.bijwerken"
+                            "(zaken.bijwerken | zaken.geforceerd-bijwerken)"
                         ]
                     }
                 ]
@@ -3532,7 +3554,7 @@
                 "security": [
                     {
                         "JWT-Claims": [
-                            "(zaken.aanmaken | zaken.bijwerken)"
+                            "(zaken.aanmaken | zaken.bijwerken | zaken.geforceerd-bijwerken)"
                         ]
                     }
                 ]
@@ -4728,7 +4750,7 @@
                 "security": [
                     {
                         "JWT-Claims": [
-                            "(zaken.aanmaken | zaken.bijwerken)"
+                            "(zaken.aanmaken | zaken.bijwerken | zaken.geforceerd-bijwerken)"
                         ]
                     }
                 ]
@@ -8008,7 +8030,7 @@
                 "security": [
                     {
                         "JWT-Claims": [
-                            "zaken.bijwerken"
+                            "(zaken.bijwerken | zaken.geforceerd-bijwerken)"
                         ]
                     }
                 ]
@@ -9131,7 +9153,7 @@
                     "title": "Object type overige",
                     "description": "Beschrijft het type OBJECT als `objectType` de waarde \"overige\" heeft.",
                     "type": "string",
-                    "pattern": "[a-z\\_]+",
+                    "pattern": "[a-z_]+",
                     "maxLength": 100
                 },
                 "relatieomschrijving": {
@@ -11321,7 +11343,7 @@
                 },
                 "besluit": {
                     "title": "Besluit",
-                    "description": "URL-referentie naar het BESLUIT (in de Besluiten API), waar ook de relatieinformatie opgevraagd kan worden.",
+                    "description": "URL-referentie naar het BESLUIT (in de Besluiten API).",
                     "type": "string",
                     "format": "uri",
                     "maxLength": 1000,

--- a/src/openzaak/components/zaken/tests/factories.py
+++ b/src/openzaak/components/zaken/tests/factories.py
@@ -68,7 +68,9 @@ class ZaakInformatieObjectFactory(factory.django.DjangoModelFactory):
 
 class ZaakEigenschapFactory(factory.django.DjangoModelFactory):
     zaak = factory.SubFactory(ZaakFactory)
-    eigenschap = factory.SubFactory(EigenschapFactory)
+    eigenschap = factory.SubFactory(
+        EigenschapFactory, zaaktype=factory.SelfAttribute("..zaak.zaaktype")
+    )
     _naam = factory.Faker("word")
     waarde = factory.Faker("word")
 
@@ -116,7 +118,9 @@ class StatusFactory(factory.django.DjangoModelFactory):
 
 class ResultaatFactory(factory.django.DjangoModelFactory):
     zaak = factory.SubFactory(ZaakFactory)
-    resultaattype = factory.SubFactory(ResultaatTypeFactory)
+    resultaattype = factory.SubFactory(
+        ResultaatTypeFactory, zaaktype=factory.SelfAttribute("..zaak.zaaktype"),
+    )
 
     class Meta:
         model = "zaken.Resultaat"

--- a/src/openzaak/components/zaken/tests/factories.py
+++ b/src/openzaak/components/zaken/tests/factories.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from django.utils import timezone
 
 import factory
@@ -35,6 +37,16 @@ class ZaakFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = "zaken.Zaak"
+
+    class Params:
+        closed = factory.Trait(
+            einddatum=factory.LazyFunction(date.today),
+            status_set=factory.RelatedFactory(
+                "openzaak.components.zaken.tests.factories.StatusFactory",
+                factory_related_name="zaak",
+                statustype__zaaktype=factory.SelfAttribute("..zaak.zaaktype"),
+            ),
+        )
 
 
 class RelevanteZaakRelatieFactory(factory.django.DjangoModelFactory):

--- a/src/openzaak/components/zaken/tests/test_amsterdam_overlast_water.py
+++ b/src/openzaak/components/zaken/tests/test_amsterdam_overlast_water.py
@@ -54,9 +54,9 @@ class Application:
     def store_notification(self):
         # registreer zaak & zet statussen, resultaat
         self.registreer_zaak()
-        self.zet_statussen_resultaat()
         self.registreer_domein_data()
         self.registreer_klantcontact()
+        self.zet_statussen_resultaat()
 
     def registreer_zaak(self):
         zaaktype = ZaakTypeFactory.create(concept=False)

--- a/src/openzaak/components/zaken/tests/test_notifications_send.py
+++ b/src/openzaak/components/zaken/tests/test_notifications_send.py
@@ -262,11 +262,7 @@ class FailedNotificationTests(JWTAuthMixin, APITestCase):
 
     def test_zaakobject_create_fail_send_notification_create_db_entry(self):
         url = get_operation_url("zaakobject_create")
-        zaak = ZaakFactory.create(
-            einddatum=now(),
-            archiefactiedatum="2020-01-01",
-            archiefnominatie=Archiefnominatie.blijvend_bewaren,
-        )
+        zaak = ZaakFactory.create()
         zaak_url = reverse(zaak)
         data = {
             "zaak": zaak_url,

--- a/src/openzaak/components/zaken/tests/test_zaak_archive.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_archive.py
@@ -256,7 +256,7 @@ class US345TestCase(JWTAuthMixin, APITestCase):
         """
         Add RESULTAAT that causes `archiefactiedatum` to be set.
         """
-        zaak = ZaakFactory.create(einddatum=date(2019, 1, 1))
+        zaak = ZaakFactory.create()
         zaak_url = get_operation_url("zaak_read", uuid=zaak.uuid)
         resultaattype = ResultaatTypeFactory.create(
             archiefactietermijn="P10Y",

--- a/src/openzaak/components/zaken/tests/test_zaak_closed.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_closed.py
@@ -1,5 +1,6 @@
 import datetime
 
+from django.test import tag
 from django.utils import timezone
 
 from rest_framework import status
@@ -50,7 +51,7 @@ class ZaakClosedTests(JWTAuthMixin, APITestCase):
         self.assertEqual(zaak.betalingsindicatie, BetalingsIndicatie.nvt)
 
     def test_update_zaak_closed_not_allowed(self):
-        zaak = ZaakFactory.create(einddatum=timezone.now(), zaaktype=self.zaaktype)
+        zaak = ZaakFactory.create(zaaktype=self.zaaktype, closed=True)
         url = reverse(zaak)
 
         response = self.client.patch(
@@ -60,7 +61,7 @@ class ZaakClosedTests(JWTAuthMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_update_zaak_closed_allowed(self):
-        zaak = ZaakFactory.create(einddatum=timezone.now(), zaaktype=self.zaaktype)
+        zaak = ZaakFactory.create(zaaktype=self.zaaktype, closed=True)
         url = reverse(zaak)
 
         self.autorisatie.scopes = [SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN]
@@ -124,3 +125,32 @@ class ZaakClosedTests(JWTAuthMixin, APITestCase):
         self.assertEqual(
             data["detail"], "Reopening a closed case with current scope is forbidden"
         )
+
+
+@tag("closed-zaak")
+class ClosedZaakRelatedDataNotAllowedTests(JWTAuthMixin, APITestCase):
+    """
+    Test that updating/adding related data of a Zaak is not allowed when the Zaak is
+    closed.
+    """
+
+    scopes = [SCOPE_ZAKEN_BIJWERKEN]
+    component = ComponentTypes.zrc
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.zaaktype = ZaakTypeFactory.create()
+        cls.zaak = ZaakFactory.create(zaaktype=cls.zaaktype, closed=True)
+        super().setUpTestData()
+
+    def test_zaakinformatieobjecten_create(self):
+        pass
+
+    def test_zaakinformatieobjecten_update(self):
+        pass
+
+    def test_zaakinformatieobjecten_partial_update(self):
+        pass
+
+    def test_zaakinformatieobjecten_destroy(self):
+        pass

--- a/src/openzaak/components/zaken/tests/test_zaak_closed.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_closed.py
@@ -3,25 +3,54 @@ import datetime
 from django.test import tag
 from django.utils import timezone
 
+import requests_mock
 from rest_framework import status
 from rest_framework.test import APITestCase
+from vng_api_common.authorizations.models import Autorisatie
 from vng_api_common.constants import Archiefnominatie, ComponentTypes
 from vng_api_common.tests import reverse
 
+from openzaak.components.besluiten.api.scopes import (
+    SCOPE_BESLUITEN_AANMAKEN,
+    SCOPE_BESLUITEN_ALLES_LEZEN,
+    SCOPE_BESLUITEN_ALLES_VERWIJDEREN,
+)
+from openzaak.components.besluiten.models import Besluit
+from openzaak.components.besluiten.tests.factories import BesluitFactory
 from openzaak.components.catalogi.tests.factories import (
+    BesluitTypeFactory,
+    RolTypeFactory,
     StatusTypeFactory,
     ZaakTypeFactory,
+)
+from openzaak.components.documenten.tests.factories import (
+    EnkelvoudigInformatieObjectFactory,
 )
 from openzaak.utils.tests import JWTAuthMixin
 
 from ..api.scopes import (
     SCOPE_STATUSSEN_TOEVOEGEN,
+    SCOPE_ZAKEN_ALLES_LEZEN,
     SCOPE_ZAKEN_BIJWERKEN,
     SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
     SCOPEN_ZAKEN_HEROPENEN,
 )
 from ..constants import BetalingsIndicatie
-from .factories import ZaakFactory
+from ..models import (
+    KlantContact,
+    Resultaat,
+    Rol,
+    ZaakEigenschap,
+    ZaakInformatieObject,
+    ZaakObject,
+)
+from .factories import (
+    ResultaatFactory,
+    RolFactory,
+    ZaakEigenschapFactory,
+    ZaakFactory,
+    ZaakInformatieObjectFactory,
+)
 from .utils import ZAAK_WRITE_KWARGS, get_operation_url
 
 
@@ -134,7 +163,7 @@ class ClosedZaakRelatedDataNotAllowedTests(JWTAuthMixin, APITestCase):
     closed.
     """
 
-    scopes = [SCOPE_ZAKEN_BIJWERKEN]
+    scopes = [SCOPE_ZAKEN_ALLES_LEZEN, SCOPE_ZAKEN_BIJWERKEN]
     component = ComponentTypes.zrc
 
     @classmethod
@@ -143,14 +172,163 @@ class ClosedZaakRelatedDataNotAllowedTests(JWTAuthMixin, APITestCase):
         cls.zaak = ZaakFactory.create(zaaktype=cls.zaaktype, closed=True)
         super().setUpTestData()
 
-    def test_zaakinformatieobjecten_create(self):
-        pass
+    def setUp(self):
+        super().setUp()
 
-    def test_zaakinformatieobjecten_update(self):
-        pass
+        m = requests_mock.Mocker()
+        m.start()
+        self.addCleanup(m.stop)
 
-    def test_zaakinformatieobjecten_partial_update(self):
-        pass
+    def assertCreateBlocked(self, url: str, data: dict):
+        with self.subTest(action="create"):
+            response = self.client.post(url, data)
 
-    def test_zaakinformatieobjecten_destroy(self):
-        pass
+            self.assertEqual(
+                response.status_code, status.HTTP_403_FORBIDDEN, response.data
+            )
+
+    def assertUpdateBlocked(self, url: str):
+        with self.subTest(action="update"):
+            detail = self.client.get(url).data
+
+            response = self.client.put(url, detail)
+
+            self.assertEqual(
+                response.status_code, status.HTTP_403_FORBIDDEN, response.data
+            )
+
+    def assertPartialUpdateBlocked(self, url: str):
+        with self.subTest(action="partial_update"):
+            response = self.client.patch(url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.data)
+
+    def assertDestroyBlocked(self, url: str):
+        with self.subTest(action="destroy"):
+            response = self.client.delete(url)
+
+            self.assertEqual(
+                response.status_code, status.HTTP_403_FORBIDDEN, response.data
+            )
+
+    def test_zaakinformatieobjecten(self):
+        io = EnkelvoudigInformatieObjectFactory.create(
+            informatieobjecttype__zaaktypen__zaaktype=self.zaaktype,
+            informatieobjecttype__catalogus=self.zaaktype.catalogus,
+        )
+        io_url = reverse(io)
+        zio = ZaakInformatieObjectFactory(
+            zaak=self.zaak,
+            informatieobject__latest_version__informatieobjecttype__zaaktypen__zaaktype=self.zaaktype,
+            informatieobject__latest_version__informatieobjecttype__catalogus=self.zaaktype.catalogus,
+        )
+        zio_url = reverse(zio)
+
+        self.assertCreateBlocked(
+            reverse(ZaakInformatieObject),
+            {
+                "zaak": reverse(self.zaak),
+                "informatieobject": f"http://testserver{io_url}",
+            },
+        )
+        self.assertUpdateBlocked(zio_url)
+        self.assertPartialUpdateBlocked(zio_url)
+        self.assertDestroyBlocked(zio_url)
+
+    def test_zaakobjecten(self):
+        self.assertCreateBlocked(
+            reverse(ZaakObject),
+            {
+                "zaak": reverse(self.zaak),
+                "object": "https://example.com/",
+                "objectType": "overige",
+                "objectTypeOverige": "website",
+            },
+        )
+
+    def test_zaakeigenschappen(self):
+        zaak_eigenschap = ZaakEigenschapFactory.create(zaak=self.zaak)
+        eigenschap_url = reverse(zaak_eigenschap.eigenschap)
+
+        self.assertCreateBlocked(
+            reverse(ZaakEigenschap, kwargs={"zaak_uuid": self.zaak.uuid}),
+            {
+                "zaak": reverse(self.zaak),
+                "eigenschap": f"http://testserver{eigenschap_url}",
+                "waarde": "123",
+            },
+        )
+
+    def test_klantcontacten(self):
+        url = reverse(KlantContact)
+        data = {
+            "zaak": reverse(self.zaak),
+            "datumtijd": "2020-01-30T15:08:00Z",
+        }
+
+        self.assertCreateBlocked(url, data)
+
+    def test_rollen(self):
+        roltype = RolTypeFactory.create(zaaktype=self.zaaktype)
+        rol = RolFactory.create(zaak=self.zaak, roltype=roltype)
+        rol_url = reverse(rol)
+
+        create_url = reverse(Rol)
+        data = {
+            "zaak": reverse(self.zaak),
+            "roltype": f"http://testserver{reverse(roltype)}",
+            "betrokkeneType": "vestiging",
+            "betrokkene": "https://example.com",
+            "roltoelichting": "foo",
+        }
+
+        self.assertCreateBlocked(create_url, data)
+        self.assertDestroyBlocked(rol_url)
+
+    def test_resultaten(self):
+        resultaat = ResultaatFactory.create(zaak=self.zaak)
+        resultaat_url = reverse(resultaat)
+
+        self.assertUpdateBlocked(resultaat_url)
+        self.assertPartialUpdateBlocked(resultaat_url)
+        self.assertDestroyBlocked(resultaat_url)
+
+        resultaat.delete()
+
+        data = {
+            "zaak": reverse(self.zaak),
+            "resultaattype": f"http://testserver{reverse(resultaat.resultaattype)}",
+        }
+        self.assertCreateBlocked(reverse(Resultaat), data)
+
+    def test_zaakbesluiten(self):
+        besluittype = BesluitTypeFactory.create(
+            zaaktypen=[self.zaaktype], concept=False
+        )
+        besluittype_url = f"http://testserver{reverse(besluittype)}"
+        Autorisatie.objects.create(
+            applicatie=self.applicatie,
+            component=ComponentTypes.brc,
+            scopes=[
+                SCOPE_BESLUITEN_AANMAKEN,
+                SCOPE_BESLUITEN_ALLES_LEZEN,
+                SCOPE_BESLUITEN_ALLES_VERWIJDEREN,
+            ],
+            besluittype=besluittype_url,
+        )
+
+        self.assertCreateBlocked(
+            reverse(Besluit),
+            {
+                "besluittype": besluittype_url,
+                "zaak": f"http://testserver{reverse(self.zaak)}",
+                "verantwoordelijke_organisatie": "517439943",  # RSIN
+                "identificatie": "123123",
+                "datum": "2018-09-06",
+                "toelichting": "Vergunning verleend.",
+                "ingangsdatum": "2018-10-01",
+            },
+        )
+
+        besluit = BesluitFactory.create(zaak=self.zaak, besluittype=besluittype)
+        self.assertDestroyBlocked(reverse(besluit))

--- a/src/openzaak/components/zaken/tests/test_zaak_closed.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_closed.py
@@ -179,6 +179,7 @@ class ClosedZaakRelatedDataNotAllowedTests(JWTAuthMixin, APITestCase):
 
         m = requests_mock.Mocker()
         m.start()
+        m.get("https://example.com", status_code=200)
         self.addCleanup(m.stop)
 
     def assertCreateBlocked(self, url: str, data: dict):
@@ -242,7 +243,7 @@ class ClosedZaakRelatedDataNotAllowedTests(JWTAuthMixin, APITestCase):
             reverse(ZaakObject),
             {
                 "zaak": reverse(self.zaak),
-                "object": "https://example.com/",
+                "object": "https://example.com",
                 "objectType": "overige",
                 "objectTypeOverige": "website",
             },


### PR DESCRIPTION
Changing of Zaak data is not allowed if the Zaak is closed. This extends to related objects:

- [x] ZaakInformatieObject
- [x] ZaakObject
- [x] Resultaat
- [x] KlantContact
- [x] Status (special exception scope)
- [x] ZaakEigenschap
- [x] Rol
- [x] ZaakBesluit

However, the updates are allowed if you have the scope `zaken.geforceerd-bijwerken`.

- [x] ZaakInformatieObject
- [x] ZaakObject
- [x] Resultaat
- [x] KlantContact
- [x] Status (special exception scope)
- [x] ZaakEigenschap
- [x] Rol
