### PR TITLE
Issue/isort v5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,19 +57,19 @@ jobs:
 
     - name: "Code imports"
       before_install: skip
-      install: pip install -r requirements/dev.txt
+      install: pip install -r requirements/ci.txt
       before_script: skip
       script: isort --check-only --diff .
 
     - name: "Code format"
       before_install: skip
-      install: pip install -r requirements/dev.txt
+      install: pip install -r requirements/ci.txt
       before_script: skip
       script: black --check src --diff
 
     - name: "Code style"
       before_install: skip
-      install: pip install -r requirements/dev.txt
+      install: pip install -r requirements/ci.txt
       before_script: skip
       script: flake8 src
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,22 +57,19 @@ jobs:
 
     - name: "Code imports"
       before_install: skip
-      install:
-        - pip install isort
+      install: pip install -r requirements/dev.txt
       before_script: skip
-      script: isort --recursive --check-only --diff .
+      script: isort --check-only --diff .
 
     - name: "Code format"
       before_install: skip
-      install:
-        - pip install black
+      install: pip install -r requirements/dev.txt
       before_script: skip
       script: black --check src --diff
 
     - name: "Code style"
       before_install: skip
-      install:
-        - pip install flake8
+      install: pip install -r requirements/dev.txt
       before_script: skip
       script: flake8 src
 

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,10 +4,14 @@
 #
 #    pip-compile --no-index --output-file=requirements/ci.txt requirements/base.txt requirements/test-tools.in
 #
+appdirs==1.4.4            # via black
+attrs==19.3.0             # via black
 beautifulsoup4==4.8.1     # via webtest
+black==19.10b0            # via -r requirements/test-tools.in
 certifi==2018.4.16        # via -r requirements/base.txt, requests
 cffi==1.13.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
+click==7.1.2              # via black
 cmislib-maykin==0.7.4     # via -r requirements/base.txt, drc-cmis
 coreapi==2.3.3            # via -r requirements/base.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi, drf-yasg
@@ -47,24 +51,31 @@ drf-writable-nested==0.4.3  # via -r requirements/base.txt
 drf-yasg==1.16.0          # via -r requirements/base.txt, vng-api-common
 factory-boy==2.12.0       # via -r requirements/test-tools.in
 faker==2.0.1              # via factory-boy
+flake8==3.8.3             # via -r requirements/test-tools.in
 freezegun==0.3.12         # via -r requirements/test-tools.in
 gemma-zds-client==0.13.0  # via -r requirements/base.txt, vng-api-common, zgw-consumers
 httplib2==0.17.0          # via -r requirements/base.txt, cmislib-maykin
 humanize==0.5.1           # via -r requirements/base.txt
 idna==2.6                 # via -r requirements/base.txt, requests
+importlib-metadata==1.7.0  # via flake8
 inflection==0.3.1         # via -r requirements/base.txt, drf-yasg
 iso-639==0.4.5            # via -r requirements/base.txt, vng-api-common
 iso8601==0.1.12           # via -r requirements/base.txt, cmislib-maykin, drc-cmis
 isodate==0.6.0            # via -r requirements/base.txt, vng-api-common
+isort==5.0.7              # via -r requirements/test-tools.in
 itypes==1.1.0             # via -r requirements/base.txt, coreapi
 jinja2==2.10.1            # via -r requirements/base.txt, coreschema
 markdown==3.0.1           # via -r requirements/base.txt
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 maykin-django-better-admin-arrayfield==1.0.5  # via -r requirements/base.txt
+mccabe==0.6.1             # via flake8
 nlx-url-rewriter==0.1.2   # via -r requirements/base.txt
 oyaml==0.7                # via -r requirements/base.txt, vng-api-common
+pathspec==0.8.0           # via black
 psycopg2==2.8.4           # via -r requirements/base.txt
+pycodestyle==2.6.0        # via flake8
 pycparser==2.19           # via -r requirements/base.txt, cffi
+pyflakes==2.2.0           # via flake8
 pyjwt==1.6.4              # via -r requirements/base.txt, django-auth-adfs, gemma-zds-client, vng-api-common
 python-dateutil==2.7.3    # via -r requirements/base.txt, django-relativedelta, faker, freezegun
 python-decouple==3.1      # via -r requirements/base.txt
@@ -73,6 +84,7 @@ pytz==2019.1              # via -r requirements/base.txt, django, django-axes
 pyyaml==5.1               # via -r requirements/base.txt, gemma-zds-client, oyaml, vng-api-common
 raven==6.9.0              # via -r requirements/base.txt
 redis==3.3.8              # via -r requirements/base.txt, django-redis
+regex==2020.6.8           # via black
 requests-mock==1.6.0      # via -r requirements/test-tools.in
 requests==2.21.0          # via -r requirements/base.txt, coreapi, django-auth-adfs, gemma-zds-client, requests-mock, vng-api-common
 ruamel.yaml.clib==0.2.0   # via -r requirements/base.txt, ruamel.yaml
@@ -82,6 +94,8 @@ soupsieve==1.9.5          # via beautifulsoup4
 sqlparse==0.3.0           # via -r requirements/base.txt, django
 tblib==1.4.0              # via -r requirements/test-tools.in
 text-unidecode==1.2       # via faker
+toml==0.10.1              # via black
+typed-ast==1.4.1          # via black
 unidecode==1.0.22         # via -r requirements/base.txt, vng-api-common
 uritemplate==3.0.0        # via -r requirements/base.txt, coreapi, drf-yasg
 urllib3==1.24.3           # via -r requirements/base.txt, requests
@@ -91,3 +105,4 @@ waitress==1.4.3           # via webtest
 webob==1.8.5              # via webtest
 webtest==2.0.33           # via django-webtest
 zgw-consumers==0.8.1      # via -r requirements/base.txt
+zipp==3.1.0               # via importlib-metadata

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -3,8 +3,8 @@ bumpversion
 pip-tools
 
 # Code formatting
-black
 isort
+black
 flake8
 
 # Debug tooling

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -2,11 +2,6 @@
 bumpversion
 pip-tools
 
-# Code formatting
-isort
-black
-flake8
-
 # Debug tooling
 django-debug-toolbar
 django-extensions

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -58,10 +58,9 @@ drf-flex-fields==0.5.0    # via -r requirements/ci.txt
 drf-nested-routers==0.90.2  # via -r requirements/ci.txt, vng-api-common
 drf-writable-nested==0.4.3  # via -r requirements/ci.txt
 drf-yasg==1.16.0          # via -r requirements/ci.txt, vng-api-common
-entrypoints==0.3          # via flake8
 factory-boy==2.12.0       # via -r requirements/ci.txt
 faker==2.0.1              # via -r requirements/ci.txt, factory-boy
-flake8==3.7.9             # via -r requirements/dev.in
+flake8==3.8.3             # via -r requirements/dev.in
 freezegun==0.3.12         # via -r requirements/ci.txt
 gemma-zds-client==0.13.0  # via -r requirements/ci.txt, vng-api-common, zgw-consumers
 gprof2dot==2019.11.30     # via django-silk
@@ -69,11 +68,12 @@ httplib2==0.17.0          # via -r requirements/ci.txt, cmislib-maykin
 humanize==0.5.1           # via -r requirements/ci.txt
 idna==2.6                 # via -r requirements/ci.txt, requests
 imagesize==1.1.0          # via sphinx
+importlib-metadata==1.7.0  # via flake8
 inflection==0.3.1         # via -r requirements/ci.txt, drf-yasg
 iso-639==0.4.5            # via -r requirements/ci.txt, vng-api-common
 iso8601==0.1.12           # via -r requirements/ci.txt, cmislib-maykin, drc-cmis
 isodate==0.6.0            # via -r requirements/ci.txt, vng-api-common
-isort==4.3.21             # via -r requirements/dev.in
+isort==5.0.7              # via -r requirements/dev.in
 itypes==1.1.0             # via -r requirements/ci.txt, coreapi
 jinja2==2.10.1            # via -r requirements/ci.txt, coreschema, django-silk, sphinx
 markdown==3.0.1           # via -r requirements/ci.txt, sphinx-markdown-tables
@@ -86,9 +86,9 @@ packaging==19.2           # via sphinx
 pathspec==0.6.0           # via black
 pip-tools==5.1.2          # via -r requirements/dev.in
 psycopg2==2.8.4           # via -r requirements/ci.txt
-pycodestyle==2.5.0        # via autopep8, flake8
+pycodestyle==2.6.0        # via autopep8, flake8
 pycparser==2.19           # via -r requirements/ci.txt, cffi
-pyflakes==2.1.1           # via flake8
+pyflakes==2.2.0           # via flake8
 pygments==2.4.2           # via django-silk, sphinx
 pyjwt==1.6.4              # via -r requirements/ci.txt, django-auth-adfs, gemma-zds-client, vng-api-common
 pyparsing==2.4.2          # via packaging
@@ -132,6 +132,7 @@ webob==1.8.5              # via -r requirements/ci.txt, webtest
 webtest==2.0.33           # via -r requirements/ci.txt, django-webtest
 whitenoise==5.1.0         # via -r requirements/dev.in
 zgw-consumers==0.8.1      # via -r requirements/ci.txt
+zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,17 +5,17 @@
 #    pip-compile --no-index --output-file=requirements/dev.txt requirements/ci.txt requirements/dev.in
 #
 alabaster==0.7.12         # via sphinx
-appdirs==1.4.3            # via black
-attrs==19.1.0             # via black
+appdirs==1.4.4            # via -r requirements/ci.txt, black
+attrs==19.3.0             # via -r requirements/ci.txt, black
 autopep8==1.5.2           # via django-silk
 babel==2.7.0              # via sphinx
 beautifulsoup4==4.8.1     # via -r requirements/ci.txt, webtest
-black==19.10b0            # via -r requirements/dev.in
+black==19.10b0            # via -r requirements/ci.txt
 bumpversion==0.5.3        # via -r requirements/dev.in
 certifi==2018.4.16        # via -r requirements/ci.txt, requests
 cffi==1.13.2              # via -r requirements/ci.txt, cryptography
 chardet==3.0.4            # via -r requirements/ci.txt, requests
-click==7.0                # via black, pip-tools
+click==7.1.2              # via -r requirements/ci.txt, black, pip-tools
 cmislib-maykin==0.7.4     # via -r requirements/ci.txt, drc-cmis
 commonmark==0.9.1         # via recommonmark
 coreapi==2.3.3            # via -r requirements/ci.txt, drf-yasg
@@ -60,7 +60,7 @@ drf-writable-nested==0.4.3  # via -r requirements/ci.txt
 drf-yasg==1.16.0          # via -r requirements/ci.txt, vng-api-common
 factory-boy==2.12.0       # via -r requirements/ci.txt
 faker==2.0.1              # via -r requirements/ci.txt, factory-boy
-flake8==3.8.3             # via -r requirements/dev.in
+flake8==3.8.3             # via -r requirements/ci.txt
 freezegun==0.3.12         # via -r requirements/ci.txt
 gemma-zds-client==0.13.0  # via -r requirements/ci.txt, vng-api-common, zgw-consumers
 gprof2dot==2019.11.30     # via django-silk
@@ -68,27 +68,27 @@ httplib2==0.17.0          # via -r requirements/ci.txt, cmislib-maykin
 humanize==0.5.1           # via -r requirements/ci.txt
 idna==2.6                 # via -r requirements/ci.txt, requests
 imagesize==1.1.0          # via sphinx
-importlib-metadata==1.7.0  # via flake8
+importlib-metadata==1.7.0  # via -r requirements/ci.txt, flake8
 inflection==0.3.1         # via -r requirements/ci.txt, drf-yasg
 iso-639==0.4.5            # via -r requirements/ci.txt, vng-api-common
 iso8601==0.1.12           # via -r requirements/ci.txt, cmislib-maykin, drc-cmis
 isodate==0.6.0            # via -r requirements/ci.txt, vng-api-common
-isort==5.0.7              # via -r requirements/dev.in
+isort==5.0.7              # via -r requirements/ci.txt
 itypes==1.1.0             # via -r requirements/ci.txt, coreapi
 jinja2==2.10.1            # via -r requirements/ci.txt, coreschema, django-silk, sphinx
 markdown==3.0.1           # via -r requirements/ci.txt, sphinx-markdown-tables
 markupsafe==1.1.1         # via -r requirements/ci.txt, jinja2
 maykin-django-better-admin-arrayfield==1.0.5  # via -r requirements/ci.txt
-mccabe==0.6.1             # via flake8
+mccabe==0.6.1             # via -r requirements/ci.txt, flake8
 nlx-url-rewriter==0.1.2   # via -r requirements/ci.txt
 oyaml==0.7                # via -r requirements/ci.txt, vng-api-common
 packaging==19.2           # via sphinx
-pathspec==0.6.0           # via black
+pathspec==0.8.0           # via -r requirements/ci.txt, black
 pip-tools==5.1.2          # via -r requirements/dev.in
 psycopg2==2.8.4           # via -r requirements/ci.txt
-pycodestyle==2.6.0        # via autopep8, flake8
+pycodestyle==2.6.0        # via -r requirements/ci.txt, autopep8, flake8
 pycparser==2.19           # via -r requirements/ci.txt, cffi
-pyflakes==2.2.0           # via flake8
+pyflakes==2.2.0           # via -r requirements/ci.txt, flake8
 pygments==2.4.2           # via django-silk, sphinx
 pyjwt==1.6.4              # via -r requirements/ci.txt, django-auth-adfs, gemma-zds-client, vng-api-common
 pyparsing==2.4.2          # via packaging
@@ -100,7 +100,7 @@ pyyaml==5.1               # via -r requirements/ci.txt, gemma-zds-client, oyaml,
 raven==6.9.0              # via -r requirements/ci.txt
 recommonmark==0.6.0       # via -r requirements/dev.in
 redis==3.3.8              # via -r requirements/ci.txt, django-redis
-regex==2019.11.1          # via black
+regex==2020.6.8           # via -r requirements/ci.txt, black
 requests-mock==1.6.0      # via -r requirements/ci.txt
 requests==2.21.0          # via -r requirements/ci.txt, coreapi, django-auth-adfs, django-silk, gemma-zds-client, requests-mock, sphinx, vng-api-common
 ruamel.yaml.clib==0.2.0   # via -r requirements/ci.txt, ruamel.yaml
@@ -120,8 +120,8 @@ sphinxcontrib-serializinghtml==1.1.3  # via sphinx
 sqlparse==0.3.0           # via -r requirements/ci.txt, django, django-debug-toolbar, django-silk
 tblib==1.4.0              # via -r requirements/ci.txt
 text-unidecode==1.2       # via -r requirements/ci.txt, faker
-toml==0.10.0              # via black
-typed-ast==1.4.0          # via black
+toml==0.10.1              # via -r requirements/ci.txt, black
+typed-ast==1.4.1          # via -r requirements/ci.txt, black
 unidecode==1.0.22         # via -r requirements/ci.txt, vng-api-common
 uritemplate==3.0.0        # via -r requirements/ci.txt, coreapi, drf-yasg
 urllib3==1.24.3           # via -r requirements/ci.txt, requests
@@ -132,7 +132,7 @@ webob==1.8.5              # via -r requirements/ci.txt, webtest
 webtest==2.0.33           # via -r requirements/ci.txt, django-webtest
 whitenoise==5.1.0         # via -r requirements/dev.in
 zgw-consumers==0.8.1      # via -r requirements/ci.txt
-zipp==3.1.0               # via importlib-metadata
+zipp==3.1.0               # via -r requirements/ci.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test-tools.in
+++ b/requirements/test-tools.in
@@ -5,3 +5,8 @@ factory_boy
 freezegun
 requests-mock
 tblib
+
+# Code formatting
+isort
+black
+flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,10 +6,10 @@ line_length = 88
 multi_line_output = 3
 skip = env,node_modules
 skip_glob = **/migrations/**
-not_skip = __init__.py
 known_django = django
 known_first_party = openzaak
 sections = FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+ensure_newline_before_comments = true
 
 ; black compatible settings
 [flake8]


### PR DESCRIPTION
Fixes #638 

**Changes**

* pinned black, isort and flake8 in CI requirements
* removed deprecated options from isort in travis
