### PR TITLE
Implement new filters in API standard

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,11 +1,11 @@
 [bumpversion]
 commit = False
 tag = False
-current_version = 1.2.0
+current_version = 1.2.1.dev1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.dev(?P<dev>\d+))?
-serialize =
-    {major}.{minor}.{patch}.dev{dev}
-    {major}.{minor}.{patch}
+serialize = 
+	{major}.{minor}.{patch}.dev{dev}
+	{major}.{minor}.{patch}
 
 [bumpversion:part:dev]
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = False
-current_version = 1.2.1.dev1
+current_version = 1.2.1.dev2
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.dev(?P<dev>\d+))?
 serialize = 
 	{major}.{minor}.{patch}.dev{dev}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,6 +2,12 @@
 commit = False
 tag = False
 current_version = 1.2.0
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.dev(?P<dev>\d+))?
+serialize =
+    {major}.{minor}.{patch}.dev{dev}
+    {major}.{minor}.{patch}
+
+[bumpversion:part:dev]
 
 [bumpversion:file:README.rst]
 

--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@
 
 | | | |
 |-|-|-|
-| **Version:** | 1.2.0 |
+| **Version:** | 1.2.1.dev1 |
 | **Source:** | https://github.com/open-zaak/open-zaak |
 | **Keywords:** | zaken, zaakgericht werken, zaken-api, catalogi-api, besluiten-api, documenten-api |
 | **PythonVersion:** | 3.7 |

--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@
 
 | | | |
 |-|-|-|
-| **Version:** | 1.2.1.dev1 |
+| **Version:** | 1.2.1.dev2 |
 | **Source:** | https://github.com/open-zaak/open-zaak |
 | **Keywords:** | zaken, zaakgericht werken, zaken-api, catalogi-api, besluiten-api, documenten-api |
 | **PythonVersion:** | 3.7 |

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Open Zaak
 
 .. _`Read this in English`: README.en.md
 
-:Version: 1.2.0
+:Version: 1.2.1.dev1
 :Source: https://github.com/open-zaak/open-zaak
 :Keywords: zaken, zaakgericht werken, zaken-api, catalogi-api, besluiten-api, documenten-api
 :PythonVersion: 3.7

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Open Zaak
 
 .. _`Read this in English`: README.en.md
 
-:Version: 1.2.1.dev1
+:Version: 1.2.1.dev2
 :Source: https://github.com/open-zaak/open-zaak
 :Keywords: zaken, zaakgericht werken, zaken-api, catalogi-api, besluiten-api, documenten-api
 :PythonVersion: 3.7

--- a/deployment/kubernetes/apps.yml
+++ b/deployment/kubernetes/apps.yml
@@ -16,7 +16,7 @@
   roles:
     - role: open_zaak_k8s
       vars:  # these override vars_files
-        openzaak_version: '1.2.0'
+        openzaak_version: '1.2.1.dev1'
         openzaak_db_host: "{{ db.privateIp }}"
         openzaak_db_port: "{{ db.port }}"
       tags:

--- a/deployment/kubernetes/apps.yml
+++ b/deployment/kubernetes/apps.yml
@@ -16,7 +16,7 @@
   roles:
     - role: open_zaak_k8s
       vars:  # these override vars_files
-        openzaak_version: '1.2.1.dev1'
+        openzaak_version: '1.2.1.dev2'
         openzaak_db_host: "{{ db.privateIp }}"
         openzaak_db_port: "{{ db.port }}"
       tags:

--- a/deployment/single-server/open-zaak.yml
+++ b/deployment/single-server/open-zaak.yml
@@ -61,7 +61,7 @@
 
     - role: open_zaak_docker
       vars:
-        openzaak_version: '1.2.0'  # see https://hub.docker.com/r/openzaak/open-zaak/tags
+        openzaak_version: '1.2.1.dev1'  # see https://hub.docker.com/r/openzaak/open-zaak/tags
       tags:
         - replicas
 

--- a/deployment/single-server/open-zaak.yml
+++ b/deployment/single-server/open-zaak.yml
@@ -61,7 +61,7 @@
 
     - role: open_zaak_docker
       vars:
-        openzaak_version: '1.2.1.dev1'  # see https://hub.docker.com/r/openzaak/open-zaak/tags
+        openzaak_version: '1.2.1.dev2'  # see https://hub.docker.com/r/openzaak/open-zaak/tags
       tags:
         - replicas
 

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -64,3 +64,14 @@ Once the PR is merged to master, check out the ``master`` branch and tag it:
     git tag 1.0.0
 
 Tagging will ensure that a Docker image ``openzaak/open-zaak:1.0.0`` is published.
+
+Releasing a dev-version
+-----------------------
+
+You can also make use of bumpversion to mark a release as a dev release:
+
+.. code-block:: bash
+
+    bumpversion dev
+
+Which will take care of the ``major.minor.patch.devX`` suffix of ``devX``.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openzaak",
-  "version": "1.2.0",
+  "version": "1.2.1-1-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openzaak",
-  "version": "1.2.1-1-alpha",
+  "version": "1.2.1-2-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openzaak",
-  "version": "1.2.0",
+  "version": "1.2.1-1-alpha",
   "description": "Open Zaak",
   "main": "src/index.js",
   "directories": {
@@ -17,7 +17,7 @@
     "url": "git+ssh://git@github.com/open-zaak/open-zaak.git"
   },
   "author": "Maykin Media",
-  "license": "EUPL 1.2",
+  "license": "EUPL-1.2",
   "homepage": "https://github.com/open-zaak/open-zaak/",
   "dependencies": {
     "autoprefixer": "^9.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openzaak",
-  "version": "1.2.1-1-alpha",
+  "version": "1.2.1-2-alpha",
   "description": "Open Zaak",
   "main": "src/index.js",
   "directories": {

--- a/src/openzaak/components/zaken/api/filters.py
+++ b/src/openzaak/components/zaken/api/filters.py
@@ -25,6 +25,15 @@ class ZaakFilter(FilterSet):
         ),
     )
 
+    rol__betrokkene_identificatie__natuurlijk_persoon__inp_bsn = filters.CharFilter(
+        field_name="rol__natuurlijkpersoon__inp_bsn",
+        help_text=get_help_text("zaken.NatuurlijkPersoon", "inp_bsn"),
+    )
+    rol__betrokkene_identificatie__medewerker__identificatie = filters.CharFilter(
+        field_name="rol__medewerker__identificatie",
+        help_text=get_help_text("zaken.Medewerker", "identificatie"),
+    )
+
     class Meta:
         model = Zaak
         fields = {
@@ -35,6 +44,10 @@ class ZaakFilter(FilterSet):
             "archiefactiedatum": ["exact", "lt", "gt"],
             "archiefstatus": ["exact", "in"],
             "startdatum": ["exact", "gt", "gte", "lt", "lte"],
+            # filters for werkvoorraad
+            "rol__betrokkene_type": ["exact"],
+            "rol__betrokkene": ["exact"],
+            "rol__omschrijving_generiek": ["exact"],
         }
 
 

--- a/src/openzaak/components/zaken/api/filters.py
+++ b/src/openzaak/components/zaken/api/filters.py
@@ -3,6 +3,8 @@ from django_loose_fk.filters import FkOrUrlFieldFilter
 from vng_api_common.filtersets import FilterSet
 from vng_api_common.utils import get_help_text
 
+from openzaak.utils.filters import MaximaleVertrouwelijkheidaanduidingFilter
+
 from ..models import (
     KlantContact,
     Resultaat,
@@ -15,6 +17,14 @@ from ..models import (
 
 
 class ZaakFilter(FilterSet):
+    maximale_vertrouwelijkheidaanduiding = MaximaleVertrouwelijkheidaanduidingFilter(
+        field_name="vertrouwelijkheidaanduiding",
+        help_text=(
+            "Zaken met een vertrouwelijkheidaanduiding die beperkter is dan de "
+            "aangegeven aanduiding worden uit de resultaten gefiltered."
+        ),
+    )
+
     class Meta:
         model = Zaak
         fields = {

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -9474,7 +9474,9 @@ components:
           description: Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
             termijn vernietigd moet worden.
           type: string
-          minLength: 1
+          enum:
+          - blijvend_bewaren
+          - vernietigen
         archiefnominatie__in:
           title: Archiefnominatie  in
           description: Multiple values may be separated by commas.
@@ -9509,7 +9511,11 @@ components:
           description: Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
             termijn vernietigd moet worden.
           type: string
-          minLength: 1
+          enum:
+          - nog_te_archiveren
+          - gearchiveerd
+          - gearchiveerd_procestermijn_onbekend
+          - overgedragen
         archiefstatus__in:
           title: Archiefstatus  in
           description: Multiple values may be separated by commas.
@@ -9544,7 +9550,12 @@ components:
           title: Rol  betrokkenetype
           description: Type van de `betrokkene`.
           type: string
-          minLength: 1
+          enum:
+          - natuurlijk_persoon
+          - niet_natuurlijk_persoon
+          - vestiging
+          - organisatorische_eenheid
+          - medewerker
         rol__betrokkene:
           title: Rol  betrokkene
           description: URL-referentie naar een betrokkene gerelateerd aan de ZAAK.
@@ -9555,13 +9566,29 @@ components:
           description: Algemeen gehanteerde benaming van de aard van de ROL, afgeleid
             uit het ROLTYPE.
           type: string
-          minLength: 1
+          enum:
+          - adviseur
+          - behandelaar
+          - belanghebbende
+          - beslisser
+          - initiator
+          - klantcontacter
+          - zaakcoordinator
+          - mede_initiator
         maximaleVertrouwelijkheidaanduiding:
           title: Maximalevertrouwelijkheidaanduiding
           description: Zaken met een vertrouwelijkheidaanduiding die beperkter is
             dan de aangegeven aanduiding worden uit de resultaten gefiltered.
           type: string
-          minLength: 1
+          enum:
+          - openbaar
+          - beperkt_openbaar
+          - intern
+          - zaakvertrouwelijk
+          - vertrouwelijk
+          - confidentieel
+          - geheim
+          - zeer_geheim
         rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn:
           title: Rol  betrokkeneidentificatie  natuurlijkpersoon  inpbsn
           description: Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -4237,6 +4237,41 @@ paths:
         required: false
         schema:
           type: string
+      - name: rol__betrokkeneType
+        in: query
+        description: Type van de `betrokkene`.
+        required: false
+        schema:
+          type: string
+          enum:
+          - natuurlijk_persoon
+          - niet_natuurlijk_persoon
+          - vestiging
+          - organisatorische_eenheid
+          - medewerker
+      - name: rol__betrokkene
+        in: query
+        description: URL-referentie naar een betrokkene gerelateerd aan de ZAAK.
+        required: false
+        schema:
+          type: string
+          format: uri
+      - name: rol__omschrijvingGeneriek
+        in: query
+        description: Algemeen gehanteerde benaming van de aard van de ROL, afgeleid
+          uit het ROLTYPE.
+        required: false
+        schema:
+          type: string
+          enum:
+          - adviseur
+          - behandelaar
+          - belanghebbende
+          - beslisser
+          - initiator
+          - klantcontacter
+          - zaakcoordinator
+          - mede_initiator
       - name: maximaleVertrouwelijkheidaanduiding
         in: query
         description: Zaken met een vertrouwelijkheidaanduiding die beperkter is dan
@@ -4253,6 +4288,19 @@ paths:
           - confidentieel
           - geheim
           - zeer_geheim
+      - name: rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn
+        in: query
+        description: Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet algemene
+          bepalingen burgerservicenummer.
+        required: false
+        schema:
+          type: string
+      - name: rol__betrokkeneIdentificatie__medewerker__identificatie
+        in: query
+        description: Een korte unieke aanduiding van de MEDEWERKER.
+        required: false
+        schema:
+          type: string
       - name: ordering
         in: query
         description: Which field to use when ordering the results.
@@ -9492,10 +9540,37 @@ components:
           description: De datum waarop met de uitvoering van de zaak is gestart
           type: string
           minLength: 1
+        rol__betrokkeneType:
+          title: Rol  betrokkenetype
+          description: Type van de `betrokkene`.
+          type: string
+          minLength: 1
+        rol__betrokkene:
+          title: Rol  betrokkene
+          description: URL-referentie naar een betrokkene gerelateerd aan de ZAAK.
+          type: string
+          minLength: 1
+        rol__omschrijvingGeneriek:
+          title: Rol  omschrijvinggeneriek
+          description: Algemeen gehanteerde benaming van de aard van de ROL, afgeleid
+            uit het ROLTYPE.
+          type: string
+          minLength: 1
         maximaleVertrouwelijkheidaanduiding:
           title: Maximalevertrouwelijkheidaanduiding
           description: Zaken met een vertrouwelijkheidaanduiding die beperkter is
             dan de aangegeven aanduiding worden uit de resultaten gefiltered.
+          type: string
+          minLength: 1
+        rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn:
+          title: Rol  betrokkeneidentificatie  natuurlijkpersoon  inpbsn
+          description: Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet
+            algemene bepalingen burgerservicenummer.
+          type: string
+          minLength: 1
+        rol__betrokkeneIdentificatie__medewerker__identificatie:
+          title: Rol  betrokkeneidentificatie  medewerker  identificatie
+          description: Een korte unieke aanduiding van de MEDEWERKER.
           type: string
           minLength: 1
         ordering:

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -9471,8 +9471,18 @@ components:
           minLength: 1
         archiefnominatie:
           title: Archiefnominatie
-          description: Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
+          description: 'Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
             termijn vernietigd moet worden.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `blijvend_bewaren` - Het zaakdossier moet bewaard blijven en op de Archiefactiedatum
+            overgedragen worden naar een archiefbewaarplaats.
+
+            * `vernietigen` - Het zaakdossier moet op of na de Archiefactiedatum vernietigd
+            worden.'
           type: string
           enum:
           - blijvend_bewaren
@@ -9508,8 +9518,25 @@ components:
           minLength: 1
         archiefstatus:
           title: Archiefstatus
-          description: Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
+          description: 'Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde
             termijn vernietigd moet worden.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `nog_te_archiveren` - De zaak cq. het zaakdossier is nog niet als geheel
+            gearchiveerd.
+
+            * `gearchiveerd` - De zaak cq. het zaakdossier is als geheel niet-wijzigbaar
+            bewaarbaar gemaakt.
+
+            * `gearchiveerd_procestermijn_onbekend` - De zaak cq. het zaakdossier
+            is als geheel niet-wijzigbaar bewaarbaar gemaakt maar de vernietigingsdatum
+            kan nog niet bepaald worden.
+
+            * `overgedragen` - De zaak cq. het zaakdossier is overgebracht naar een
+            archiefbewaarplaats.'
           type: string
           enum:
           - nog_te_archiveren
@@ -9548,7 +9575,21 @@ components:
           minLength: 1
         rol__betrokkeneType:
           title: Rol  betrokkenetype
-          description: Type van de `betrokkene`.
+          description: 'Type van de `betrokkene`.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `natuurlijk_persoon` - Natuurlijk persoon
+
+            * `niet_natuurlijk_persoon` - Niet-natuurlijk persoon
+
+            * `vestiging` - Vestiging
+
+            * `organisatorische_eenheid` - Organisatorische eenheid
+
+            * `medewerker` - Medewerker'
           type: string
           enum:
           - natuurlijk_persoon
@@ -9563,8 +9604,12 @@ components:
           minLength: 1
         rol__omschrijvingGeneriek:
           title: Rol  omschrijvinggeneriek
-          description: Algemeen gehanteerde benaming van de aard van de ROL, afgeleid
-            uit het ROLTYPE.
+          description: "Algemeen gehanteerde benaming van de aard van de ROL, afgeleid\
+            \ uit het ROLTYPE.\n\nUitleg bij mogelijke waarden:\n\n* `adviseur` -\
+            \ Adviseur\n* `behandelaar` - Behandelaar\n* `belanghebbende` - Belanghebbende\n\
+            * `beslisser` - Beslisser\n* `initiator` - Initiator\n* `klantcontacter`\
+            \ - Klantcontacter\n* `zaakcoordinator` - Zaakco\xF6rdinator\n* `mede_initiator`\
+            \ - Mede-initiator"
           type: string
           enum:
           - adviseur
@@ -9577,8 +9622,28 @@ components:
           - mede_initiator
         maximaleVertrouwelijkheidaanduiding:
           title: Maximalevertrouwelijkheidaanduiding
-          description: Zaken met een vertrouwelijkheidaanduiding die beperkter is
+          description: 'Zaken met een vertrouwelijkheidaanduiding die beperkter is
             dan de aangegeven aanduiding worden uit de resultaten gefiltered.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `openbaar` - Openbaar
+
+            * `beperkt_openbaar` - Beperkt openbaar
+
+            * `intern` - Intern
+
+            * `zaakvertrouwelijk` - Zaakvertrouwelijk
+
+            * `vertrouwelijk` - Vertrouwelijk
+
+            * `confidentieel` - Confidentieel
+
+            * `geheim` - Geheim
+
+            * `zeer_geheim` - Zeer geheim'
           type: string
           enum:
           - openbaar

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -4237,6 +4237,22 @@ paths:
         required: false
         schema:
           type: string
+      - name: maximaleVertrouwelijkheidaanduiding
+        in: query
+        description: Zaken met een vertrouwelijkheidaanduiding die beperkter is dan
+          de aangegeven aanduiding worden uit de resultaten gefiltered.
+        required: false
+        schema:
+          type: string
+          enum:
+          - openbaar
+          - beperkt_openbaar
+          - intern
+          - zaakvertrouwelijk
+          - vertrouwelijk
+          - confidentieel
+          - geheim
+          - zeer_geheim
       - name: ordering
         in: query
         description: Which field to use when ordering the results.
@@ -9474,6 +9490,12 @@ components:
         startdatum__lte:
           title: Startdatum  lte
           description: De datum waarop met de uitvoering van de zaak is gestart
+          type: string
+          minLength: 1
+        maximaleVertrouwelijkheidaanduiding:
+          title: Maximalevertrouwelijkheidaanduiding
+          description: Zaken met een vertrouwelijkheidaanduiding die beperkter is
+            dan de aangegeven aanduiding worden uit de resultaten gefiltered.
           type: string
           minLength: 1
         ordering:

--- a/src/openzaak/components/zaken/swagger2.0.json
+++ b/src/openzaak/components/zaken/swagger2.0.json
@@ -11177,7 +11177,10 @@
                     "title": "Archiefnominatie",
                     "description": "Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde termijn vernietigd moet worden.",
                     "type": "string",
-                    "minLength": 1
+                    "enum": [
+                        "blijvend_bewaren",
+                        "vernietigen"
+                    ]
                 },
                 "archiefnominatie__in": {
                     "title": "Archiefnominatie  in",
@@ -11207,7 +11210,12 @@
                     "title": "Archiefstatus",
                     "description": "Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde termijn vernietigd moet worden.",
                     "type": "string",
-                    "minLength": 1
+                    "enum": [
+                        "nog_te_archiveren",
+                        "gearchiveerd",
+                        "gearchiveerd_procestermijn_onbekend",
+                        "overgedragen"
+                    ]
                 },
                 "archiefstatus__in": {
                     "title": "Archiefstatus  in",
@@ -11249,7 +11257,13 @@
                     "title": "Rol  betrokkenetype",
                     "description": "Type van de `betrokkene`.",
                     "type": "string",
-                    "minLength": 1
+                    "enum": [
+                        "natuurlijk_persoon",
+                        "niet_natuurlijk_persoon",
+                        "vestiging",
+                        "organisatorische_eenheid",
+                        "medewerker"
+                    ]
                 },
                 "rol__betrokkene": {
                     "title": "Rol  betrokkene",
@@ -11261,13 +11275,31 @@
                     "title": "Rol  omschrijvinggeneriek",
                     "description": "Algemeen gehanteerde benaming van de aard van de ROL, afgeleid uit het ROLTYPE.",
                     "type": "string",
-                    "minLength": 1
+                    "enum": [
+                        "adviseur",
+                        "behandelaar",
+                        "belanghebbende",
+                        "beslisser",
+                        "initiator",
+                        "klantcontacter",
+                        "zaakcoordinator",
+                        "mede_initiator"
+                    ]
                 },
                 "maximaleVertrouwelijkheidaanduiding": {
                     "title": "Maximalevertrouwelijkheidaanduiding",
                     "description": "Zaken met een vertrouwelijkheidaanduiding die beperkter is dan de aangegeven aanduiding worden uit de resultaten gefiltered.",
                     "type": "string",
-                    "minLength": 1
+                    "enum": [
+                        "openbaar",
+                        "beperkt_openbaar",
+                        "intern",
+                        "zaakvertrouwelijk",
+                        "vertrouwelijk",
+                        "confidentieel",
+                        "geheim",
+                        "zeer_geheim"
+                    ]
                 },
                 "rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn": {
                     "title": "Rol  betrokkeneidentificatie  natuurlijkpersoon  inpbsn",

--- a/src/openzaak/components/zaken/swagger2.0.json
+++ b/src/openzaak/components/zaken/swagger2.0.json
@@ -5050,6 +5050,45 @@
                         "type": "string"
                     },
                     {
+                        "name": "rol__betrokkeneType",
+                        "in": "query",
+                        "description": "Type van de `betrokkene`.",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "natuurlijk_persoon",
+                            "niet_natuurlijk_persoon",
+                            "vestiging",
+                            "organisatorische_eenheid",
+                            "medewerker"
+                        ]
+                    },
+                    {
+                        "name": "rol__betrokkene",
+                        "in": "query",
+                        "description": "URL-referentie naar een betrokkene gerelateerd aan de ZAAK.",
+                        "required": false,
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    {
+                        "name": "rol__omschrijvingGeneriek",
+                        "in": "query",
+                        "description": "Algemeen gehanteerde benaming van de aard van de ROL, afgeleid uit het ROLTYPE.",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "adviseur",
+                            "behandelaar",
+                            "belanghebbende",
+                            "beslisser",
+                            "initiator",
+                            "klantcontacter",
+                            "zaakcoordinator",
+                            "mede_initiator"
+                        ]
+                    },
+                    {
                         "name": "maximaleVertrouwelijkheidaanduiding",
                         "in": "query",
                         "description": "Zaken met een vertrouwelijkheidaanduiding die beperkter is dan de aangegeven aanduiding worden uit de resultaten gefiltered.",
@@ -5065,6 +5104,20 @@
                             "geheim",
                             "zeer_geheim"
                         ]
+                    },
+                    {
+                        "name": "rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn",
+                        "in": "query",
+                        "description": "Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet algemene bepalingen burgerservicenummer.",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "rol__betrokkeneIdentificatie__medewerker__identificatie",
+                        "in": "query",
+                        "description": "Een korte unieke aanduiding van de MEDEWERKER.",
+                        "required": false,
+                        "type": "string"
                     },
                     {
                         "name": "ordering",
@@ -11192,9 +11245,39 @@
                     "type": "string",
                     "minLength": 1
                 },
+                "rol__betrokkeneType": {
+                    "title": "Rol  betrokkenetype",
+                    "description": "Type van de `betrokkene`.",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "rol__betrokkene": {
+                    "title": "Rol  betrokkene",
+                    "description": "URL-referentie naar een betrokkene gerelateerd aan de ZAAK.",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "rol__omschrijvingGeneriek": {
+                    "title": "Rol  omschrijvinggeneriek",
+                    "description": "Algemeen gehanteerde benaming van de aard van de ROL, afgeleid uit het ROLTYPE.",
+                    "type": "string",
+                    "minLength": 1
+                },
                 "maximaleVertrouwelijkheidaanduiding": {
                     "title": "Maximalevertrouwelijkheidaanduiding",
                     "description": "Zaken met een vertrouwelijkheidaanduiding die beperkter is dan de aangegeven aanduiding worden uit de resultaten gefiltered.",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn": {
+                    "title": "Rol  betrokkeneidentificatie  natuurlijkpersoon  inpbsn",
+                    "description": "Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet algemene bepalingen burgerservicenummer.",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "rol__betrokkeneIdentificatie__medewerker__identificatie": {
+                    "title": "Rol  betrokkeneidentificatie  medewerker  identificatie",
+                    "description": "Een korte unieke aanduiding van de MEDEWERKER.",
                     "type": "string",
                     "minLength": 1
                 },

--- a/src/openzaak/components/zaken/swagger2.0.json
+++ b/src/openzaak/components/zaken/swagger2.0.json
@@ -5050,6 +5050,23 @@
                         "type": "string"
                     },
                     {
+                        "name": "maximaleVertrouwelijkheidaanduiding",
+                        "in": "query",
+                        "description": "Zaken met een vertrouwelijkheidaanduiding die beperkter is dan de aangegeven aanduiding worden uit de resultaten gefiltered.",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "openbaar",
+                            "beperkt_openbaar",
+                            "intern",
+                            "zaakvertrouwelijk",
+                            "vertrouwelijk",
+                            "confidentieel",
+                            "geheim",
+                            "zeer_geheim"
+                        ]
+                    },
+                    {
                         "name": "ordering",
                         "in": "query",
                         "description": "Which field to use when ordering the results.",
@@ -11172,6 +11189,12 @@
                 "startdatum__lte": {
                     "title": "Startdatum  lte",
                     "description": "De datum waarop met de uitvoering van de zaak is gestart",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "maximaleVertrouwelijkheidaanduiding": {
+                    "title": "Maximalevertrouwelijkheidaanduiding",
+                    "description": "Zaken met een vertrouwelijkheidaanduiding die beperkter is dan de aangegeven aanduiding worden uit de resultaten gefiltered.",
                     "type": "string",
                     "minLength": 1
                 },

--- a/src/openzaak/components/zaken/swagger2.0.json
+++ b/src/openzaak/components/zaken/swagger2.0.json
@@ -11175,7 +11175,7 @@
                 },
                 "archiefnominatie": {
                     "title": "Archiefnominatie",
-                    "description": "Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde termijn vernietigd moet worden.",
+                    "description": "Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde termijn vernietigd moet worden.\n\nUitleg bij mogelijke waarden:\n\n* `blijvend_bewaren` - Het zaakdossier moet bewaard blijven en op de Archiefactiedatum overgedragen worden naar een archiefbewaarplaats.\n* `vernietigen` - Het zaakdossier moet op of na de Archiefactiedatum vernietigd worden.",
                     "type": "string",
                     "enum": [
                         "blijvend_bewaren",
@@ -11208,7 +11208,7 @@
                 },
                 "archiefstatus": {
                     "title": "Archiefstatus",
-                    "description": "Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde termijn vernietigd moet worden.",
+                    "description": "Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde termijn vernietigd moet worden.\n\nUitleg bij mogelijke waarden:\n\n* `nog_te_archiveren` - De zaak cq. het zaakdossier is nog niet als geheel gearchiveerd.\n* `gearchiveerd` - De zaak cq. het zaakdossier is als geheel niet-wijzigbaar bewaarbaar gemaakt.\n* `gearchiveerd_procestermijn_onbekend` - De zaak cq. het zaakdossier is als geheel niet-wijzigbaar bewaarbaar gemaakt maar de vernietigingsdatum kan nog niet bepaald worden.\n* `overgedragen` - De zaak cq. het zaakdossier is overgebracht naar een archiefbewaarplaats.",
                     "type": "string",
                     "enum": [
                         "nog_te_archiveren",
@@ -11255,7 +11255,7 @@
                 },
                 "rol__betrokkeneType": {
                     "title": "Rol  betrokkenetype",
-                    "description": "Type van de `betrokkene`.",
+                    "description": "Type van de `betrokkene`.\n\nUitleg bij mogelijke waarden:\n\n* `natuurlijk_persoon` - Natuurlijk persoon\n* `niet_natuurlijk_persoon` - Niet-natuurlijk persoon\n* `vestiging` - Vestiging\n* `organisatorische_eenheid` - Organisatorische eenheid\n* `medewerker` - Medewerker",
                     "type": "string",
                     "enum": [
                         "natuurlijk_persoon",
@@ -11273,7 +11273,7 @@
                 },
                 "rol__omschrijvingGeneriek": {
                     "title": "Rol  omschrijvinggeneriek",
-                    "description": "Algemeen gehanteerde benaming van de aard van de ROL, afgeleid uit het ROLTYPE.",
+                    "description": "Algemeen gehanteerde benaming van de aard van de ROL, afgeleid uit het ROLTYPE.\n\nUitleg bij mogelijke waarden:\n\n* `adviseur` - Adviseur\n* `behandelaar` - Behandelaar\n* `belanghebbende` - Belanghebbende\n* `beslisser` - Beslisser\n* `initiator` - Initiator\n* `klantcontacter` - Klantcontacter\n* `zaakcoordinator` - Zaakco\u00f6rdinator\n* `mede_initiator` - Mede-initiator",
                     "type": "string",
                     "enum": [
                         "adviseur",
@@ -11288,7 +11288,7 @@
                 },
                 "maximaleVertrouwelijkheidaanduiding": {
                     "title": "Maximalevertrouwelijkheidaanduiding",
-                    "description": "Zaken met een vertrouwelijkheidaanduiding die beperkter is dan de aangegeven aanduiding worden uit de resultaten gefiltered.",
+                    "description": "Zaken met een vertrouwelijkheidaanduiding die beperkter is dan de aangegeven aanduiding worden uit de resultaten gefiltered.\n\nUitleg bij mogelijke waarden:\n\n* `openbaar` - Openbaar\n* `beperkt_openbaar` - Beperkt openbaar\n* `intern` - Intern\n* `zaakvertrouwelijk` - Zaakvertrouwelijk\n* `vertrouwelijk` - Vertrouwelijk\n* `confidentieel` - Confidentieel\n* `geheim` - Geheim\n* `zeer_geheim` - Zeer geheim",
                     "type": "string",
                     "enum": [
                         "openbaar",

--- a/src/openzaak/components/zaken/tests/test_zaken.py
+++ b/src/openzaak/components/zaken/tests/test_zaken.py
@@ -13,6 +13,8 @@ from vng_api_common.constants import (
     Archiefnominatie,
     BrondatumArchiefprocedureAfleidingswijze,
     ComponentTypes,
+    RolOmschrijving,
+    RolTypes,
     VertrouwelijkheidsAanduiding,
 )
 from vng_api_common.tests import get_validation_errors, reverse
@@ -32,9 +34,9 @@ from ..api.scopes import (
     SCOPEN_ZAKEN_HEROPENEN,
 )
 from ..constants import BetalingsIndicatie
-from ..models import Zaak
+from ..models import Medewerker, NatuurlijkPersoon, Zaak
 from .constants import POLYGON_AMSTERDAM_CENTRUM
-from .factories import StatusFactory, ZaakFactory
+from .factories import RolFactory, StatusFactory, ZaakFactory
 from .utils import (
     ZAAK_READ_KWARGS,
     ZAAK_WRITE_KWARGS,
@@ -748,3 +750,145 @@ class ZaakCreateExternalURLsTests(JWTAuthMixin, APITestCase):
 
         error = get_validation_errors(response, "zaaktype")
         self.assertEqual(error["code"], "not-published")
+
+
+class ZakenWerkVoorraadTests(JWTAuthMixin, APITestCase):
+    """
+    Test that the queries to build up a 'werkvoorraad' work as expected.
+    """
+
+    heeft_alle_autorisaties = True
+
+    def test_rol_medewerker_url(self):
+        """
+        Test that zaken for a specific medewerker can be retrieved.
+        """
+        url = reverse(Zaak)
+        MEDEWERKER = "https://medewerkers.nl/api/v1/medewerkers/1"
+        rol1 = RolFactory.create(
+            betrokkene=MEDEWERKER,
+            betrokkene_type=RolTypes.medewerker,
+            omschrijving_generiek=RolOmschrijving.behandelaar,
+        )
+        rol2 = RolFactory.create(
+            betrokkene_type=RolTypes.medewerker,
+            omschrijving_generiek=RolOmschrijving.behandelaar,
+        )
+        RolFactory.create(
+            betrokkene_type=RolTypes.natuurlijk_persoon,
+            omschrijving_generiek=RolOmschrijving.initiator,
+        )
+        zaak1, zaak2 = rol1.zaak, rol2.zaak
+
+        with self.subTest(filter_on="betrokkeneType"):
+            query = {"rol__betrokkeneType": RolTypes.medewerker}
+
+            response = self.client.get(url, query, **ZAAK_READ_KWARGS)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 2)
+            urls = {result["url"] for result in response.data["results"]}
+            self.assertEqual(
+                urls,
+                {
+                    f"http://testserver{reverse(zaak1)}",
+                    f"http://testserver{reverse(zaak2)}",
+                },
+            )
+
+        with self.subTest(filter_on="omschrijving generiek"):
+            query = {"rol__omschrijvingGeneriek": RolOmschrijving.behandelaar}
+
+            response = self.client.get(url, query, **ZAAK_READ_KWARGS)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 2)
+            urls = {result["url"] for result in response.data["results"]}
+            self.assertEqual(
+                urls,
+                {
+                    f"http://testserver{reverse(zaak1)}",
+                    f"http://testserver{reverse(zaak2)}",
+                },
+            )
+
+        with self.subTest(filter_on="betrokkene"):
+            query = {"rol__betrokkene": MEDEWERKER}
+
+            response = self.client.get(url, query, **ZAAK_READ_KWARGS)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 1)
+            self.assertEqual(
+                response.data["results"][0]["url"],
+                f"http://testserver{reverse(zaak1)}",
+            )
+
+    def test_rol_medewerker_identificatie(self):
+        url = reverse(Zaak)
+        rol = RolFactory.create(
+            betrokkene_type=RolTypes.medewerker,
+            omschrijving_generiek=RolOmschrijving.behandelaar,
+        )
+        Medewerker.objects.create(
+            rol=rol, identificatie="some-username",
+        )
+
+        with self.subTest(expected="no-match"):
+            response = self.client.get(
+                url,
+                {"rol__betrokkeneIdentificatie__medewerker__identificatie": "no-match"},
+                **ZAAK_READ_KWARGS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 0)
+
+        with self.subTest(expected="match"):
+            response = self.client.get(
+                url,
+                {
+                    "rol__betrokkeneIdentificatie__medewerker__identificatie": "some-username"
+                },
+                **ZAAK_READ_KWARGS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 1)
+
+    def test_rol_np_bsn(self):
+        """
+        Essential to be able to fetch all Zaken related to a particular citizen.
+        """
+        url = reverse(Zaak)
+        rol = RolFactory.create(
+            betrokkene_type=RolTypes.natuurlijk_persoon,
+            omschrijving_generiek=RolOmschrijving.initiator,
+        )
+        NatuurlijkPersoon.objects.create(
+            rol=rol, inp_bsn="129117729"
+        )  # http://www.wilmans.com/sofinummer/
+
+        with self.subTest(expected="no-match"):
+            response = self.client.get(
+                url,
+                {
+                    "rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn": "000000000"
+                },
+                **ZAAK_READ_KWARGS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 0)
+
+        with self.subTest(expected="match"):
+            response = self.client.get(
+                url,
+                {
+                    "rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn": "129117729"
+                },
+                **ZAAK_READ_KWARGS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 1)

--- a/src/openzaak/components/zaken/tests/test_zaken.py
+++ b/src/openzaak/components/zaken/tests/test_zaken.py
@@ -505,6 +505,35 @@ class ZakenTests(JWTAuthMixin, APITestCase):
         self.assertEqual(data[1]["startdatum"], "2019-02-01")
         self.assertEqual(data[2]["startdatum"], "2019-01-01")
 
+    def test_filter_max_vertrouwelijkheidaanduiding(self):
+        zaak1 = ZaakFactory.create(
+            zaaktype=self.zaaktype,
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.openbaar,
+        )
+        zaak2 = ZaakFactory.create(
+            zaaktype=self.zaaktype,
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.geheim,
+        )
+
+        url = reverse(Zaak)
+
+        response = self.client.get(
+            url,
+            {
+                "maximaleVertrouwelijkheidaanduiding": VertrouwelijkheidsAanduiding.zaakvertrouwelijk
+            },
+            **ZAAK_READ_KWARGS,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(
+            response.data["results"][0]["url"], f"http://testserver{reverse(zaak1)}",
+        )
+        self.assertNotEqual(
+            response.data["results"][0]["url"], f"http://testserver{reverse(zaak2)}",
+        )
+
 
 class ZaakArchivingTests(JWTAuthMixin, APITestCase):
 

--- a/src/openzaak/utils/filters.py
+++ b/src/openzaak/utils/filters.py
@@ -1,0 +1,23 @@
+from django_filters import filters
+from vng_api_common.constants import VertrouwelijkheidsAanduiding
+
+
+class MaximaleVertrouwelijkheidaanduidingFilter(filters.ChoiceFilter):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("choices", VertrouwelijkheidsAanduiding.choices)
+        kwargs.setdefault("lookup_expr", "lte")
+        super().__init__(*args, **kwargs)
+
+        # rewrite the field_name correctly
+        self._field_name = self.field_name
+        self.field_name = f"_{self._field_name}_order"
+
+    def filter(self, qs, value):
+        if value in filters.EMPTY_VALUES:
+            return qs
+        order_expression = VertrouwelijkheidsAanduiding.get_order_expression(
+            self._field_name
+        )
+        qs = qs.annotate(**{self.field_name: order_expression})
+        numeric_value = VertrouwelijkheidsAanduiding.get_choice(value).order
+        return super().filter(qs, numeric_value)


### PR DESCRIPTION
Fixes #591

**Changes**

* implemented the `maxVertrouwelijkheidaanduiding` filter on the `zaak-list` operation
* implemented the `betrokkene*` filters on the `zaak-list` operation
