### PR TITLE
Added test for creating Zaaktype without referentieproces.link

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -72,5 +72,5 @@ unidecode==1.0.22         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via requests
 uwsgi==2.0.18
-vng-api-common==1.0.37
+vng-api-common==1.0.38
 zgw-consumers==0.8.1

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -82,7 +82,7 @@ unidecode==1.0.22
 uritemplate==3.0.0
 urllib3==1.24.3
 uwsgi==2.0.18
-vng-api-common==1.0.37
+vng-api-common==1.0.38
 waitress==1.4.3           # via webtest
 webob==1.8.5              # via webtest
 webtest==2.0.33           # via django-webtest

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -118,7 +118,7 @@ unidecode==1.0.22
 uritemplate==3.0.0
 urllib3==1.24.3
 uwsgi==2.0.18
-vng-api-common==1.0.37
+vng-api-common==1.0.38
 waitress==1.4.3
 webob==1.8.5
 webtest==2.0.33


### PR DESCRIPTION
Fixes #544 

**Changes**

* added a test for bug that occurred when creating a Zaaktype via the API without referentieproces.link (which should be optional)

