### PR TITLE
Fixes 584 download non existing EIO causes 500 error

### DIFF
--- a/src/openzaak/components/documenten/api/renderers.py
+++ b/src/openzaak/components/documenten/api/renderers.py
@@ -10,4 +10,9 @@ class BinaryFileRenderer(BaseRenderer):
     render_style = "binary"
 
     def render(self, data, media_type=None, renderer_context=None):
+        # When trying to download a non-existing file, `data` contains a string instead of binary data.
+        # The string needs to be encoded as UTF-8, or it will be coerced into a bytestring using self.charset,
+        # which will cause an error (issue #584)
+        if isinstance(data, str):
+            return data.encode("utf-8")
         return data

--- a/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject.py
+++ b/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject.py
@@ -411,6 +411,23 @@ class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APITestCase):
         # Test response
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_download_deleted_eio(self):
+        eio = EnkelvoudigInformatieObjectFactory.create(
+            beschrijving="beschrijving1", inhoud__data=b"inhoud1"
+        )
+
+        eio_url = get_operation_url(
+            "enkelvoudiginformatieobject_download", uuid=eio.uuid
+        )
+
+        response = self.client.delete(reverse(eio))
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        response = self.client.get(eio_url, HTTP_ACCEPT="application/octet-stream")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
 
 @override_settings(SENDFILE_BACKEND="django_sendfile.backends.simple")
 class EnkelvoudigInformatieObjectVersionHistoryAPITests(JWTAuthMixin, APITestCase):

--- a/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject_cmis.py
@@ -405,6 +405,23 @@ class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APICMISTestCase, OioMixi
 
         self.assertEqual(error["code"], "invalid")
 
+    def test_download_deleted_eio(self):
+        eio = EnkelvoudigInformatieObjectFactory.create(
+            beschrijving="beschrijving1", inhoud__data=b"inhoud1"
+        )
+
+        eio_url = get_operation_url(
+            "enkelvoudiginformatieobject_download", uuid=eio.uuid
+        )
+
+        response = self.client.delete(reverse(eio))
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        response = self.client.get(eio_url, HTTP_ACCEPT="application/octet-stream")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
 
 @tag("cmis")
 @override_settings(CMIS_ENABLED=True)


### PR DESCRIPTION
Fixes #584 

**Changes**
Added a check for when strings are passed to the `BinaryFileRenderer`

In the case where there is an error response and the renderer is `BinaryFileRenderer`, the response content is a string rather than binary data. If a renderer returns a string, the `Response` class attempts to encode it using the specified charset. 
In the `BinaryFileRenderer` the charset is set to `None`, so this caused an error.
Now, inside `BinaryFileRenderer` there is a check for string responses, which are then encoded to UTF-8.


