### PR TITLE
Bump django-auth-adfs-db version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ cryptography==2.8         # via django-auth-adfs
 dictdiffer==0.8.0
 django-admin-index==1.2.2
 django-appconf==1.0.2     # via django-axes
-django-auth-adfs-db==0.1.1
+django-auth-adfs-db==0.2.0
 django-auth-adfs==1.3.1   # via django-auth-adfs-db
 django-axes==4.4.0
 django-choices==1.7.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -15,7 +15,7 @@ cryptography==2.8
 dictdiffer==0.8.0
 django-admin-index==1.2.2
 django-appconf==1.0.2
-django-auth-adfs-db==0.1.1
+django-auth-adfs-db==0.2.0
 django-auth-adfs==1.3.1
 django-axes==4.4.0
 django-choices==1.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -23,7 +23,7 @@ cryptography==2.8
 dictdiffer==0.8.0
 django-admin-index==1.2.2
 django-appconf==1.0.2
-django-auth-adfs-db==0.1.1
+django-auth-adfs-db==0.2.0
 django-auth-adfs==1.3.1
 django-axes==4.4.0
 django-choices==1.7.0


### PR DESCRIPTION
This version supports the toggle to not sync user groups. In certain
cases, the group claim is not included, leading to a reset of the user
groups. Disabling group sync prevents this reset.