### PR TITLE
Issue/cmis eio inhoud url

### DIFF
--- a/src/openzaak/components/documenten/api/serializers.py
+++ b/src/openzaak/components/documenten/api/serializers.py
@@ -39,6 +39,7 @@ from ..models import (
     Gebruiksrechten,
     ObjectInformatieObject,
 )
+from ..utils import PrivateMediaStorageWithCMIS
 from .validators import InformatieObjectUniqueValidator, StatusValidator
 
 
@@ -75,8 +76,9 @@ class AnyBase64File(Base64FileField):
 
     def to_representation(self, file):
         is_private_storage = isinstance(file.storage, PrivateMediaFileSystemStorage)
+        is_cmis_storage = isinstance(file.storage, PrivateMediaStorageWithCMIS)
 
-        if not is_private_storage or self.represent_in_base64:
+        if not (is_private_storage or is_cmis_storage) or self.represent_in_base64:
             return super().to_representation(file)
 
         assert (

--- a/src/openzaak/components/documenten/querysets.py
+++ b/src/openzaak/components/documenten/querysets.py
@@ -27,7 +27,7 @@ from .query import (
     InformatieobjectRelatedQuerySet,
     ObjectInformatieObjectQuerySet,
 )
-from .utils import CMISStorageFile
+from .utils import CMISStorageFile, eio_version_to_cmis
 
 logger = logging.getLogger(__name__)
 
@@ -545,6 +545,8 @@ class CMISQuerySet(InformatieobjectQuerySet):
                     )
             elif key == "creatiedatum__isnull":
                 filters["creatiedatum"] = ""
+            elif key_bits[0] == "versie":
+                filters[key_bits[0]] = eio_version_to_cmis(value)
             else:
                 filters[key_bits[0]] = value
 

--- a/src/openzaak/components/documenten/tests/test_eio_file_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_eio_file_cmis.py
@@ -88,9 +88,10 @@ class US39TestCase(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.data["results"]
-        download_url = urlparse(data[0]["inhoud"])
+        download_url = reverse(
+            "enkelvoudiginformatieobject-download", kwargs={"uuid": eio.uuid}
+        )
 
         self.assertEqual(
-            download_url.path,
-            f"/alfresco/s/api/node/content/workspace/SpacesStore/{eio.uuid}",
+            data[0]["inhoud"], f"http://testserver{download_url}?versie={eio.versie}",
         )

--- a/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject_cmis.py
@@ -86,13 +86,15 @@ class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(stored_object.vertrouwelijkheidaanduiding, "openbaar")
 
         expected_url = reverse(stored_object)
+        download_url = reverse(
+            "enkelvoudiginformatieobject-download", kwargs={"uuid": stored_object.uuid}
+        )
 
         expected_response = content.copy()
         expected_response.update(
             {
                 "url": f"http://testserver{expected_url}",
-                "inhoud": f"http://localhost:8082/"
-                f"alfresco/s/api/node/content/workspace/SpacesStore/{stored_object.uuid}",
+                "inhoud": f"http://testserver{download_url}?versie=200",
                 "versie": 200,
                 "beginRegistratie": stored_object.begin_registratie.isoformat().replace(
                     "+00:00", "Z"
@@ -157,6 +159,10 @@ class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APICMISTestCase):
         # Test response
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+        download_url = reverse(
+            "enkelvoudiginformatieobject-download", kwargs={"uuid": test_object.uuid}
+        )
+
         expected = {
             "url": f"http://testserver{detail_url}",
             "identificatie": str(test_object.identificatie),
@@ -172,7 +178,7 @@ class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APICMISTestCase):
             ),
             "versie": 110,
             "bestandsnaam": "",
-            "inhoud": f"http://localhost:8082/alfresco/s/api/node/content/workspace/SpacesStore/{test_object.uuid}",
+            "inhoud": f"http://testserver{download_url}?versie=110",
             "bestandsomvang": test_object.inhoud.size,
             "link": "",
             "beschrijving": "",

--- a/src/openzaak/components/documenten/utils.py
+++ b/src/openzaak/components/documenten/utils.py
@@ -1,4 +1,5 @@
 import io
+from decimal import Decimal
 
 from django.conf import settings
 from django.core.files.base import File
@@ -113,3 +114,11 @@ class PrivateMediaStorageWithCMIS(LazyObject):
 
 
 private_media_storage_cmis = PrivateMediaStorageWithCMIS()
+
+
+def eio_version_to_cmis(version):
+    """
+    Convert an Open Zaak EnkelvoudigInformatieObject `versie` number to its
+    corresponding version number for CMIS
+    """
+    return Decimal(version) / 100


### PR DESCRIPTION
Fixes https://github.com/open-zaak/open-zaak/pull/626#pullrequestreview-436733071

**Changes**

* fixed serialization of EIO.inhoud for CMIS_ENABLED
* changed EIO filtering by version to use the OZ version (e.g. 110) instead of the Alfresco version (e.g. 1.1)

