### PR TITLE
Issue/resultaattype omschrijving generiek not updating

### DIFF
--- a/src/openzaak/components/catalogi/models/resultaattype.py
+++ b/src/openzaak/components/catalogi/models/resultaattype.py
@@ -220,7 +220,7 @@ class ResultaatType(models.Model):
         """
         Save some derived fields into local object as a means of caching.
         """
-        if not self.omschrijving_generiek and self.resultaattypeomschrijving:
+        if self.resultaattypeomschrijving:
             response = requests.get(self.resultaattypeomschrijving).json()
             self.omschrijving_generiek = response["omschrijving"]
 

--- a/src/openzaak/components/catalogi/models/resultaattype.py
+++ b/src/openzaak/components/catalogi/models/resultaattype.py
@@ -13,6 +13,7 @@ from vng_api_common.constants import (
 from vng_api_common.descriptors import GegevensGroepType
 
 from openzaak.utils.fields import DurationField
+from openzaak.utils.tests import no_fetch
 
 
 class ResultaatType(models.Model):
@@ -220,7 +221,10 @@ class ResultaatType(models.Model):
         """
         Save some derived fields into local object as a means of caching.
         """
-        if self.resultaattypeomschrijving:
+        if (
+            self.resultaattypeomschrijving
+            and self.resultaattypeomschrijving is not no_fetch
+        ):
             response = requests.get(self.resultaattypeomschrijving).json()
             self.omschrijving_generiek = response["omschrijving"]
 

--- a/src/openzaak/components/catalogi/tests/admin/test_import_export_catalogus.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_import_export_catalogus.py
@@ -74,14 +74,22 @@ class CatalogusAdminImportExportTests(WebTest):
             zaaktype=zaaktype, statustype_omschrijving="bla"
         )
         roltype = RolTypeFactory.create(zaaktype=zaaktype)
-        resultaattype = ResultaatTypeFactory.create(
-            zaaktype=zaaktype,
-            omschrijving_generiek="bla",
-            brondatum_archiefprocedure_afleidingswijze="ander_datumkenmerk",
-            brondatum_archiefprocedure_datumkenmerk="datum",
-            brondatum_archiefprocedure_registratie="bla",
-            brondatum_archiefprocedure_objecttype="besluit",
-        )
+        with requests_mock.Mocker() as m:
+            resultaattypeomschrijving = (
+                "https://example.com/resultaattypeomschrijving/1"
+            )
+            m.register_uri(
+                "GET", resultaattypeomschrijving, json={"omschrijving": "init"}
+            )
+            resultaattype = ResultaatTypeFactory.create(
+                zaaktype=zaaktype,
+                omschrijving_generiek="bla",
+                brondatum_archiefprocedure_afleidingswijze="ander_datumkenmerk",
+                brondatum_archiefprocedure_datumkenmerk="datum",
+                brondatum_archiefprocedure_registratie="bla",
+                brondatum_archiefprocedure_objecttype="besluit",
+                resultaattypeomschrijving=resultaattypeomschrijving,
+            )
 
         eigenschap = EigenschapFactory.create(zaaktype=zaaktype, definitie="bla")
         Catalogus.objects.exclude(pk=catalogus.pk).delete()
@@ -205,14 +213,22 @@ class CatalogusAdminImportExportTests(WebTest):
             zaaktype=zaaktype, statustype_omschrijving="bla"
         )
         roltype = RolTypeFactory.create(zaaktype=zaaktype)
-        resultaattype = ResultaatTypeFactory.create(
-            zaaktype=zaaktype,
-            omschrijving_generiek="bla",
-            brondatum_archiefprocedure_afleidingswijze="ander_datumkenmerk",
-            brondatum_archiefprocedure_datumkenmerk="datum",
-            brondatum_archiefprocedure_registratie="bla",
-            brondatum_archiefprocedure_objecttype="besluit",
-        )
+        with requests_mock.Mocker() as m:
+            resultaattypeomschrijving = (
+                "https://example.com/resultaattypeomschrijving/1"
+            )
+            m.register_uri(
+                "GET", resultaattypeomschrijving, json={"omschrijving": "init"}
+            )
+            resultaattype = ResultaatTypeFactory.create(
+                zaaktype=zaaktype,
+                omschrijving_generiek="bla",
+                brondatum_archiefprocedure_afleidingswijze="ander_datumkenmerk",
+                brondatum_archiefprocedure_datumkenmerk="datum",
+                brondatum_archiefprocedure_registratie="bla",
+                brondatum_archiefprocedure_objecttype="besluit",
+                resultaattypeomschrijving=resultaattypeomschrijving,
+            )
 
         eigenschap = EigenschapFactory.create(zaaktype=zaaktype, definitie="bla")
         Catalogus.objects.exclude(pk=catalogus.pk).delete()

--- a/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
@@ -102,14 +102,22 @@ class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
             zaaktype=zaaktype, statustype_omschrijving="bla"
         )
         roltype = RolTypeFactory.create(zaaktype=zaaktype)
-        resultaattype = ResultaatTypeFactory.create(
-            zaaktype=zaaktype,
-            omschrijving_generiek="bla",
-            brondatum_archiefprocedure_afleidingswijze="ander_datumkenmerk",
-            brondatum_archiefprocedure_datumkenmerk="datum",
-            brondatum_archiefprocedure_registratie="bla",
-            brondatum_archiefprocedure_objecttype="besluit",
-        )
+        with requests_mock.Mocker() as m:
+            resultaattypeomschrijving = (
+                "https://example.com/resultaattypeomschrijving/1"
+            )
+            m.register_uri(
+                "GET", resultaattypeomschrijving, json={"omschrijving": "init"}
+            )
+            resultaattype = ResultaatTypeFactory.create(
+                zaaktype=zaaktype,
+                omschrijving_generiek="bla",
+                brondatum_archiefprocedure_afleidingswijze="ander_datumkenmerk",
+                brondatum_archiefprocedure_datumkenmerk="datum",
+                brondatum_archiefprocedure_registratie="bla",
+                brondatum_archiefprocedure_objecttype="besluit",
+                resultaattypeomschrijving=resultaattypeomschrijving,
+            )
 
         eigenschap = EigenschapFactory.create(zaaktype=zaaktype, definitie="bla")
         Catalogus.objects.exclude(pk=catalogus.pk).delete()
@@ -219,14 +227,22 @@ class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
             zaaktype=zaaktype, statustype_omschrijving="bla"
         )
         roltype = RolTypeFactory.create(zaaktype=zaaktype)
-        resultaattype = ResultaatTypeFactory.create(
-            zaaktype=zaaktype,
-            omschrijving_generiek="bla",
-            brondatum_archiefprocedure_afleidingswijze="ander_datumkenmerk",
-            brondatum_archiefprocedure_datumkenmerk="datum",
-            brondatum_archiefprocedure_registratie="bla",
-            brondatum_archiefprocedure_objecttype="besluit",
-        )
+        with requests_mock.Mocker() as m:
+            resultaattypeomschrijving = (
+                "https://example.com/resultaattypeomschrijving/1"
+            )
+            m.register_uri(
+                "GET", resultaattypeomschrijving, json={"omschrijving": "init"}
+            )
+            resultaattype = ResultaatTypeFactory.create(
+                zaaktype=zaaktype,
+                omschrijving_generiek="bla",
+                brondatum_archiefprocedure_afleidingswijze="ander_datumkenmerk",
+                brondatum_archiefprocedure_datumkenmerk="datum",
+                brondatum_archiefprocedure_registratie="bla",
+                brondatum_archiefprocedure_objecttype="besluit",
+                resultaattypeomschrijving=resultaattypeomschrijving,
+            )
 
         eigenschap = EigenschapFactory.create(zaaktype=zaaktype, definitie="bla")
         Catalogus.objects.exclude(pk=catalogus.pk).delete()

--- a/src/openzaak/components/catalogi/tests/admin/test_zaaktype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_zaaktype_admin.py
@@ -123,7 +123,11 @@ class ZaaktypeAdminTests(ClearCachesMixin, WebTest):
         )
         # reverse fk relations
         statustype_old = StatusTypeFactory.create(zaaktype=zaaktype_old)
-        resultaattype_old = ResultaatTypeFactory.create(zaaktype=zaaktype_old)
+        resultaattypeomschrijving = "https://example.com/resultaattypeomschrijving/1"
+        m.register_uri("GET", resultaattypeomschrijving, json={"omschrijving": "init"})
+        resultaattype_old = ResultaatTypeFactory.create(
+            zaaktype=zaaktype_old, resultaattypeomschrijving=resultaattypeomschrijving
+        )
         roltype_old = RolTypeFactory.create(zaaktype=zaaktype_old)
         eigenschap_old = EigenschapFactory.create(zaaktype=zaaktype_old)
         zaaktypenrelatie_old = ZaakTypenRelatieFactory.create(zaaktype=zaaktype_old)

--- a/src/openzaak/components/catalogi/tests/factories/resultaattype.py
+++ b/src/openzaak/components/catalogi/tests/factories/resultaattype.py
@@ -2,6 +2,8 @@ import factory
 import factory.fuzzy
 from dateutil.relativedelta import relativedelta
 
+from openzaak.utils.tests import no_fetch
+
 from ...models import ResultaatType
 from .zaaktype import ZaakTypeFactory
 
@@ -9,7 +11,7 @@ from .zaaktype import ZaakTypeFactory
 class ResultaatTypeFactory(factory.django.DjangoModelFactory):
     zaaktype = factory.SubFactory(ZaakTypeFactory)
     omschrijving = factory.Faker("word", locale="nl")
-    resultaattypeomschrijving = factory.Faker("url")
+    resultaattypeomschrijving = no_fetch
     omschrijving_generiek = factory.Faker("word")
     selectielijstklasse = factory.Faker("url")
     archiefnominatie = factory.fuzzy.FuzzyChoice(["blijvend_bewaren", "vernietigen"])

--- a/src/openzaak/components/catalogi/tests/management/test_import_export.py
+++ b/src/openzaak/components/catalogi/tests/management/test_import_export.py
@@ -232,14 +232,22 @@ class ImportCatalogiTests(TestCase):
             zaaktype=zaaktype, statustype_omschrijving="bla"
         )
         roltype = RolTypeFactory.create(zaaktype=zaaktype)
-        resultaattype = ResultaatTypeFactory.create(
-            zaaktype=zaaktype,
-            omschrijving_generiek="bla",
-            brondatum_archiefprocedure_afleidingswijze="ander_datumkenmerk",
-            brondatum_archiefprocedure_datumkenmerk="datum",
-            brondatum_archiefprocedure_registratie="bla",
-            brondatum_archiefprocedure_objecttype="besluit",
-        )
+        with requests_mock.Mocker() as m:
+            resultaattypeomschrijving = (
+                "https://example.com/resultaattypeomschrijving/1"
+            )
+            m.register_uri(
+                "GET", resultaattypeomschrijving, json={"omschrijving": "init"}
+            )
+            resultaattype = ResultaatTypeFactory.create(
+                zaaktype=zaaktype,
+                omschrijving_generiek="bla",
+                brondatum_archiefprocedure_afleidingswijze="ander_datumkenmerk",
+                brondatum_archiefprocedure_datumkenmerk="datum",
+                brondatum_archiefprocedure_registratie="bla",
+                brondatum_archiefprocedure_objecttype="besluit",
+                resultaattypeomschrijving=resultaattypeomschrijving,
+            )
         eigenschap = EigenschapFactory.create(zaaktype=zaaktype, definitie="bla")
         Catalogus.objects.exclude(pk=catalogus.pk).delete()
 

--- a/src/openzaak/components/catalogi/tests/test_resultaattype.py
+++ b/src/openzaak/components/catalogi/tests/test_resultaattype.py
@@ -83,7 +83,16 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(data[0]["url"], f"http://testserver{resultaattype2_url}")
 
     def test_get_detail(self):
-        resultaattype = ResultaatTypeFactory.create()
+        with requests_mock.Mocker() as m:
+            resultaattypeomschrijving = (
+                "https://example.com/resultaattypeomschrijving/1"
+            )
+            m.register_uri(
+                "GET", resultaattypeomschrijving, json={"omschrijving": "init"}
+            )
+            resultaattype = ResultaatTypeFactory.create(
+                resultaattypeomschrijving=resultaattypeomschrijving
+            )
         url = reverse(resultaattype)
         zaaktype_url = reverse(
             "zaaktype-detail", kwargs={"uuid": resultaattype.zaaktype.uuid}
@@ -464,10 +473,21 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
 
     def test_partial_update_resultaattype(self):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
-        resultaattype = ResultaatTypeFactory.create(zaaktype=zaaktype)
-        resultaattype_url = reverse(resultaattype)
+        with requests_mock.Mocker() as m:
+            resultaattypeomschrijving = (
+                "https://example.com/resultaattypeomschrijving/1"
+            )
+            m.register_uri(
+                "GET", resultaattypeomschrijving, json={"omschrijving": "init"}
+            )
+            resultaattype = ResultaatTypeFactory.create(
+                zaaktype=zaaktype, resultaattypeomschrijving=resultaattypeomschrijving
+            )
+            resultaattype_url = reverse(resultaattype)
 
-        response = self.client.patch(resultaattype_url, {"omschrijving": "aangepast"})
+            response = self.client.patch(
+                resultaattype_url, {"omschrijving": "aangepast"}
+            )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["omschrijving"], "aangepast")

--- a/src/openzaak/components/catalogi/tests/test_resultaattype.py
+++ b/src/openzaak/components/catalogi/tests/test_resultaattype.py
@@ -515,6 +515,41 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         error = get_validation_errors(response, "nonFieldErrors")
         self.assertEqual(error["code"], "non-concept-zaaktype")
 
+    @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
+    @patch("vng_api_common.oas.fetcher.fetch", return_value={})
+    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    def test_update_resultaattype_omschrijving_generiek(self, *mocks):
+        zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
+        zaaktype_url = reverse(zaaktype)
+
+        resultaattypeomschrijving_url = "http://example.com/omschrijving/1"
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                "GET", resultaattypeomschrijving_url, json={"omschrijving": "init"}
+            )
+            resultaattype = ResultaatTypeFactory.create(
+                zaaktype=zaaktype,
+                resultaattypeomschrijving=resultaattypeomschrijving_url,
+            )
+        self.assertEqual(resultaattype.omschrijving_generiek, "init")
+
+        resultaattype_url = reverse(resultaattype)
+
+        data = {
+            "zaaktype": f"http://testserver{zaaktype_url}",
+            "omschrijving": "aangepast",
+            "resultaattypeomschrijving": resultaattypeomschrijving_url,
+        }
+
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                "GET", resultaattypeomschrijving_url, json={"omschrijving": "test"}
+            )
+            response = self.client.patch(resultaattype_url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["omschrijving_generiek"], "test")
+
 
 class ResultaatTypeFilterAPITests(APITestCase):
     maxDiff = None

--- a/src/openzaak/utils/tests.py
+++ b/src/openzaak/utils/tests.py
@@ -109,3 +109,6 @@ class AdminTestMixin:
     def tearDown(self) -> None:
         super().tearDown()
         self.client.logout()
+
+
+no_fetch = object()


### PR DESCRIPTION
Fixes #532 

**Changes**

* fixed issue with readonly field `ResultaatType.omschrijving_generiek` not updating after updating `resultaattypeomschrijving`

