### PR TITLE
Don't ignore nested eigenschapspecificatie

### DIFF
--- a/src/openzaak/components/catalogi/api/serializers/eigenschap.py
+++ b/src/openzaak/components/catalogi/api/serializers/eigenschap.py
@@ -1,3 +1,4 @@
+from drf_writable_nested import NestedCreateMixin, NestedUpdateMixin
 from rest_framework import serializers
 from vng_api_common.serializers import add_choice_values_help_text
 
@@ -18,9 +19,11 @@ class EigenschapSpecificatieSerializer(serializers.ModelSerializer):
         self.fields["formaat"].help_text += f"\n\n{value_display_mapping}"
 
 
-class EigenschapSerializer(serializers.HyperlinkedModelSerializer):
+class EigenschapSerializer(
+    NestedCreateMixin, NestedUpdateMixin, serializers.HyperlinkedModelSerializer
+):
     specificatie = EigenschapSpecificatieSerializer(
-        read_only=True, source="specificatie_van_eigenschap"
+        source="specificatie_van_eigenschap", required=False,
     )
 
     class Meta:

--- a/src/openzaak/components/catalogi/tests/factories/eigenschap.py
+++ b/src/openzaak/components/catalogi/tests/factories/eigenschap.py
@@ -5,6 +5,10 @@ from .zaaktype import ZaakTypeFactory
 
 
 class EigenschapSpecificatieFactory(factory.django.DjangoModelFactory):
+    groep = "groep"
+    formaat = "datum"
+    lengte = "8"
+    kardinaliteit = "1"
     waardenverzameling = []  # ArrayField has blank=True but not null=True
 
     class Meta:

--- a/src/openzaak/components/catalogi/tests/test_eigenschap.py
+++ b/src/openzaak/components/catalogi/tests/test_eigenschap.py
@@ -177,6 +177,40 @@ class EigenschapAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(eigenschap.eigenschapnaam, "Beoogd product")
         self.assertEqual(eigenschap.zaaktype, zaaktype)
 
+    def test_create_eigenschap_nested_specifcatie(self):
+        zaaktype = ZaakTypeFactory.create(catalogus=self.catalogus)
+        zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})
+        eigenschap_list_url = reverse("eigenschap-list")
+        data = {
+            "naam": "Beoogd product",
+            "definitie": "test",
+            "toelichting": "",
+            "zaaktype": "http://testserver{}".format(zaaktype_url),
+            "specificatie": {
+                "groep": "een_groep",
+                "formaat": "datum",
+                "lengte": "8",
+                "kardinaliteit": "1",
+                "waardenverzameling": [],
+            },
+        }
+
+        response = self.client.post(eigenschap_list_url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+
+        eigenschap = Eigenschap.objects.get()
+
+        self.assertEqual(eigenschap.eigenschapnaam, "Beoogd product")
+        self.assertEqual(eigenschap.zaaktype, zaaktype)
+
+        spec = eigenschap.specificatie_van_eigenschap
+        self.assertEqual(spec.groep, "een_groep")
+        self.assertEqual(spec.formaat, FormaatChoices.datum)
+        self.assertEqual(spec.lengte, "8")
+        self.assertEqual(spec.kardinaliteit, "1")
+        self.assertEqual(spec.waardenverzameling, [])
+
     def test_create_eigenschap_fail_not_concept_zaaktype(self):
         zaaktype = ZaakTypeFactory.create(concept=False)
         zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})


### PR DESCRIPTION
Fixes #562 

**Changes**

Removed the `read_only` status of `Eigenschap.specificatie`. The object _is_ included in the API spec for the writable body, and it's the only way to specify the spec in the API.

