### PR TITLE
Issue/afleidingswijze constraint

### DIFF
--- a/src/openzaak/components/catalogi/api/validators.py
+++ b/src/openzaak/components/catalogi/api/validators.py
@@ -144,6 +144,10 @@ class ProcestermijnAfleidingswijzeValidator:
         afleidingswijze = archiefprocedure["afleidingswijze"]
 
         error = False
+
+        if not procestermijn:
+            return
+
         if (
             procestermijn == Procestermijn.nihil
             and afleidingswijze != Afleidingswijze.afgehandeld

--- a/src/openzaak/components/catalogi/tests/test_resultaattype.py
+++ b/src/openzaak/components/catalogi/tests/test_resultaattype.py
@@ -818,6 +818,49 @@ class ResultaatTypeValidationTests(APITestCase):
         self.assertEqual(error["code"], "invalid-afleidingswijze-for-procestermijn")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
+    @patch("vng_api_common.validators.fetcher")
+    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    def test_procestermijn_empty_and_afleidingswijze_afgehandeld(self, *mocks):
+        zaaktype = ZaakTypeFactory.create(
+            selectielijst_procestype=PROCESTYPE_URL, concept=True
+        )
+        zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})
+
+        responses = {
+            SELECTIELIJSTKLASSE_URL: {
+                "url": SELECTIELIJSTKLASSE_URL,
+                "procesType": PROCESTYPE_URL,
+                "procestermijn": "",
+            }
+        }
+
+        data = {
+            "zaaktype": f"http://testserver{zaaktype_url}",
+            "omschrijving": "illum",
+            "resultaattypeomschrijving": "https://garcia.org/",
+            "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
+            "archiefnominatie": "blijvend_bewaren",
+            "archiefactietermijn": "P10Y",
+            "brondatumArchiefprocedure": {
+                "afleidingswijze": Afleidingswijze.ander_datumkenmerk,
+                "einddatumBekend": False,
+                "procestermijn": None,
+                "datumkenmerk": "identificatie",
+                "objecttype": "pand",
+                "registratie": "test",
+            },
+        }
+
+        with mock_client(responses):
+            with requests_mock.Mocker() as m:
+                m.register_uri(
+                    "GET", "https://garcia.org/", json={"omschrijving": "bla"}
+                )
+                response = self.client.post(self.list_url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
     @patch("vng_api_common.validators.obj_has_shape", return_value=True)
     def test_procestermijn_ingeschatte_bestaansduur_procesobject_and_afleidingswijze_niet_termijn_fails(
         self, *mocks
@@ -859,6 +902,49 @@ class ResultaatTypeValidationTests(APITestCase):
 
         error = get_validation_errors(response, "nonFieldErrors")
         self.assertEqual(error["code"], "invalid-afleidingswijze-for-procestermijn")
+
+    @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
+    @patch("vng_api_common.validators.fetcher")
+    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    def test_procestermijn_empty_and_afleidingswijze_niet_termijn(self, *mocks):
+        zaaktype = ZaakTypeFactory.create(
+            selectielijst_procestype=PROCESTYPE_URL, concept=True
+        )
+        zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})
+
+        responses = {
+            SELECTIELIJSTKLASSE_URL: {
+                "url": SELECTIELIJSTKLASSE_URL,
+                "procesType": PROCESTYPE_URL,
+                "procestermijn": "",
+            }
+        }
+
+        data = {
+            "zaaktype": f"http://testserver{zaaktype_url}",
+            "omschrijving": "illum",
+            "resultaattypeomschrijving": "https://garcia.org/",
+            "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
+            "archiefnominatie": "blijvend_bewaren",
+            "archiefactietermijn": "P10Y",
+            "brondatumArchiefprocedure": {
+                "afleidingswijze": Afleidingswijze.afgehandeld,
+                "einddatumBekend": False,
+                "procestermijn": None,
+                "datumkenmerk": "",
+                "objecttype": "",
+                "registratie": "",
+            },
+        }
+
+        with mock_client(responses):
+            with requests_mock.Mocker() as m:
+                m.register_uri(
+                    "GET", "https://garcia.org/", json={"omschrijving": "bla"}
+                )
+                response = self.client.post(self.list_url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
     @patch("vng_api_common.validators.fetcher")


### PR DESCRIPTION
Fixes #520 

**Changes**

* now any afleidingswijze can be selected if procestermijn is empty (https://github.com/open-zaak/open-zaak/issues/520#issuecomment-608496349)

