### PR TITLE
Bump django-sendfile2 and httplib

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -43,7 +43,7 @@ drf-nested-routers==0.90.2  # via vng-api-common
 drf-writable-nested==0.4.3  # via -r requirements/base.in
 drf-yasg==1.16.0          # via -r requirements/base.in, vng-api-common
 gemma-zds-client==0.13.0  # via vng-api-common, zgw-consumers
-httplib2==0.17.0          # via cmislib-maykin
+httplib2==0.18.1          # via cmislib-maykin
 humanize==0.5.1           # via -r requirements/base.in
 idna==2.6                 # via requests
 inflection==0.3.1         # via drf-yasg

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -30,7 +30,7 @@ django-ordered-model==2.1.0  # via django-admin-index
 django-privates==1.2.1    # via -r requirements/base.in
 django-redis==4.10.0      # via -r requirements/base.in
 django-relativedelta==1.0.5  # via -r requirements/base.in
-django-sendfile2==0.5.1   # via django-privates
+django-sendfile2==0.6.0   # via django-privates
 django-sniplates==0.7.0   # via -r requirements/base.in
 django-solo==1.1.3        # via django-auth-adfs-db, drc-cmis, vng-api-common, zgw-consumers
 django==2.2.10            # via -r requirements/base.in, django-auth-adfs, django-auth-adfs-db, django-choices, django-db-logger, django-extra-fields, django-extra-views, django-filter, django-loose-fk, django-markup, django-privates, django-redis, django-relativedelta, django-sendfile2, django-sniplates, drc-cmis, drf-nested-routers, drf-yasg, nlx-url-rewriter, vng-api-common, zgw-consumers

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -36,7 +36,7 @@ django-ordered-model==2.1.0  # via -r requirements/base.txt, django-admin-index
 django-privates==1.2.1    # via -r requirements/base.txt
 django-redis==4.10.0      # via -r requirements/base.txt
 django-relativedelta==1.0.5  # via -r requirements/base.txt
-django-sendfile2==0.5.1   # via -r requirements/base.txt, django-privates
+django-sendfile2==0.6.0   # via -r requirements/base.txt, django-privates
 django-sniplates==0.7.0   # via -r requirements/base.txt
 django-solo==1.1.3        # via -r requirements/base.txt, django-auth-adfs-db, drc-cmis, vng-api-common, zgw-consumers
 django-webtest==1.9.7     # via -r requirements/test-tools.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -54,7 +54,7 @@ faker==2.0.1              # via factory-boy
 flake8==3.8.3             # via -r requirements/test-tools.in
 freezegun==0.3.12         # via -r requirements/test-tools.in
 gemma-zds-client==0.13.0  # via -r requirements/base.txt, vng-api-common, zgw-consumers
-httplib2==0.17.0          # via -r requirements/base.txt, cmislib-maykin
+httplib2==0.18.1          # via -r requirements/base.txt, cmislib-maykin
 humanize==0.5.1           # via -r requirements/base.txt
 idna==2.6                 # via -r requirements/base.txt, requests
 importlib-metadata==1.7.0  # via flake8

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -64,7 +64,7 @@ flake8==3.8.3             # via -r requirements/ci.txt
 freezegun==0.3.12         # via -r requirements/ci.txt
 gemma-zds-client==0.13.0  # via -r requirements/ci.txt, vng-api-common, zgw-consumers
 gprof2dot==2019.11.30     # via django-silk
-httplib2==0.17.0          # via -r requirements/ci.txt, cmislib-maykin
+httplib2==0.18.1          # via -r requirements/ci.txt, cmislib-maykin
 humanize==0.5.1           # via -r requirements/ci.txt
 idna==2.6                 # via -r requirements/ci.txt, requests
 imagesize==1.1.0          # via sphinx

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -43,7 +43,7 @@ django-ordered-model==2.1.0  # via -r requirements/ci.txt, django-admin-index
 django-privates==1.2.1    # via -r requirements/ci.txt
 django-redis==4.10.0      # via -r requirements/ci.txt
 django-relativedelta==1.0.5  # via -r requirements/ci.txt
-django-sendfile2==0.5.1   # via -r requirements/ci.txt, django-privates
+django-sendfile2==0.6.0   # via -r requirements/ci.txt, django-privates
 django-silk==4.0.1        # via -r requirements/dev.in
 django-sniplates==0.7.0   # via -r requirements/ci.txt
 django-solo==1.1.3        # via -r requirements/ci.txt, django-auth-adfs-db, drc-cmis, vng-api-common, zgw-consumers


### PR DESCRIPTION
PR #634 and #630 fix security vulnerabilities in our depencies used. This PR bundles them using our pip-tools stack.