### PR TITLE
Feature/issue 732 extra zaken filter

### DIFF
--- a/src/openzaak/components/zaken/api/filters.py
+++ b/src/openzaak/components/zaken/api/filters.py
@@ -35,6 +35,10 @@ class ZaakFilter(FilterSet):
         field_name="rol__medewerker__identificatie",
         help_text=get_help_text("zaken.Medewerker", "identificatie"),
     )
+    rol__betrokkene_identificatie__organisatorische_eenheid__identificatie = filters.CharFilter(
+        field_name="rol__organisatorischeeenheid__identificatie",
+        help_text=get_help_text("zaken.OrganisatorischeEenheid", "identificatie"),
+    )
 
     class Meta:
         model = Zaak

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -4301,6 +4301,12 @@ paths:
         required: false
         schema:
           type: string
+      - name: rol__betrokkeneIdentificatie__organisatorischeEenheid__identificatie
+        in: query
+        description: Een korte identificatie van de organisatorische eenheid.
+        required: false
+        schema:
+          type: string
       - name: ordering
         in: query
         description: Which field to use when ordering the results.
@@ -9663,6 +9669,11 @@ components:
         rol__betrokkeneIdentificatie__medewerker__identificatie:
           title: Rol  betrokkeneidentificatie  medewerker  identificatie
           description: Een korte unieke aanduiding van de MEDEWERKER.
+          type: string
+          minLength: 1
+        rol__betrokkeneIdentificatie__organisatorischeEenheid__identificatie:
+          title: Rol  betrokkeneidentificatie  organisatorischeeenheid  identificatie
+          description: Een korte identificatie van de organisatorische eenheid.
           type: string
           minLength: 1
         ordering:

--- a/src/openzaak/components/zaken/swagger2.0.json
+++ b/src/openzaak/components/zaken/swagger2.0.json
@@ -5120,6 +5120,13 @@
                         "type": "string"
                     },
                     {
+                        "name": "rol__betrokkeneIdentificatie__organisatorischeEenheid__identificatie",
+                        "in": "query",
+                        "description": "Een korte identificatie van de organisatorische eenheid.",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
                         "name": "ordering",
                         "in": "query",
                         "description": "Which field to use when ordering the results.",
@@ -11310,6 +11317,12 @@
                 "rol__betrokkeneIdentificatie__medewerker__identificatie": {
                     "title": "Rol  betrokkeneidentificatie  medewerker  identificatie",
                     "description": "Een korte unieke aanduiding van de MEDEWERKER.",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "rol__betrokkeneIdentificatie__organisatorischeEenheid__identificatie": {
+                    "title": "Rol  betrokkeneidentificatie  organisatorischeeenheid  identificatie",
+                    "description": "Een korte identificatie van de organisatorische eenheid.",
                     "type": "string",
                     "minLength": 1
                 },

--- a/src/openzaak/components/zaken/tests/test_zaken.py
+++ b/src/openzaak/components/zaken/tests/test_zaken.py
@@ -36,7 +36,7 @@ from ..api.scopes import (
     SCOPEN_ZAKEN_HEROPENEN,
 )
 from ..constants import BetalingsIndicatie
-from ..models import Medewerker, NatuurlijkPersoon, Zaak
+from ..models import Medewerker, NatuurlijkPersoon, OrganisatorischeEenheid, Zaak
 from .constants import POLYGON_AMSTERDAM_CENTRUM
 from .factories import RolFactory, StatusFactory, ZaakFactory
 from .utils import (
@@ -888,6 +888,41 @@ class ZakenWerkVoorraadTests(JWTAuthMixin, APITestCase):
                 url,
                 {
                     "rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn": "129117729"
+                },
+                **ZAAK_READ_KWARGS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 1)
+
+    def test_rol_organisatorische_eenheid_identificatie(self):
+        """
+        Test filter zaken on betrokkeneIdentificatie for Organisatorische Eenheid.
+        """
+        url = reverse(Zaak)
+        rol = RolFactory.create(
+            betrokkene_type=RolTypes.organisatorische_eenheid,
+            omschrijving_generiek=RolOmschrijving.behandelaar,
+        )
+        OrganisatorischeEenheid.objects.create(identificatie="OE1", rol=rol)
+
+        with self.subTest(expected="no-match"):
+            response = self.client.get(
+                url,
+                {
+                    "rol__betrokkeneIdentificatie__organisatorischeEenheid__identificatie": "123"
+                },
+                **ZAAK_READ_KWARGS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 0)
+
+        with self.subTest(expected="match"):
+            response = self.client.get(
+                url,
+                {
+                    "rol__betrokkeneIdentificatie__organisatorischeEenheid__identificatie": "OE1"
                 },
                 **ZAAK_READ_KWARGS,
             )


### PR DESCRIPTION
Fixes #732

Upstream: https://github.com/VNG-Realisatie/gemma-zaken/issues/1686

**Changes**

* Added the `rol__betrokkeneIdentificatie__organisatorischeEenheid__identificatie` filter to the zaken list endpoint

