### PR TITLE
Fix Open Zaak running on a subpath

### DIFF
--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -13,6 +13,8 @@ uwsgi_port=${UWSGI_PORT:-8000}
 uwsgi_processes=${UWSGI_PROCESSES:-2}
 uwsgi_threads=${UWSGI_THREADS:-2}
 
+mountpoint=${SUBPATH:-/}
+
 until pg_isready; do
   >&2 echo "Waiting for database connection..."
   sleep 1
@@ -40,7 +42,8 @@ fi
 uwsgi \
     --http :$uwsgi_port \
     --http-keepalive \
-    --module openzaak.wsgi \
+    --manage-script-name \
+    --mount $mountpoint=openzaak.wsgi:application \
     --static-map /static=/app/static \
     --static-map /media=/app/media  \
     --chdir src \

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,8 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    location /openzaak {
+        proxy_pass   http://web:8000;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     image: redis
 
   web:
+    build: .
     image: openzaak/open-zaak
     environment:
       - DJANGO_SETTINGS_MODULE=openzaak.conf.docker
@@ -20,7 +21,17 @@ services:
       - ALLOWED_HOSTS=*
       - CACHE_DEFAULT=redis:6379/0
       - CACHE_AXES=redis:6379/0
+      - SUBPATH=${SUBPATH:-/}
     ports:
       - 8000:8000
     depends_on:
       - db
+
+  nginx:
+    image: nginx
+    volumes:
+      - ./default.conf:/etc/nginx/conf.d/default.conf
+    ports:
+      - "9000:80"
+    depends_on:
+      - web

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -72,5 +72,5 @@ unidecode==1.0.22         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via requests
 uwsgi==2.0.18
-vng-api-common==1.0.38
+vng-api-common==1.0.41
 zgw-consumers==0.8.1

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -82,7 +82,7 @@ unidecode==1.0.22
 uritemplate==3.0.0
 urllib3==1.24.3
 uwsgi==2.0.18
-vng-api-common==1.0.38
+vng-api-common==1.0.41
 waitress==1.4.3           # via webtest
 webob==1.8.5              # via webtest
 webtest==2.0.33           # via django-webtest

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -118,7 +118,7 @@ unidecode==1.0.22
 uritemplate==3.0.0
 urllib3==1.24.3
 uwsgi==2.0.18
-vng-api-common==1.0.38
+vng-api-common==1.0.41
 waitress==1.4.3
 webob==1.8.5
 webtest==2.0.33

--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -412,7 +412,7 @@ subpath = config("SUBPATH", None)
 if subpath:
     if not subpath.startswith("/"):
         subpath = f"/{subpath}"
-    FORCE_SCRIPT_NAME = subpath
+    SUBPATH = subpath
 
 if "GIT_SHA" in os.environ:
     GIT_SHA = config("GIT_SHA", "")

--- a/src/openzaak/conf/production.py
+++ b/src/openzaak/conf/production.py
@@ -50,14 +50,9 @@ SECURE_CONTENT_TYPE_NOSNIFF = True  # Sets X-Content-Type-Options: nosniff
 SECURE_BROWSER_XSS_FILTER = True  # Sets X-XSS-Protection: 1; mode=block
 
 # Deal with being hosted on a subpath
-subpath = config("SUBPATH", None)
 if subpath:
-    if not subpath.startswith("/"):
-        subpath = f"/{subpath}"
-
-    FORCE_SCRIPT_NAME = subpath
-    STATIC_URL = f"{FORCE_SCRIPT_NAME}{STATIC_URL}"
-    MEDIA_URL = f"{FORCE_SCRIPT_NAME}{MEDIA_URL}"
+    STATIC_URL = f"{subpath}{STATIC_URL}"
+    MEDIA_URL = f"{subpath}{MEDIA_URL}"
 
 #
 # Custom settings overrides

--- a/src/openzaak/management/commands/generate_swagger_component.py
+++ b/src/openzaak/management/commands/generate_swagger_component.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.urls import set_script_prefix
 
 from vng_api_common.management.commands import generate_swagger
 
@@ -38,6 +39,9 @@ class Command(generate_swagger.Command):
 
         # Setting must exist for vng-api-common, so monkeypatch it in
         settings.API_VERSION = _version
+
+        if settings.SUBPATH:
+            set_script_prefix(settings.SUBPATH)
 
         if not component:
             super().handle(


### PR DESCRIPTION
Fixes #559 

**Changes**

* Let uwsgi handle the `SCRIPT_PATH` machinery
* Added sample nginx/docker-compose config
* Bumped vng-api-common with bugfix where the `script_prefix` is stripped from the path to resolve to a viewset, tests are added to vng-api-common.

How to test:

```bash
SUBPATH=/openzaak docker-compose up --build
```
Navigate to http://localhost:9000/openzaak/ and verify that everything works.