### PR TITLE
Provide individual API versions for each API

### DIFF
--- a/src/openzaak/components/autorisaties/api/schema.py
+++ b/src/openzaak/components/autorisaties/api/schema.py
@@ -37,7 +37,7 @@ Deze API is afhankelijk van:
 
 info = openapi.Info(
     title=f"Autorisaties API",
-    default_version=settings.API_VERSION,
+    default_version=settings.AUTORISATIES_API_VERSION,
     description=description,
     contact=openapi.Contact(
         email=settings.OPENZAAK_API_CONTACT_EMAIL, url=settings.OPENZAAK_API_CONTACT_URL

--- a/src/openzaak/components/besluiten/api/schema.py
+++ b/src/openzaak/components/besluiten/api/schema.py
@@ -44,7 +44,7 @@ Deze API is afhankelijk van:
 
 info = openapi.Info(
     title=f"Besluiten API",
-    default_version=settings.API_VERSION,
+    default_version=settings.BESLUITEN_API_VERSION,
     description=description,
     contact=openapi.Contact(
         email=settings.OPENZAAK_API_CONTACT_EMAIL, url=settings.OPENZAAK_API_CONTACT_URL

--- a/src/openzaak/components/besluiten/openapi.yaml
+++ b/src/openzaak/components/besluiten/openapi.yaml
@@ -38,7 +38,7 @@ info:
   license:
     name: EUPL 1.2
     url: https://opensource.org/licenses/EUPL-1.2
-  version: 1.0.0
+  version: 1.0.1
 security:
 - JWT-Claims: []
 paths:
@@ -1942,9 +1942,9 @@ components:
       required: true
   securitySchemes:
     JWT-Claims:
-      bearerFormat: JWT
-      scheme: bearer
       type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     Besluit:
       required:

--- a/src/openzaak/components/besluiten/swagger2.0.json
+++ b/src/openzaak/components/besluiten/swagger2.0.json
@@ -11,7 +11,7 @@
             "name": "EUPL 1.2",
             "url": "https://opensource.org/licenses/EUPL-1.2"
         },
-        "version": "1.0.0"
+        "version": "1.0.1"
     },
     "basePath": "/besluiten/api/v1",
     "consumes": [
@@ -22,9 +22,9 @@
     ],
     "securityDefinitions": {
         "JWT-Claims": {
-            "bearerFormat": "JWT",
+            "type": "http",
             "scheme": "bearer",
-            "type": "http"
+            "bearerFormat": "JWT"
         }
     },
     "security": [

--- a/src/openzaak/components/catalogi/api/schema.py
+++ b/src/openzaak/components/catalogi/api/schema.py
@@ -44,7 +44,7 @@ Deze API is afhankelijk van:
 
 info = openapi.Info(
     title=f"Catalogi API",
-    default_version=settings.API_VERSION,
+    default_version=settings.CATALOGI_API_VERSION,
     description=description,
     contact=openapi.Contact(
         email=settings.OPENZAAK_API_CONTACT_EMAIL, url=settings.OPENZAAK_API_CONTACT_URL

--- a/src/openzaak/components/documenten/api/schema.py
+++ b/src/openzaak/components/documenten/api/schema.py
@@ -63,7 +63,7 @@ Deze API is afhankelijk van:
 
 info = openapi.Info(
     title="Documenten API",
-    default_version=settings.API_VERSION,
+    default_version=settings.DOCUMENTEN_API_VERSION,
     description=description,
     contact=openapi.Contact(
         email=settings.OPENZAAK_API_CONTACT_EMAIL, url=settings.OPENZAAK_API_CONTACT_URL

--- a/src/openzaak/components/documenten/openapi.yaml
+++ b/src/openzaak/components/documenten/openapi.yaml
@@ -45,7 +45,7 @@ info:
   license:
     name: EUPL 1.2
     url: https://opensource.org/licenses/EUPL-1.2
-  version: 1.0.0
+  version: 1.0.1
 security:
 - JWT-Claims: []
 paths:
@@ -2791,6 +2791,7 @@ paths:
         required: false
         schema:
           type: string
+          format: uri
       - name: informatieobject
         in: query
         description: URL-referentie naar het INFORMATIEOBJECT.
@@ -4448,7 +4449,7 @@ components:
           type: string
           format: date-time
         einddatum:
-          title: Startdatum
+          title: Einddatum
           description: Einddatum van de periode waarin de gebruiksrechtvoorwaarden
             van toepassing zijn.
           type: string

--- a/src/openzaak/components/documenten/swagger2.0.json
+++ b/src/openzaak/components/documenten/swagger2.0.json
@@ -11,7 +11,7 @@
             "name": "EUPL 1.2",
             "url": "https://opensource.org/licenses/EUPL-1.2"
         },
-        "version": "1.0.0"
+        "version": "1.0.1"
     },
     "basePath": "/documenten/api/v1",
     "consumes": [
@@ -3291,7 +3291,8 @@
                         "in": "query",
                         "description": "URL-referentie naar het gerelateerde OBJECT (in deze of een andere API).",
                         "required": false,
-                        "type": "string"
+                        "type": "string",
+                        "format": "uri"
                     },
                     {
                         "name": "informatieobject",
@@ -4900,7 +4901,7 @@
                     "format": "date-time"
                 },
                 "einddatum": {
-                    "title": "Startdatum",
+                    "title": "Einddatum",
                     "description": "Einddatum van de periode waarin de gebruiksrechtvoorwaarden van toepassing zijn.",
                     "type": "string",
                     "format": "date-time",

--- a/src/openzaak/components/zaken/api/schema.py
+++ b/src/openzaak/components/zaken/api/schema.py
@@ -37,7 +37,7 @@ Deze API is afhankelijk van:
 
 info = openapi.Info(
     title=f"Zaken API",
-    default_version=settings.API_VERSION,
+    default_version=settings.ZAKEN_API_VERSION,
     description=description,
     contact=openapi.Contact(
         email=settings.OPENZAAK_API_CONTACT_EMAIL, url=settings.OPENZAAK_API_CONTACT_URL

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -34,7 +34,7 @@ info:
   license:
     name: EUPL 1.2
     url: https://opensource.org/licenses/EUPL-1.2
-  version: 1.0.0
+  version: 1.0.1
 security:
 - JWT-Claims: []
 paths:

--- a/src/openzaak/components/zaken/swagger2.0.json
+++ b/src/openzaak/components/zaken/swagger2.0.json
@@ -11,7 +11,7 @@
             "name": "EUPL 1.2",
             "url": "https://opensource.org/licenses/EUPL-1.2"
         },
-        "version": "1.0.0"
+        "version": "1.0.1"
     },
     "basePath": "/zaken/api/v1",
     "consumes": [

--- a/src/openzaak/components/zaken/tests/test_auth.py
+++ b/src/openzaak/components/zaken/tests/test_auth.py
@@ -828,11 +828,13 @@ class ExternalZaaktypeScopeTests(JWTAuthMixin, APITestCase):
         resultaat = ResultaatFactory.create(
             zaak__zaaktype=self.zaaktype,
             zaak__vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.openbaar,
+            resultaattype="https://externe.catalogus.nl/api/v1/resultaattypen/1",
         )
         # must not show up
         ResultaatFactory.create(
             zaak__zaaktype="https://externe.catalogus.nl/api/v1/zaaktypen/1",
             zaak__vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.openbaar,
+            resultaattype="https://externe.catalogus.nl/api/v1/resultaattypen/2",
         )
 
         response = self.client.get(url)
@@ -848,10 +850,12 @@ class ExternalZaaktypeScopeTests(JWTAuthMixin, APITestCase):
         resultaat1 = ResultaatFactory.create(
             zaak__zaaktype=self.zaaktype,
             zaak__vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.openbaar,
+            resultaattype="https://externe.catalogus.nl/api/v1/resultaattypen/1",
         )
         resultaat2 = ResultaatFactory.create(
             zaak__zaaktype="https://externe.catalogus.nl/api/v1/zaaktypen/1",
             zaak__vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.openbaar,
+            resultaattype="https://externe.catalogus.nl/api/v1/resultaattypen/2",
         )
         url1 = reverse(resultaat1)
         url2 = reverse(resultaat2)

--- a/src/openzaak/conf/includes/api.py
+++ b/src/openzaak/conf/includes/api.py
@@ -1,6 +1,13 @@
 from vng_api_common.conf.api import *  # noqa - imports white-listed
 
-API_VERSION = "1.0.0"
+# Remove the reference - we don't have a single API version.
+del API_VERSION  # noqa
+
+AUTORISATIES_API_VERSION = "1.0.0"
+BESLUITEN_API_VERSION = "1.0.1"
+CATALOGI_API_VERSION = "1.0.0"
+DOCUMENTEN_API_VERSION = "1.0.1"
+ZAKEN_API_VERSION = "1.0.1"
 
 REST_FRAMEWORK = BASE_REST_FRAMEWORK.copy()
 REST_FRAMEWORK["PAGE_SIZE"] = 100

--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -143,7 +143,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "corsheaders.middleware.CorsMiddleware",
-    "vng_api_common.middleware.APIVersionHeaderMiddleware",
+    "openzaak.utils.middleware.APIVersionHeaderMiddleware",
 ]
 
 ROOT_URLCONF = "openzaak.urls"

--- a/src/openzaak/management/commands/generate_swagger_component.py
+++ b/src/openzaak/management/commands/generate_swagger_component.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 from vng_api_common.management.commands import generate_swagger
 
 SCHEMA_MAPPING = {
@@ -30,8 +32,12 @@ class Command(generate_swagger.Command):
         urlconf,
         component=None,
         *args,
-        **options
+        **options,
     ):
+        _version = getattr(settings, f"{component.upper()}_API_VERSION")
+
+        # Setting must exist for vng-api-common, so monkeypatch it in
+        settings.API_VERSION = _version
 
         if not component:
             super().handle(
@@ -45,7 +51,7 @@ class Command(generate_swagger.Command):
                 info,
                 urlconf,
                 *args,
-                **options
+                **options,
             )
 
         # rewrite command arguments based on the component
@@ -64,5 +70,5 @@ class Command(generate_swagger.Command):
             info,
             urlconf,
             *args,
-            **options
+            **options,
         )

--- a/src/openzaak/tests/api_strategy/test_api_versioning.py
+++ b/src/openzaak/tests/api_strategy/test_api_versioning.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import override_settings
 
 import yaml
@@ -36,10 +38,9 @@ class APIVersioningTests(APITestCase):
                 doc = yaml.safe_load(response.content)
                 self.assertGreaterEqual(doc["openapi"], "3.0.0")
 
-    @override_settings(
-        ROOT_URLCONF="openzaak.tests.api_strategy.urls", API_VERSION="1.0.0"
-    )
-    def test_api_24_version_header(self):
+    @patch("openzaak.utils.middleware.get_version_mapping", return_value={"/": "1.0.0"})
+    @override_settings(ROOT_URLCONF="openzaak.tests.api_strategy.urls")
+    def test_api_24_version_header(self, m):
         response = self.client.get("/test-view")
 
         self.assertEqual(response["API-version"], "1.0.0")

--- a/src/openzaak/utils/middleware.py
+++ b/src/openzaak/utils/middleware.py
@@ -1,6 +1,15 @@
 import logging
+from typing import Dict, Optional
 
+from django.conf import settings
 from django.http import HttpRequest
+
+from rest_framework.response import Response
+from rest_framework.reverse import reverse
+from vng_api_common.middleware import (
+    VERSION_HEADER,
+    APIVersionHeaderMiddleware as _APIVersionHeaderMiddleware,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -15,3 +24,45 @@ class LogHeadersMiddleware:
 
     def log(self, request: HttpRequest):
         logger.debug("Request headers for %s: %r", request.path, request.headers)
+
+
+def get_version_mapping() -> Dict[str, str]:
+    apis = ("autorisaties", "besluiten", "catalogi", "documenten", "zaken")
+    version = settings.REST_FRAMEWORK["DEFAULT_VERSION"]
+
+    return {
+        reverse(f"api-root-{api}", kwargs={"version": version}): getattr(
+            settings, f"{api.upper()}_API_VERSION"
+        )
+        for api in apis
+    }
+
+
+class APIVersionHeaderMiddleware(_APIVersionHeaderMiddleware):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.version_mapping = get_version_mapping()
+
+    def __call__(self, request):
+        if self.get_response is None:
+            return None
+
+        response = self.get_response(request)
+
+        # not an API response, exit early
+        if not isinstance(response, Response):
+            return response
+
+        # set the header
+        version = self._get_version(request.path)
+        if version is not None:
+            response[VERSION_HEADER] = version
+
+        return response
+
+    def _get_version(self, path: str) -> Optional[str]:
+        for prefix, version in self.version_mapping.items():
+            if path.startswith(prefix):
+                return version
+        return None


### PR DESCRIPTION
* Each API has a (potentially) different patch version
* Ensure the API version header is correctly returned
* Ensure the API version is correctly reflected in the API spec