### PR TITLE
Bump deployment dependencies

### DIFF
--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -4,42 +4,38 @@
 #
 #    pip-compile --no-index requirements.in
 #
-ansible==2.9.2
-attrs==19.3.0             # via jsonschema
-cachetools==3.1.1         # via google-auth
-certifi==2019.9.11        # via kubernetes, requests
-cffi==1.13.0              # via cryptography
+ansible==2.9.13           # via -r requirements.in
+attrs==20.2.0             # via jsonschema
+cachetools==4.1.1         # via google-auth
+certifi==2020.6.20        # via kubernetes, requests
+cffi==1.14.2              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==2.8         # via ansible
-dictdiffer==0.8.0         # via openshift
-google-auth==1.6.3        # via kubernetes
-idna==2.8                 # via requests
-importlib-metadata==0.23  # via jsonschema
-jinja2==2.10.3            # via ansible, openshift
-jsonschema==3.1.1         # via kubernetes-validate
-kubernetes-validate==1.16.0
-kubernetes==9.0.1         # via openshift
+cryptography==3.1         # via ansible
+google-auth==1.21.2       # via kubernetes
+idna==2.10                # via requests
+jinja2==2.11.2            # via ansible, openshift
+jsonschema==3.2.0         # via kubernetes-validate
+kubernetes-validate==1.18.0  # via -r requirements.in
+kubernetes==11.0.0        # via openshift
 markupsafe==1.1.1         # via jinja2
-more-itertools==7.2.0     # via zipp
 oauthlib==3.1.0           # via requests-oauthlib
-openshift==0.9.2
-passlib==1.7.1
-pyasn1-modules==0.2.7     # via google-auth
-pyasn1==0.4.7             # via pyasn1-modules, rsa
-pycparser==2.19           # via cffi
-pyrsistent==0.15.4        # via jsonschema
-python-dateutil==2.8.0    # via kubernetes
-python-string-utils==0.6.0  # via openshift
-pyyaml==5.1.2
-requests-oauthlib==1.2.0  # via kubernetes
-requests==2.22.0          # via kubernetes, requests-oauthlib
-rsa==4.0                  # via google-auth
-ruamel.yaml.clib==0.2.0   # via ruamel.yaml
-ruamel.yaml==0.16.5       # via openshift
-six==1.12.0               # via cryptography, google-auth, jsonschema, kubernetes, openshift, pyrsistent, python-dateutil, websocket-client
-urllib3==1.25.6           # via kubernetes, requests
-websocket-client==0.56.0  # via kubernetes
-zipp==0.6.0               # via importlib-metadata
+openshift==0.11.2         # via -r requirements.in
+passlib==1.7.2            # via -r requirements.in
+pyasn1-modules==0.2.8     # via google-auth
+pyasn1==0.4.8             # via pyasn1-modules, rsa
+pycparser==2.20           # via cffi
+pyrsistent==0.17.3        # via jsonschema
+python-dateutil==2.8.1    # via kubernetes
+python-string-utils==1.0.0  # via openshift
+pyyaml==5.3.1             # via -r requirements.in, ansible, kubernetes, kubernetes-validate
+requests-oauthlib==1.3.0  # via kubernetes
+requests==2.24.0          # via kubernetes, requests-oauthlib
+rsa==4.6                  # via google-auth
+ruamel.yaml.clib==0.2.2   # via ruamel.yaml
+ruamel.yaml==0.16.12      # via openshift
+six==1.15.0               # via cryptography, google-auth, jsonschema, kubernetes, openshift, python-dateutil, websocket-client
+urllib3==1.25.10          # via kubernetes, requests
+websocket-client==0.57.0  # via kubernetes
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==44.0.0        # via jsonschema, kubernetes
+# setuptools

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -13,3 +13,7 @@ sphinx
 sphinx_rtd_theme
 recommonmark
 sphinx-markdown-tables
+
+# Deployment
+
+-r ../deployment/requirements.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,14 +5,16 @@
 #    pip-compile --no-index --output-file=requirements/dev.txt requirements/ci.txt requirements/dev.in
 #
 alabaster==0.7.12         # via sphinx
+ansible==2.9.13           # via -r requirements/../deployment/requirements.in
 appdirs==1.4.4            # via -r requirements/ci.txt, black
-attrs==19.3.0             # via -r requirements/ci.txt, black
+attrs==19.3.0             # via -r requirements/ci.txt, black, jsonschema
 autopep8==1.5.2           # via django-silk
 babel==2.7.0              # via sphinx
 beautifulsoup4==4.8.1     # via -r requirements/ci.txt, webtest
 black==19.10b0            # via -r requirements/ci.txt
 bumpversion==0.5.3        # via -r requirements/dev.in
-certifi==2018.4.16        # via -r requirements/ci.txt, requests, sentry-sdk
+cachetools==4.1.1         # via google-auth
+certifi==2018.4.16        # via -r requirements/ci.txt, kubernetes, requests, sentry-sdk
 cffi==1.13.2              # via -r requirements/ci.txt, cryptography
 chardet==3.0.4            # via -r requirements/ci.txt, requests
 click==7.1.2              # via -r requirements/ci.txt, black, pip-tools
@@ -21,7 +23,7 @@ commonmark==0.9.1         # via recommonmark
 coreapi==2.3.3            # via -r requirements/ci.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/ci.txt, coreapi, drf-yasg
 coverage==4.5.4           # via -r requirements/ci.txt
-cryptography==2.8         # via -r requirements/ci.txt, django-auth-adfs
+cryptography==2.8         # via -r requirements/ci.txt, ansible, django-auth-adfs
 dictdiffer==0.8.0         # via -r requirements/ci.txt
 django-admin-index==1.2.2  # via -r requirements/ci.txt
 django-appconf==1.0.2     # via -r requirements/ci.txt, django-axes
@@ -65,6 +67,7 @@ freezegun==0.3.12         # via -r requirements/ci.txt
 gemma-zds-client==0.13.0  # via -r requirements/ci.txt, vng-api-common, zgw-consumers
 gitdb==4.0.5              # via -r requirements/ci.txt, gitpython
 gitpython==3.1.7          # via -r requirements/ci.txt
+google-auth==1.21.2       # via kubernetes
 gprof2dot==2019.11.30     # via django-silk
 httplib2==0.18.1          # via -r requirements/ci.txt, cmislib-maykin
 humanize==0.5.1           # via -r requirements/ci.txt
@@ -76,36 +79,48 @@ iso8601==0.1.12           # via -r requirements/ci.txt, cmislib-maykin, drc-cmis
 isodate==0.6.0            # via -r requirements/ci.txt, vng-api-common
 isort==5.0.7              # via -r requirements/ci.txt
 itypes==1.1.0             # via -r requirements/ci.txt, coreapi
-jinja2==2.10.1            # via -r requirements/ci.txt, coreschema, django-silk, sphinx
+jinja2==2.10.1            # via -r requirements/ci.txt, ansible, coreschema, django-silk, openshift, sphinx
+jsonschema==3.2.0         # via kubernetes-validate
+kubernetes-validate==1.18.0  # via -r requirements/../deployment/requirements.in
+kubernetes==11.0.0        # via openshift
 markdown==3.0.1           # via -r requirements/ci.txt, sphinx-markdown-tables
 markupsafe==1.1.1         # via -r requirements/ci.txt, jinja2
 maykin-django-better-admin-arrayfield==1.0.5  # via -r requirements/ci.txt
 mccabe==0.6.1             # via -r requirements/ci.txt, flake8
 nlx-url-rewriter==0.1.2   # via -r requirements/ci.txt
+oauthlib==3.1.0           # via requests-oauthlib
+openshift==0.11.2         # via -r requirements/../deployment/requirements.in
 oyaml==0.7                # via -r requirements/ci.txt, vng-api-common
 packaging==19.2           # via sphinx
+passlib==1.7.2            # via -r requirements/../deployment/requirements.in
 pathspec==0.8.0           # via -r requirements/ci.txt, black
 pip-tools==5.1.2          # via -r requirements/dev.in
 psycopg2==2.8.4           # via -r requirements/ci.txt
+pyasn1-modules==0.2.8     # via google-auth
+pyasn1==0.4.8             # via pyasn1-modules, rsa
 pycodestyle==2.6.0        # via -r requirements/ci.txt, autopep8, flake8
 pycparser==2.19           # via -r requirements/ci.txt, cffi
 pyflakes==2.2.0           # via -r requirements/ci.txt, flake8
 pygments==2.4.2           # via django-silk, sphinx
 pyjwt==1.6.4              # via -r requirements/ci.txt, django-auth-adfs, gemma-zds-client, vng-api-common
 pyparsing==2.4.2          # via packaging
-python-dateutil==2.7.3    # via -r requirements/ci.txt, django-relativedelta, django-silk, faker, freezegun
+pyrsistent==0.17.3        # via jsonschema
+python-dateutil==2.7.3    # via -r requirements/ci.txt, django-relativedelta, django-silk, faker, freezegun, kubernetes
 python-decouple==3.1      # via -r requirements/ci.txt
 python-dotenv==0.8.2      # via -r requirements/ci.txt
+python-string-utils==1.0.0  # via openshift
 pytz==2019.1              # via -r requirements/ci.txt, babel, django, django-axes, django-silk
-pyyaml==5.1               # via -r requirements/ci.txt, gemma-zds-client, oyaml, vng-api-common
+pyyaml==5.1               # via -r requirements/../deployment/requirements.in, -r requirements/ci.txt, ansible, gemma-zds-client, kubernetes, kubernetes-validate, oyaml, vng-api-common
 recommonmark==0.6.0       # via -r requirements/dev.in
 redis==3.3.8              # via -r requirements/ci.txt, django-redis
 regex==2020.6.8           # via -r requirements/ci.txt, black
 requests-mock==1.6.0      # via -r requirements/ci.txt
-requests==2.21.0          # via -r requirements/ci.txt, coreapi, django-auth-adfs, django-silk, gemma-zds-client, requests-mock, sphinx, vng-api-common
-ruamel.yaml==0.16.7       # via -r requirements/ci.txt, drf-yasg
+requests-oauthlib==1.3.0  # via kubernetes
+requests==2.21.0          # via -r requirements/ci.txt, coreapi, django-auth-adfs, django-silk, gemma-zds-client, kubernetes, requests-mock, requests-oauthlib, sphinx, vng-api-common
+rsa==4.6                  # via google-auth
+ruamel.yaml==0.16.7       # via -r requirements/ci.txt, drf-yasg, openshift
 sentry-sdk==0.16.5        # via -r requirements/ci.txt
-six==1.11.0               # via -r requirements/ci.txt, cmislib-maykin, cryptography, django-extensions, django-extra-views, django-markup, drf-yasg, faker, freezegun, isodate, packaging, pip-tools, python-dateutil, requests-mock, webtest
+six==1.11.0               # via -r requirements/ci.txt, cmislib-maykin, cryptography, django-extensions, django-extra-views, django-markup, drf-yasg, faker, freezegun, google-auth, isodate, jsonschema, kubernetes, openshift, packaging, pip-tools, python-dateutil, requests-mock, websocket-client, webtest
 smmap==3.0.4              # via -r requirements/ci.txt, gitdb
 snowballstemmer==2.0.0    # via sphinx
 soupsieve==1.9.5          # via -r requirements/ci.txt, beautifulsoup4
@@ -125,11 +140,12 @@ toml==0.10.1              # via -r requirements/ci.txt, black
 typed-ast==1.4.1          # via -r requirements/ci.txt, black
 unidecode==1.0.22         # via -r requirements/ci.txt, vng-api-common
 uritemplate==3.0.0        # via -r requirements/ci.txt, coreapi, drf-yasg
-urllib3==1.24.3           # via -r requirements/ci.txt, requests, sentry-sdk
+urllib3==1.24.3           # via -r requirements/ci.txt, kubernetes, requests, sentry-sdk
 uwsgi==2.0.18             # via -r requirements/ci.txt
 vng-api-common==1.0.47    # via -r requirements/ci.txt, drc-cmis
 waitress==1.4.3           # via -r requirements/ci.txt, webtest
 webob==1.8.5              # via -r requirements/ci.txt, webtest
+websocket-client==0.57.0  # via kubernetes
 webtest==2.0.33           # via -r requirements/ci.txt, django-webtest
 whitenoise==5.1.0         # via -r requirements/dev.in
 zgw-consumers==0.8.1      # via -r requirements/ci.txt


### PR DESCRIPTION
Latest Ansible & Kubernetes package versions.

**Changes**

* Updated the packaged/bundled deployment deps to latest minor/patch releases
* Deployed Open Zaak 1.3.1 to https://test.openzaak.nl
* Included deployment deps into `requirements/dev.in` so we get all dev and deployment deps in `requirements/dev.txt`

