### PR TITLE
Issue 685 eigenschap specificatie validatie inconsistent

### DIFF
--- a/src/openzaak/components/catalogi/api/serializers/eigenschap.py
+++ b/src/openzaak/components/catalogi/api/serializers/eigenschap.py
@@ -21,6 +21,11 @@ class EigenschapSpecificatieSerializer(serializers.ModelSerializer):
         value_display_mapping = add_choice_values_help_text(FormaatChoices)
         self.fields["formaat"].help_text += f"\n\n{value_display_mapping}"
 
+    def validate(self, attrs):
+        instance = EigenschapSpecificatie(**attrs)
+        instance.clean()
+        return attrs
+
 
 class EigenschapSerializer(
     NestedCreateMixin, NestedUpdateMixin, serializers.HyperlinkedModelSerializer

--- a/src/openzaak/components/catalogi/models/eigenschap.py
+++ b/src/openzaak/components/catalogi/models/eigenschap.py
@@ -93,9 +93,8 @@ class EigenschapSpecificatie(models.Model):
                 )
 
         elif self.formaat == FormaatChoices.getal:
-            # specificatie spreekt over kommagescheiden decimaal, wij nemen echter aan dat het punt gescheiden is
             try:
-                Decimal(self.lengte)
+                Decimal(self.lengte.replace(",", "."))
             except (InvalidOperation, TypeError):
                 raise ValidationError(
                     _(

--- a/src/openzaak/components/catalogi/tests/admin/test_eigenschap_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_eigenschap_admin.py
@@ -6,6 +6,7 @@ from django_webtest import WebTest
 
 from openzaak.accounts.tests.factories import SuperUserFactory
 
+from ...models import EigenschapSpecificatie
 from ..factories import EigenschapSpecificatieFactory
 
 
@@ -36,3 +37,15 @@ class EigenschapSpecificatieAdminTests(WebTest):
 
         # Assert that the comma is still in place
         self.assertEqual(specificatie.waardenverzameling, ["some,comma", "bla"])
+
+    def test_validation_length_comma_separated(self):
+        form = self.app.get(reverse("admin:catalogi_eigenschapspecificatie_add")).form
+
+        form["formaat"] = "getal"
+        form["lengte"] = "5,3"
+        form["kardinaliteit"] = "1"
+        form["waardenverzameling"] = "Waarden"
+        form.submit()
+
+        new_specificatie = EigenschapSpecificatie.objects.get()
+        self.assertEqual(new_specificatie.lengte, "5,3")


### PR DESCRIPTION
Fixes #685 

**Changes**
During validation of the `lengte` a dot was expected instead of a comma. The replacement of the comma for validation by `Decimal` was added.



