### PR TITLE
Issue/resultaattype admin keyerror

### DIFF
--- a/src/openzaak/components/catalogi/admin/resultaattype.py
+++ b/src/openzaak/components/catalogi/admin/resultaattype.py
@@ -134,6 +134,11 @@ class ResultaatTypeAdmin(
                 "Please save this Resultaattype first to get proper filtering of selectielijstklasses"
             )
         url = obj.zaaktype.selectielijst_procestype
+        if not url:
+            return _(
+                "Please select a Procestype for the related ZaakType to "
+                "get proper filtering of selectielijstklasses"
+            )
         client = ReferentieLijstConfig.get_client()
         procestype = client.retrieve("procestype", url)
         return f"{procestype['nummer']} - {procestype['naam']}"


### PR DESCRIPTION
Fixes #556 

**Changes**

* Resultaattype admin now shows a message that indicates that Zaaktype.procestype should be set (if it isn't already) to filter selectielijstklassen properly

