### PR TITLE
Fixes #738 -- remove the need for vng_api_common.APICredential records

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,7 @@ django-markup==1.3        # via -r requirements/base.in
 django-ordered-model==2.1.0  # via django-admin-index
 django-privates==1.2.1    # via -r requirements/base.in
 django-redis==4.10.0      # via -r requirements/base.in
-django-relativedelta==1.0.5  # via -r requirements/base.in
+django-relativedelta==1.0.5  # via -r requirements/base.in, zgw-consumers
 django-sendfile2==0.6.0   # via django-privates
 django-sniplates==0.7.0   # via -r requirements/base.in
 django-solo==1.1.3        # via django-auth-adfs-db, drc-cmis, vng-api-common, zgw-consumers
@@ -68,7 +68,7 @@ python-dotenv==0.8.2      # via -r requirements/base.in
 pytz==2019.1              # via django, django-axes
 pyyaml==5.1               # via gemma-zds-client, oyaml, vng-api-common
 redis==3.3.8              # via django-redis
-requests==2.21.0          # via -r requirements/base.in, coreapi, django-auth-adfs, gemma-zds-client, vng-api-common
+requests==2.21.0          # via -r requirements/base.in, coreapi, django-auth-adfs, gemma-zds-client, vng-api-common, zgw-consumers
 ruamel.yaml==0.16.7       # via drf-yasg
 sentry-sdk==0.16.5        # via -r requirements/base.in
 six==1.11.0               # via cmislib-maykin, cryptography, django-extra-views, django-markup, drf-yasg, isodate, python-dateutil
@@ -78,5 +78,5 @@ unidecode==1.0.22         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via requests, sentry-sdk
 uwsgi==2.0.18             # via -r requirements/base.in
-vng-api-common==1.0.47    # via -r requirements/base.in, drc-cmis
+vng-api-common==1.0.52    # via -r requirements/base.in, drc-cmis
 zgw-consumers==0.12.2     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -35,7 +35,7 @@ django-markup==1.3        # via -r requirements/base.txt
 django-ordered-model==2.1.0  # via -r requirements/base.txt, django-admin-index
 django-privates==1.2.1    # via -r requirements/base.txt
 django-redis==4.10.0      # via -r requirements/base.txt
-django-relativedelta==1.0.5  # via -r requirements/base.txt
+django-relativedelta==1.0.5  # via -r requirements/base.txt, zgw-consumers
 django-sendfile2==0.6.0   # via -r requirements/base.txt, django-privates
 django-sniplates==0.7.0   # via -r requirements/base.txt
 django-solo==1.1.3        # via -r requirements/base.txt, django-auth-adfs-db, drc-cmis, vng-api-common, zgw-consumers
@@ -86,7 +86,7 @@ pyyaml==5.1               # via -r requirements/base.txt, gemma-zds-client, oyam
 redis==3.3.8              # via -r requirements/base.txt, django-redis
 regex==2020.6.8           # via black
 requests-mock==1.6.0      # via -r requirements/test-tools.in
-requests==2.21.0          # via -r requirements/base.txt, coreapi, django-auth-adfs, gemma-zds-client, requests-mock, vng-api-common
+requests==2.21.0          # via -r requirements/base.txt, coreapi, django-auth-adfs, gemma-zds-client, requests-mock, vng-api-common, zgw-consumers
 ruamel.yaml==0.16.7       # via -r requirements/base.txt, drf-yasg
 sentry-sdk==0.16.5        # via -r requirements/base.txt
 six==1.11.0               # via -r requirements/base.txt, cmislib-maykin, cryptography, django-extra-views, django-markup, drf-yasg, faker, freezegun, isodate, python-dateutil, requests-mock, webtest
@@ -101,7 +101,7 @@ unidecode==1.0.22         # via -r requirements/base.txt, vng-api-common
 uritemplate==3.0.0        # via -r requirements/base.txt, coreapi, drf-yasg
 urllib3==1.24.3           # via -r requirements/base.txt, requests, sentry-sdk
 uwsgi==2.0.18             # via -r requirements/base.txt
-vng-api-common==1.0.47    # via -r requirements/base.txt, drc-cmis
+vng-api-common==1.0.52    # via -r requirements/base.txt, drc-cmis
 waitress==1.4.3           # via webtest
 webob==1.8.5              # via webtest
 webtest==2.0.33           # via django-webtest

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -44,7 +44,7 @@ django-markup==1.3        # via -r requirements/ci.txt
 django-ordered-model==2.1.0  # via -r requirements/ci.txt, django-admin-index
 django-privates==1.2.1    # via -r requirements/ci.txt
 django-redis==4.10.0      # via -r requirements/ci.txt
-django-relativedelta==1.0.5  # via -r requirements/ci.txt
+django-relativedelta==1.0.5  # via -r requirements/ci.txt, zgw-consumers
 django-sendfile2==0.6.0   # via -r requirements/ci.txt, django-privates
 django-silk==4.0.1        # via -r requirements/dev.in
 django-sniplates==0.7.0   # via -r requirements/ci.txt
@@ -116,7 +116,7 @@ redis==3.3.8              # via -r requirements/ci.txt, django-redis
 regex==2020.6.8           # via -r requirements/ci.txt, black
 requests-mock==1.6.0      # via -r requirements/ci.txt
 requests-oauthlib==1.3.0  # via kubernetes
-requests==2.21.0          # via -r requirements/ci.txt, coreapi, django-auth-adfs, django-silk, gemma-zds-client, kubernetes, requests-mock, requests-oauthlib, sphinx, vng-api-common
+requests==2.21.0          # via -r requirements/ci.txt, coreapi, django-auth-adfs, django-silk, gemma-zds-client, kubernetes, requests-mock, requests-oauthlib, sphinx, vng-api-common, zgw-consumers
 rsa==4.6                  # via google-auth
 ruamel.yaml==0.16.7       # via -r requirements/ci.txt, drf-yasg, openshift
 sentry-sdk==0.16.5        # via -r requirements/ci.txt
@@ -142,7 +142,7 @@ unidecode==1.0.22         # via -r requirements/ci.txt, vng-api-common
 uritemplate==3.0.0        # via -r requirements/ci.txt, coreapi, drf-yasg
 urllib3==1.24.3           # via -r requirements/ci.txt, kubernetes, requests, sentry-sdk
 uwsgi==2.0.18             # via -r requirements/ci.txt
-vng-api-common==1.0.47    # via -r requirements/ci.txt, drc-cmis
+vng-api-common==1.0.52    # via -r requirements/ci.txt, drc-cmis
 waitress==1.4.3           # via -r requirements/ci.txt, webtest
 webob==1.8.5              # via -r requirements/ci.txt, webtest
 websocket-client==0.57.0  # via kubernetes

--- a/src/openzaak/components/besluiten/tests/test_notifications_kanaal.py
+++ b/src/openzaak/components/besluiten/tests/test_notifications_kanaal.py
@@ -15,17 +15,21 @@ from ..models import Besluit
 
 @override_settings(IS_HTTPS=True)
 class CreateNotifKanaalTestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
         site = Site.objects.get_current()
         site.domain = "example.com"
         site.save()
 
-    @patch("zds_client.Client")
-    def test_kanaal_create_with_name(self, mock_client):
+    @patch(
+        "vng_api_common.notifications.management.commands.register_kanaal.get_client"
+    )
+    def test_kanaal_create_with_name(self, mock_get_client):
         """
         Test is request to create kanaal is send with specified kanaal name
         """
-        client = mock_client.from_url.return_value
+        client = mock_get_client.return_value
         client.list.return_value = []
         # ensure this is added to the registry
         Kanaal(label="kanaal_test", main_resource=Besluit)
@@ -47,13 +51,15 @@ class CreateNotifKanaalTestCase(APITestCase):
             },
         )
 
-    @patch("zds_client.Client")
+    @patch(
+        "vng_api_common.notifications.management.commands.register_kanaal.get_client"
+    )
     @override_settings(NOTIFICATIONS_KANAAL="dummy-kanaal")
-    def test_kanaal_create_without_name(self, mock_client):
+    def test_kanaal_create_without_name(self, mock_get_client):
         """
         Test is request to create kanaal is send with default kanaal name
         """
-        client = mock_client.from_url.return_value
+        client = mock_get_client.return_value
         client.list.return_value = []
         # ensure this is added to the registry
         Kanaal(label="dummy-kanaal", main_resource=Besluit)

--- a/src/openzaak/components/documenten/tests/test_notifications_kanaal.py
+++ b/src/openzaak/components/documenten/tests/test_notifications_kanaal.py
@@ -15,17 +15,21 @@ from ..models import EnkelvoudigInformatieObject
 
 @override_settings(IS_HTTPS=True)
 class CreateNotifKanaalTestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
         site = Site.objects.get_current()
         site.domain = "example.com"
         site.save()
 
-    @patch("zds_client.Client")
-    def test_kanaal_create_with_name(self, mock_client):
+    @patch(
+        "vng_api_common.notifications.management.commands.register_kanaal.get_client"
+    )
+    def test_kanaal_create_with_name(self, mock_get_client):
         """
         Test is request to create kanaal is send with specified kanaal name
         """
-        client = mock_client.from_url.return_value
+        client = mock_get_client.return_value
         client.list.return_value = []
         # ensure this is added to the registry
         Kanaal(label="kanaal_test", main_resource=EnkelvoudigInformatieObject)
@@ -47,13 +51,15 @@ class CreateNotifKanaalTestCase(APITestCase):
             },
         )
 
-    @patch("zds_client.Client")
+    @patch(
+        "vng_api_common.notifications.management.commands.register_kanaal.get_client"
+    )
     @override_settings(NOTIFICATIONS_KANAAL="dummy-kanaal")
-    def test_kanaal_create_without_name(self, mock_client):
+    def test_kanaal_create_without_name(self, mock_get_client):
         """
         Test is request to create kanaal is send with default kanaal name
         """
-        client = mock_client.from_url.return_value
+        client = mock_get_client.return_value
         client.list.return_value = []
         # ensure this is added to the registry
         Kanaal(label="dummy-kanaal", main_resource=EnkelvoudigInformatieObject)

--- a/src/openzaak/components/zaken/tests/test_auth.py
+++ b/src/openzaak/components/zaken/tests/test_auth.py
@@ -923,6 +923,7 @@ class JWTExpiredTests(JWTAuthMixin, APITestCase):
         )
         self.client.credentials(HTTP_AUTHORIZATION=token)
 
+    @override_settings(JWT_EXPIRY=60 * 60)
     @freeze_time("2019-01-01T13:00:00")
     def test_jwt_expired(self):
         zaak = ZaakFactory.create()

--- a/src/openzaak/components/zaken/tests/test_notifications_kanaal.py
+++ b/src/openzaak/components/zaken/tests/test_notifications_kanaal.py
@@ -15,17 +15,22 @@ from ..models import Zaak
 
 @override_settings(IS_HTTPS=True)
 class CreateNotifKanaalTestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
         site = Site.objects.get_current()
         site.domain = "example.com"
         site.save()
 
-    @patch("zds_client.Client")
-    def test_kanaal_create_with_name(self, mock_client):
+    @patch(
+        "vng_api_common.notifications.management.commands.register_kanaal.get_client"
+    )
+    def test_kanaal_create_with_name(self, mock_get_client):
         """
         Test is request to create kanaal is send with specified kanaal name
         """
-        client = mock_client.from_url.return_value
+        client = mock_get_client.return_value
         client.list.return_value = []
         # ensure this is added to the registry
         Kanaal(label="kanaal_test", main_resource=Zaak)
@@ -47,13 +52,15 @@ class CreateNotifKanaalTestCase(APITestCase):
             },
         )
 
-    @patch("zds_client.Client")
+    @patch(
+        "vng_api_common.notifications.management.commands.register_kanaal.get_client"
+    )
     @override_settings(NOTIFICATIONS_KANAAL="dummy-kanaal")
-    def test_kanaal_create_without_name(self, mock_client):
+    def test_kanaal_create_without_name(self, mock_get_client):
         """
-        Test is request to create kanaal is send with default kanaal name
+        Test request to create kanaal is sent with default kanaal name
         """
-        client = mock_client.from_url.return_value
+        client = mock_get_client.return_value
         client.list.return_value = []
         # ensure this is added to the registry
         Kanaal(label="dummy-kanaal", main_resource=Zaak)

--- a/src/openzaak/tests/test_register_kanaal.py
+++ b/src/openzaak/tests/test_register_kanaal.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2020 Dimpact
+"""
+Test the correct invocations for registering notification channels.
+"""
+from django.core.management import call_command
+from django.test import TestCase
+
+import jwt
+import requests_mock
+from vng_api_common.notifications.models import NotificationsConfig
+from zgw_consumers.constants import APITypes, AuthTypes
+from zgw_consumers.models import Service
+
+from openzaak.tests.utils import mock_service_oas_get
+
+
+class RegisterKanaalTests(TestCase):
+    def test_correct_credentials_used(self):
+        svc, _ = Service.objects.update_or_create(
+            api_root="https://open-notificaties.local/api/v1/",
+            defaults=dict(
+                label="NRC",
+                api_type=APITypes.nrc,
+                client_id="some-client-id",
+                secret="some-secret",
+                auth_type=AuthTypes.zgw,
+            ),
+        )
+        config = NotificationsConfig.get_solo()
+        config.api_root = svc.api_root
+        config.save()
+
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "nrc", url=svc.api_root)
+            m.get("https://open-notificaties.local/api/v1/kanaal?naam=zaken", json=[])
+            m.post("https://open-notificaties.local/api/v1/kanaal", status_code=201)
+
+            call_command("register_kanaal", kanaal="zaken")
+
+            # check for auth in the calls
+            for request in m.request_history[1:]:
+                with self.subTest(method=request.method, url=request.url):
+                    self.assertIn("Authorization", request.headers)
+                    token = request.headers["Authorization"].split(" ")[1]
+                    try:
+                        jwt.decode(token, key="some-secret", algorithms=["HS256"])
+                    except Exception as exc:
+                        self.fail("Not a vaid JWT in Authorization header: %s" % exc)


### PR DESCRIPTION
Fixes #738

**Changes**

* [x] Added regression test for management command auth
* [x] Applied fix in vng-api-common re-using an older pattern

