### PR TITLE
Issue 608 upload binary file gives 500

### DIFF
--- a/src/openzaak/components/documenten/api/serializers.py
+++ b/src/openzaak/components/documenten/api/serializers.py
@@ -66,7 +66,8 @@ class AnyBase64File(Base64FileField):
             return super().to_internal_value(base64_data)
         except Exception:
             try:
-                b64decode(base64_data)
+                # If validate is False, no check is done to see if the data contains non base-64 alphabet characters
+                b64decode(base64_data, validate=True)
             except binascii.Error as e:
                 if str(e) == "Incorrect padding":
                     raise ValidationError(

--- a/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject.py
+++ b/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject.py
@@ -386,6 +386,31 @@ class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APITestCase):
 
         self.assertEqual(error["code"], "invalid")
 
+    def test_inhoud_invalid_utf8_char_not_b64_encoded(self):
+        informatieobjecttype = InformatieObjectTypeFactory.create(concept=False)
+        informatieobjecttype_url = reverse(informatieobjecttype)
+        content = {
+            "identificatie": uuid.uuid4().hex,
+            "bronorganisatie": "159351741",
+            "creatiedatum": "2018-06-27",
+            "titel": "detailed summary",
+            "auteur": "test_auteur",
+            "formaat": "txt",
+            "taal": "eng",
+            "bestandsnaam": "dummy.txt",
+            "inhoud": "<",
+            "link": "http://een.link",
+            "beschrijving": "test_beschrijving",
+            "informatieobjecttype": f"http://testserver{informatieobjecttype_url}",
+            "vertrouwelijkheidaanduiding": "openbaar",
+        }
+
+        # Send to the API
+        response = self.client.post(self.list_url, content)
+
+        # Test response
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
 
 @override_settings(SENDFILE_BACKEND="django_sendfile.backends.simple")
 class EnkelvoudigInformatieObjectVersionHistoryAPITests(JWTAuthMixin, APITestCase):


### PR DESCRIPTION
Fixes #608 

**Changes**
`b64decode(base64_data)` => `b64decode(base64_data, validate=True)`

From the `base64` documentation:

>     If validate is False (the default), characters that are neither in the
>     normal base-64 alphabet nor the alternative alphabet are discarded prior
>     to the padding check.  If validate is True, these non-alphabet characters
>     in the input result in a binascii.Error. 

So, if the `inhoud` contained a single `>` character, this was removed (the content became empty) and this caused an error.


