### PR TITLE
Relax Resultaat.afleidingswijze validation

### DIFF
--- a/src/openzaak/components/catalogi/admin/forms.py
+++ b/src/openzaak/components/catalogi/admin/forms.py
@@ -220,7 +220,8 @@ class ResultaatTypeForm(forms.ModelForm):
 
         # mapping ZTC -> selectielijst!
         backward_not_ok = (
-            afleidingswijze in REVERSE_MAPPING
+            procestermijn
+            and afleidingswijze in REVERSE_MAPPING
             and REVERSE_MAPPING[afleidingswijze] != procestermijn
         )
         if backward_not_ok:


### PR DESCRIPTION
Fixes #520

**Changes**

The upstream standard relaxed validation in case that no 'procestermijn' is
specified for a given Selectielijst resultaat, see
https://github.com/VNG-Realisatie/gemma-zaken/pull/1596/files.

This patch relaxes that validation in the Open Zaak admin.

The API aspect of this change was already implemented in 6e38b865c.

