### PR TITLE
Bump MarkupSafe version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -43,7 +43,7 @@ isodate==0.6.0            # via vng-api-common
 itypes==1.1.0             # via coreapi
 jinja2==2.10.1            # via coreschema
 markdown==3.0.1
-markupsafe==1.0           # via jinja2
+markupsafe==1.1.1         # via jinja2
 maykin-django-better-admin-arrayfield==1.0.5
 nlx-url-rewriter==0.1.2
 oyaml==0.7                # via vng-api-common

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -49,7 +49,7 @@ isodate==0.6.0
 itypes==1.1.0
 jinja2==2.10.1
 markdown==3.0.1
-markupsafe==1.0
+markupsafe==1.1.1
 maykin-django-better-admin-arrayfield==1.0.5
 nlx-url-rewriter==0.1.2
 oyaml==0.7

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -64,7 +64,7 @@ isort==4.3.21
 itypes==1.1.0
 jinja2==2.10.1
 markdown==3.0.1
-markupsafe==1.0
+markupsafe==1.1.1
 maykin-django-better-admin-arrayfield==1.0.5
 mccabe==0.6.1             # via flake8
 nlx-url-rewriter==0.1.2


### PR DESCRIPTION
New version works with latest setuptools, which fixes the docker image
build.

Required to make #491 and #499 pass