### PR TITLE
Issue/client id application duplicate

### DIFF
--- a/src/openzaak/components/autorisaties/admin.py
+++ b/src/openzaak/components/autorisaties/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.db import transaction
 from django.forms import BaseModelFormSet
 from django.shortcuts import redirect
 from django.urls import path, reverse
@@ -182,6 +183,12 @@ class ApplicatieAdmin(admin.ModelAdmin):
                 "admin:authorizations_applicatie_autorisaties", object_id=obj.id
             )
         return super().response_post_save_change(request, obj)
+
+    @transaction.atomic
+    def delete_model(self, request, obj):
+        secrets = JWTSecret.objects.filter(identifier__in=obj.client_ids)
+        secrets.delete()
+        super().delete_model(request, obj)
 
 
 @admin.register(AutorisatieSpec)

--- a/src/openzaak/components/autorisaties/tests/admin/test_applications_admin.py
+++ b/src/openzaak/components/autorisaties/tests/admin/test_applications_admin.py
@@ -6,6 +6,8 @@ from vng_api_common.models import JWTSecret
 
 from openzaak.accounts.tests.factories import SuperUserFactory
 
+from ..factories import ApplicatieFactory
+
 
 class ApplicationsTests(WebTest):
     @classmethod
@@ -39,6 +41,19 @@ class ApplicationsTests(WebTest):
         self.assertEqual(applicatie.client_ids, ["foo"])
         self.assertEqual(credential.identifier, "foo")
         self.assertEqual(credential.secret, "bar")
+
+    def test_delete_applicatie_cascade_inline_credentials(self):
+        jwt = JWTSecret.objects.create(identifier="testid", secret="bla")
+        applicatie = ApplicatieFactory.create(client_ids=["testid"])
+
+        url = reverse("admin:authorizations_applicatie_delete", args=(applicatie.pk,))
+        response = self.app.get(url)
+        response = response.form.submit().follow()
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(Applicatie.objects.count(), 0)
+        self.assertEqual(JWTSecret.objects.count(), 0)
 
     def test_show_related_jwt_secrets(self):
         application = Applicatie.objects.create(label="test", client_ids=["foo"])

--- a/src/openzaak/components/autorisaties/tests/admin/test_applications_admin.py
+++ b/src/openzaak/components/autorisaties/tests/admin/test_applications_admin.py
@@ -43,7 +43,7 @@ class ApplicationsTests(WebTest):
         self.assertEqual(credential.secret, "bar")
 
     def test_delete_applicatie_cascade_inline_credentials(self):
-        jwt = JWTSecret.objects.create(identifier="testid", secret="bla")
+        JWTSecret.objects.create(identifier="testid", secret="bla")
         applicatie = ApplicatieFactory.create(client_ids=["testid"])
 
         url = reverse("admin:authorizations_applicatie_delete", args=(applicatie.pk,))


### PR DESCRIPTION
Fixes #551 

**Changes**

* Deleting an Applicatie via the admin now deletes all related client credentials (JWTSecrets) as well
