### PR TITLE
Start documentation for client-developers

### DIFF
--- a/docs/client-development/authentication.rst
+++ b/docs/client-development/authentication.rst
@@ -1,0 +1,80 @@
+.. _client-development-auth:
+
+Authentication and authorization
+================================
+
+All endpoints are authorization protected, per the upstream `Standard`_.
+
+Open Zaak uses the described authentication and authorization mechanism based on
+JSON Web Tokens (JTW in short). You can read more about JWT's on https://jwt.io
+
+To connect to Open Zaak, you have received a Client ID and a Secret, which you must use
+to build a JWT.
+
+The payload of the JWT is:
+
+.. code-block:: json
+
+    {
+        "iss": "<value of Client ID>",
+        "iat": 1602857301,
+        "client_id": "<value of Client ID>",
+        "user_id": "<unique user ID of the actual end user>",
+        "user_representation": "<e.g. the name of the actual end user>"
+    }
+
+The JWT must be generated with the ``HS256`` algorithm and signed with the secret you
+received. ``iat`` is the Unix timestamp when token-creation happened.
+
+Next, for every API call you make, you must include this token in the appropriate header:
+
+.. code-block:: none
+
+    Authorization: Bearer <jwt>
+
+An example:
+-----------
+
+Given a Client ID ``docs`` and secret ``example-secret``, the header of the JWT is:
+
+.. code-block:: json
+
+    {
+        "typ": "JWT",
+        "alg": "HS256"
+    }
+
+The payload is:
+
+.. code-block:: json
+
+    {
+      "iss": "docs",
+      "iat": 1602857301,
+      "client_id": "docs",
+      "user_id": "docs@example.com",
+      "user_representation": "Documentation Example"
+    }
+
+Which leads to the following JWT:
+
+.. code-block:: none
+
+    eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkb2NzIiwiaWF0IjoxNjAyODU3MzAxLCJjbGllbnRfaWQiOiJkb2NzIiwidXNlcl9pZCI6ImRvY3NAZXhhbXBsZS5jb20iLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiRG9jdW1lbnRhdGlvbiBFeGFtcGxlIn0.DZu7E780xG4zqRiT8ZhrBeMudz45301wNVDT0ra-Iyw
+
+This would then be used in an API call like:
+
+.. code-block:: http
+
+    GET https://test.openzaak.nl/besluiten/api/v1/besuiten HTTP/1.1
+    Host: test.open-zaak.nl
+    Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkb2NzIiwiaWF0IjoxNjAyODU3MzAxLCJjbGllbnRfaWQiOiJkb2NzIiwidXNlcl9pZCI6ImRvY3NAZXhhbXBsZS5jb20iLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiRG9jdW1lbnRhdGlvbiBFeGFtcGxlIn0.DZu7E780xG4zqRiT8ZhrBeMudz45301wNVDT0ra-Iyw
+
+.. warning::
+
+    Note that you are expected to generate a JWT almost for every call! Open Zaak by
+    default expires JWT's one hour past the ``iat`` timestamp, and for audit-purposes,
+    the ``user_id`` and ``user_representation`` claims should match the end-user of
+    the application.
+
+.. _Standard: https://vng-realisatie.github.io/gemma-zaken/

--- a/docs/client-development/index.rst
+++ b/docs/client-development/index.rst
@@ -1,0 +1,15 @@
+.. _client-development:
+
+Open Zaak client documentation
+==============================
+
+Open Zaak is primarily a provider of API's to be consumed by clients. If you're
+developing such a client (or consumer), you're in the right place!
+
+Please select your relevant topic
+
+.. toctree::
+   :maxdepth: 2
+
+   authentication
+   recipes

--- a/docs/client-development/recipes.rst
+++ b/docs/client-development/recipes.rst
@@ -5,3 +5,250 @@ Recipes
 
 In the recipes documentation, we aim to describe some patterns to organize your API
 calls to maximize performance.
+
+If you can give the equivalent example in your own language-of-preference, please
+submit a pull request!
+
+Creating a Zaak, a Document and relating them
+---------------------------------------------
+
+Python/Django
++++++++++++++
+
+Using Django with `zgw-consumers`_
+
+.. code-block:: python
+
+    import base64
+    from datetime import date
+
+    from zgw_consumers.constants import APITypes
+    from zgw_consumers.models import Service
+
+    zrc_client = Service.objects.filter(api_type=APITypes.zrc).get()
+    drc_client = Service.objects.filter(api_type=APITypes.drc).get()
+
+    # zaak creation
+    today = date.today().strftime("%Y-%m-%d")
+    zaak_body = {
+        "zaaktype": "https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff",
+        "bronorganisatie": "123456782",
+        "verantwoordelijkeOrganisatie": "123456782",
+        "registratiedatum": today,
+        "startdatum": today,
+    }
+    zaak: dict = zrc_client.create("zaak", zaak_body)
+
+    # document creation
+    with open("/tmp/some_file.txt", "rb") as some_file:
+        document_body = {
+            "bronorganisatie": "123456782",
+            "creatiedatum": today,
+            "titel": "Example document",
+            "auteur": "Open Zaak",
+            "inhoud": base64.b64encode(some_file.read()).decode("utf-8"),
+            "bestandsomvang": some_file.size,
+            "bestandsnaam": some_file.name,
+            "taal": "nld",
+            "informatieobjecttype": (
+                "https://test.openzaak.nl/catalogi/api/v1/"
+                "informatieobjecttypen/abb89dae-238e-4e6a-aacd-0ba9724350a9"
+            )
+        }
+    document: dict = drc_client.create("enkelvoudiginformatieobject", document_body)
+
+    # relate them
+    zio_body = {
+        "zaak": zaak["url"],
+        "informatieobject": document["url"],
+    }
+    zio: dict = zrc_client.create("zaakinformatieobject", zio_body)
+
+Javascript
+++++++++++
+
+.. code-block:: javascript
+
+    import jwt from 'jsonwebtoken';
+
+    const CLIENT_ID = 'example';
+    const SECRET = 'secret';
+
+    // helpers
+    const getJWT = () => {
+      return jwt.sign(
+        {client_id: CLIENT_ID},
+        SECRET,
+        {
+          algorithm: 'HS256',
+          issuer: CLIENT_ID,
+        }
+      );
+    };
+
+    const apiCall = (url, method='get', body) => {
+      const fetchBody = body ? JSON.stringify(body) : null;
+      const token = getJWT();
+      const response = await fetch(
+        url,
+        {
+          method: method,
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Accept': 'application/json',
+          },
+          body: _body
+        }
+      );
+      const responseData = await response.json();
+      return responseData;
+    };
+
+    const toBase64 = file => new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.readAsDataURL(file);
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = error => reject(error);
+    });
+
+    // zaak creation
+    const today = '2020-10-16';
+    const zaakBody = {
+        'zaaktype': 'https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff',
+        'bronorganisatie': '123456782',
+        'verantwoordelijkeOrganisatie': '123456782',
+        'registratiedatum': today,
+        'startdatum': today,
+    }
+    const zaak = await apiCall(
+      'https://test.openzaak.nl/zaken/api/v1/zaken',
+      'POST',
+      zaakBody
+    );
+
+    // document creation
+    const someFile = document.querySelector('#myfile').files[0];
+    const documentBody = {
+      'bronorganisatie': '123456782',
+      'creatiedatum': today,
+      'titel': 'Example document',
+      'auteur': 'Open Zaak',
+      'inhoud': toBase64(someFile),
+      'bestandsomvang': someFile.size,
+      'bestandsnaam': someFile.name,
+      'taal': 'nld',
+      'informatieobjecttype': `https://test.openzaak.nl/catalogi/api/v1/
+    informatieobjecttypen/abb89dae-238e-4e6a-aacd-0ba9724350a9`
+    };
+
+    const doc = await apiCall(
+      'https://test.openzaak.nl/documenten/api/v1/enkelvoudiginformatieobjecten',
+      'POST',
+      documentBody
+    );
+
+    // relate them
+    const zioBody = {
+      'zaak': zaak.url,
+      'informatieobject': doc.url
+    };
+    const zio = await apiCall(
+      'https://test.openzaak.nl/zaken/api/v1/zaakinformatieobjecten',
+      'POST',
+      zioBody,
+    );
+
+
+
+
+Retrieving the documents related to a Zaak
+------------------------------------------
+
+Key problem here is that one Zaak has (probably) multiple documents related to it,
+and retrieving them sequentially is a performance hit that gets worse with the amount
+of documents.
+
+The solution is to use some form of threading/concurrency offered by your language.
+
+Python/Django
++++++++++++++
+
+Using Django with `zgw-consumers`_, we can use the
+``concurrent.fututures.ThreadPoolExecutor``, where each job will run in its own thread.
+This gets close to retrieving all the documents in parallel instead of sequentially,
+resulting in a constant-time determined by the slowest API call.
+
+.. code-block:: python
+
+    from typing import List
+
+    from zgw_consumers.constants import APITypes
+    from zgw_consumers.models import Service
+    from zgw_consumers.concurrent import parallel
+
+    zrc_client = Service.objects.filter(api_type=APITypes.zrc).get()
+    drc_client = Service.objects.filter(api_type=APITypes.drc).get()
+
+    zaak_url = "https://test.openzaak.nl/zaken/api/v1/zaken/b604ea56-f01c-432e-8d61-fd4ab02893dc"
+    zios: List[dict] = zrc_client.list("zaakinformatieobject", {"zaak": zaak_url})
+    document_urls = [zio["informatieobject"] for zio in zios]
+    with parallel() as executor:
+        _documents = executor.map(
+            lambda url: drc_client.retrieve("enkelvoudiginformatieobject", url=url),
+            document_urls
+        )
+    documents: List[dict] = list(_documents)
+
+
+
+Javascript
+++++++++++
+
+Similarly to the Python case, we leverage the Javacsript async/await event loop. Once
+we've collected all the URLs of documents to retrieve, we create promises and by using
+``Promise.all``, all API calls are being performed in parallel (at least for the network
+IO part).
+
+.. code-block:: javascript
+
+    import jwt from 'jsonwebtoken';
+
+    const CLIENT_ID = 'example';
+    const SECRET = 'secret';
+
+    // helpers
+    const getJWT = () => {
+      return jwt.sign(
+        {client_id: CLIENT_ID},
+        SECRET,
+        {
+          algorithm: 'HS256',
+          issuer: CLIENT_ID,
+        }
+      );
+    };
+
+    const get = (url) => {
+      const token = getJWT();
+      const response = await fetch(
+        url,
+        {
+          method: 'get',
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Accept': 'application/json',
+          },
+        }
+      );
+      const responseData = await response.json();
+      return responseData;
+    };
+
+
+    const zaakUrl = 'https://test.openzaak.nl/zaken/api/v1/zaken/b604ea56-f01c-432e-8d61-fd4ab02893dc';
+    const zios = await get(`https://test.openzaak.nl/zaken/api/v1/zaakinformatieobjecten?zaak=${zaakUrl}`);
+    const promises = zios.map(zio => get(zio.informatieobject));
+    const documents = await Promise.all(promises);
+
+
+.. _zgw-consumers: https://pypi.org/project/zgw-consumers/

--- a/docs/client-development/recipes.rst
+++ b/docs/client-development/recipes.rst
@@ -1,0 +1,7 @@
+.. _client-development-recipes:
+
+Recipes
+=======
+
+In the recipes documentation, we aim to describe some patterns to organize your API
+calls to maximize performance.

--- a/docs/client-development/recipes.rst
+++ b/docs/client-development/recipes.rst
@@ -12,153 +12,151 @@ submit a pull request!
 Creating a Zaak, a Document and relating them
 ---------------------------------------------
 
-Python/Django
-+++++++++++++
+.. tabs::
 
-Using Django with `zgw-consumers`_
+    .. group-tab:: Python (Django)
 
-.. code-block:: python
+        Using Django with `zgw-consumers`_
 
-    import base64
-    from datetime import date
+        .. code-block:: python
 
-    from zgw_consumers.constants import APITypes
-    from zgw_consumers.models import Service
+            import base64
+            from datetime import date
 
-    zrc_client = Service.objects.filter(api_type=APITypes.zrc).get()
-    drc_client = Service.objects.filter(api_type=APITypes.drc).get()
+            from zgw_consumers.constants import APITypes
+            from zgw_consumers.models import Service
 
-    # zaak creation
-    today = date.today().strftime("%Y-%m-%d")
-    zaak_body = {
-        "zaaktype": "https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff",
-        "bronorganisatie": "123456782",
-        "verantwoordelijkeOrganisatie": "123456782",
-        "registratiedatum": today,
-        "startdatum": today,
-    }
-    zaak: dict = zrc_client.create("zaak", zaak_body)
+            zrc_client = Service.objects.filter(api_type=APITypes.zrc).get()
+            drc_client = Service.objects.filter(api_type=APITypes.drc).get()
 
-    # document creation
-    with open("/tmp/some_file.txt", "rb") as some_file:
-        document_body = {
-            "bronorganisatie": "123456782",
-            "creatiedatum": today,
-            "titel": "Example document",
-            "auteur": "Open Zaak",
-            "inhoud": base64.b64encode(some_file.read()).decode("utf-8"),
-            "bestandsomvang": some_file.size,
-            "bestandsnaam": some_file.name,
-            "taal": "nld",
-            "informatieobjecttype": (
-                "https://test.openzaak.nl/catalogi/api/v1/"
-                "informatieobjecttypen/abb89dae-238e-4e6a-aacd-0ba9724350a9"
-            )
-        }
-    document: dict = drc_client.create("enkelvoudiginformatieobject", document_body)
+            # zaak creation
+            today = date.today().strftime("%Y-%m-%d")
+            zaak_body = {
+                "zaaktype": "https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff",
+                "bronorganisatie": "123456782",
+                "verantwoordelijkeOrganisatie": "123456782",
+                "registratiedatum": today,
+                "startdatum": today,
+            }
+            zaak: dict = zrc_client.create("zaak", zaak_body)
 
-    # relate them
-    zio_body = {
-        "zaak": zaak["url"],
-        "informatieobject": document["url"],
-    }
-    zio: dict = zrc_client.create("zaakinformatieobject", zio_body)
+            # document creation
+            with open("/tmp/some_file.txt", "rb") as some_file:
+                document_body = {
+                    "bronorganisatie": "123456782",
+                    "creatiedatum": today,
+                    "titel": "Example document",
+                    "auteur": "Open Zaak",
+                    "inhoud": base64.b64encode(some_file.read()).decode("utf-8"),
+                    "bestandsomvang": some_file.size,
+                    "bestandsnaam": some_file.name,
+                    "taal": "nld",
+                    "informatieobjecttype": (
+                        "https://test.openzaak.nl/catalogi/api/v1/"
+                        "informatieobjecttypen/abb89dae-238e-4e6a-aacd-0ba9724350a9"
+                    )
+                }
+            document: dict = drc_client.create("enkelvoudiginformatieobject", document_body)
 
-Javascript
-++++++++++
+            # relate them
+            zio_body = {
+                "zaak": zaak["url"],
+                "informatieobject": document["url"],
+            }
+            zio: dict = zrc_client.create("zaakinformatieobject", zio_body)
 
-.. code-block:: javascript
+    .. group-tab:: Javascript
 
-    import jwt from 'jsonwebtoken';
+        .. code-block:: javascript
 
-    const CLIENT_ID = 'example';
-    const SECRET = 'secret';
+            import jwt from 'jsonwebtoken';
 
-    // helpers
-    const getJWT = () => {
-      return jwt.sign(
-        {client_id: CLIENT_ID},
-        SECRET,
-        {
-          algorithm: 'HS256',
-          issuer: CLIENT_ID,
-        }
-      );
-    };
+            const CLIENT_ID = 'example';
+            const SECRET = 'secret';
 
-    const apiCall = (url, method='get', body) => {
-      const fetchBody = body ? JSON.stringify(body) : null;
-      const token = getJWT();
-      const response = await fetch(
-        url,
-        {
-          method: method,
-          headers: {
-            'Authorization': `Bearer ${token}`,
-            'Accept': 'application/json',
-          },
-          body: _body
-        }
-      );
-      const responseData = await response.json();
-      return responseData;
-    };
+            // helpers
+            const getJWT = () => {
+              return jwt.sign(
+                {client_id: CLIENT_ID},
+                SECRET,
+                {
+                  algorithm: 'HS256',
+                  issuer: CLIENT_ID,
+                }
+              );
+            };
 
-    const toBase64 = file => new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.readAsDataURL(file);
-        reader.onload = () => resolve(reader.result);
-        reader.onerror = error => reject(error);
-    });
+            const apiCall = (url, method='get', body) => {
+              const fetchBody = body ? JSON.stringify(body) : null;
+              const token = getJWT();
+              const response = await fetch(
+                url,
+                {
+                  method: method,
+                  headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Accept': 'application/json',
+                  },
+                  body: _body
+                }
+              );
+              const responseData = await response.json();
+              return responseData;
+            };
 
-    // zaak creation
-    const today = '2020-10-16';
-    const zaakBody = {
-        'zaaktype': 'https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff',
-        'bronorganisatie': '123456782',
-        'verantwoordelijkeOrganisatie': '123456782',
-        'registratiedatum': today,
-        'startdatum': today,
-    }
-    const zaak = await apiCall(
-      'https://test.openzaak.nl/zaken/api/v1/zaken',
-      'POST',
-      zaakBody
-    );
+            const toBase64 = file => new Promise((resolve, reject) => {
+                const reader = new FileReader();
+                reader.readAsDataURL(file);
+                reader.onload = () => resolve(reader.result);
+                reader.onerror = error => reject(error);
+            });
 
-    // document creation
-    const someFile = document.querySelector('#myfile').files[0];
-    const documentBody = {
-      'bronorganisatie': '123456782',
-      'creatiedatum': today,
-      'titel': 'Example document',
-      'auteur': 'Open Zaak',
-      'inhoud': toBase64(someFile),
-      'bestandsomvang': someFile.size,
-      'bestandsnaam': someFile.name,
-      'taal': 'nld',
-      'informatieobjecttype': `https://test.openzaak.nl/catalogi/api/v1/
-    informatieobjecttypen/abb89dae-238e-4e6a-aacd-0ba9724350a9`
-    };
+            // zaak creation
+            const today = '2020-10-16';
+            const zaakBody = {
+                'zaaktype': 'https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff',
+                'bronorganisatie': '123456782',
+                'verantwoordelijkeOrganisatie': '123456782',
+                'registratiedatum': today,
+                'startdatum': today,
+            }
+            const zaak = await apiCall(
+              'https://test.openzaak.nl/zaken/api/v1/zaken',
+              'POST',
+              zaakBody
+            );
 
-    const doc = await apiCall(
-      'https://test.openzaak.nl/documenten/api/v1/enkelvoudiginformatieobjecten',
-      'POST',
-      documentBody
-    );
+            // document creation
+            const someFile = document.querySelector('#myfile').files[0];
+            const documentBody = {
+              'bronorganisatie': '123456782',
+              'creatiedatum': today,
+              'titel': 'Example document',
+              'auteur': 'Open Zaak',
+              'inhoud': toBase64(someFile),
+              'bestandsomvang': someFile.size,
+              'bestandsnaam': someFile.name,
+              'taal': 'nld',
+              'informatieobjecttype': `https://test.openzaak.nl/catalogi/api/v1/
+            informatieobjecttypen/abb89dae-238e-4e6a-aacd-0ba9724350a9`
+            };
 
-    // relate them
-    const zioBody = {
-      'zaak': zaak.url,
-      'informatieobject': doc.url
-    };
-    const zio = await apiCall(
-      'https://test.openzaak.nl/zaken/api/v1/zaakinformatieobjecten',
-      'POST',
-      zioBody,
-    );
+            const doc = await apiCall(
+              'https://test.openzaak.nl/documenten/api/v1/enkelvoudiginformatieobjecten',
+              'POST',
+              documentBody
+            );
 
-
+            // relate them
+            const zioBody = {
+              'zaak': zaak.url,
+              'informatieobject': doc.url
+            };
+            const zio = await apiCall(
+              'https://test.openzaak.nl/zaken/api/v1/zaakinformatieobjecten',
+              'POST',
+              zioBody,
+            );
 
 
 Retrieving the documents related to a Zaak
@@ -170,85 +168,85 @@ of documents.
 
 The solution is to use some form of threading/concurrency offered by your language.
 
-Python/Django
-+++++++++++++
+.. tabs::
 
-Using Django with `zgw-consumers`_, we can use the
-``concurrent.fututures.ThreadPoolExecutor``, where each job will run in its own thread.
-This gets close to retrieving all the documents in parallel instead of sequentially,
-resulting in a constant-time determined by the slowest API call.
+    .. group-tab:: Python (Django)
 
-.. code-block:: python
+        Using Django with `zgw-consumers`_, we can use the
+        ``concurrent.fututures.ThreadPoolExecutor``, where each job will run in its own thread.
+        This gets close to retrieving all the documents in parallel instead of sequentially,
+        resulting in a constant-time determined by the slowest API call.
 
-    from typing import List
+        .. code-block:: python
 
-    from zgw_consumers.constants import APITypes
-    from zgw_consumers.models import Service
-    from zgw_consumers.concurrent import parallel
+            from typing import List
 
-    zrc_client = Service.objects.filter(api_type=APITypes.zrc).get()
-    drc_client = Service.objects.filter(api_type=APITypes.drc).get()
+            from zgw_consumers.constants import APITypes
+            from zgw_consumers.models import Service
+            from zgw_consumers.concurrent import parallel
 
-    zaak_url = "https://test.openzaak.nl/zaken/api/v1/zaken/b604ea56-f01c-432e-8d61-fd4ab02893dc"
-    zios: List[dict] = zrc_client.list("zaakinformatieobject", {"zaak": zaak_url})
-    document_urls = [zio["informatieobject"] for zio in zios]
-    with parallel() as executor:
-        _documents = executor.map(
-            lambda url: drc_client.retrieve("enkelvoudiginformatieobject", url=url),
-            document_urls
-        )
-    documents: List[dict] = list(_documents)
+            zrc_client = Service.objects.filter(api_type=APITypes.zrc).get()
+            drc_client = Service.objects.filter(api_type=APITypes.drc).get()
 
-
-
-Javascript
-++++++++++
-
-Similarly to the Python case, we leverage the Javacsript async/await event loop. Once
-we've collected all the URLs of documents to retrieve, we create promises and by using
-``Promise.all``, all API calls are being performed in parallel (at least for the network
-IO part).
-
-.. code-block:: javascript
-
-    import jwt from 'jsonwebtoken';
-
-    const CLIENT_ID = 'example';
-    const SECRET = 'secret';
-
-    // helpers
-    const getJWT = () => {
-      return jwt.sign(
-        {client_id: CLIENT_ID},
-        SECRET,
-        {
-          algorithm: 'HS256',
-          issuer: CLIENT_ID,
-        }
-      );
-    };
-
-    const get = (url) => {
-      const token = getJWT();
-      const response = await fetch(
-        url,
-        {
-          method: 'get',
-          headers: {
-            'Authorization': `Bearer ${token}`,
-            'Accept': 'application/json',
-          },
-        }
-      );
-      const responseData = await response.json();
-      return responseData;
-    };
+            zaak_url = "https://test.openzaak.nl/zaken/api/v1/zaken/b604ea56-f01c-432e-8d61-fd4ab02893dc"
+            zios: List[dict] = zrc_client.list("zaakinformatieobject", {"zaak": zaak_url})
+            document_urls = [zio["informatieobject"] for zio in zios]
+            with parallel() as executor:
+                _documents = executor.map(
+                    lambda url: drc_client.retrieve("enkelvoudiginformatieobject", url=url),
+                    document_urls
+                )
+            documents: List[dict] = list(_documents)
 
 
-    const zaakUrl = 'https://test.openzaak.nl/zaken/api/v1/zaken/b604ea56-f01c-432e-8d61-fd4ab02893dc';
-    const zios = await get(`https://test.openzaak.nl/zaken/api/v1/zaakinformatieobjecten?zaak=${zaakUrl}`);
-    const promises = zios.map(zio => get(zio.informatieobject));
-    const documents = await Promise.all(promises);
+
+    .. group-tab:: Javascript
+
+        Similarly to the Python case, we leverage the Javacsript async/await event loop. Once
+        we've collected all the URLs of documents to retrieve, we create promises and by using
+        ``Promise.all``, all API calls are being performed in parallel (at least for the network
+        IO part).
+
+        .. code-block:: javascript
+
+            import jwt from 'jsonwebtoken';
+
+            const CLIENT_ID = 'example';
+            const SECRET = 'secret';
+
+            // helpers
+            const getJWT = () => {
+              return jwt.sign(
+                {client_id: CLIENT_ID},
+                SECRET,
+                {
+                  algorithm: 'HS256',
+                  issuer: CLIENT_ID,
+                }
+              );
+            };
+
+            const get = (url) => {
+              const token = getJWT();
+              const response = await fetch(
+                url,
+                {
+                  method: 'get',
+                  headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Accept': 'application/json',
+                  },
+                }
+              );
+              const responseData = await response.json();
+              return responseData;
+            };
+
+
+            const zaakUrl = 'https://test.openzaak.nl/zaken/api/v1/zaken/b604ea56-f01c-432e-8d61-fd4ab02893dc';
+            const zios = await get(`https://test.openzaak.nl/zaken/api/v1/zaakinformatieobjecten?zaak=${zaakUrl}`);
+            const promises = zios.map(zio => get(zio.informatieobject));
+            const documents = await Promise.all(promises);
 
 
 .. _zgw-consumers: https://pypi.org/project/zgw-consumers/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,7 @@ extensions = [
     "sphinx.ext.todo",
     "recommonmark",
     "sphinx_markdown_tables",
+    "sphinx_tabs.tabs",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -82,3 +83,5 @@ linkcheck_ignore = [
     r"http://localhost:\d+/",
     r"https://.*sentry\.openzaak\.nl.*",
 ]
+
+sphinx_tabs_valid_builders = ["linkcheck"]

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -15,3 +15,6 @@ contribute!
    principles
    releasing
    performance/index
+
+If you're looking for developer documentation as an Open Zaak *client*, head over to
+:ref:`client-development`!

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,5 +35,6 @@ Open Zaak `is`_ and only uses :ref:`introduction_open-source`.
    api/index
    installation/index
    manual/index
+   client-development/index
    support/index
    development/index

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -13,6 +13,7 @@ sphinx
 sphinx_rtd_theme
 recommonmark
 sphinx-markdown-tables
+sphinx-tabs
 
 # Deployment
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -101,7 +101,7 @@ pyasn1==0.4.8             # via pyasn1-modules, rsa
 pycodestyle==2.6.0        # via -r requirements/ci.txt, autopep8, flake8
 pycparser==2.19           # via -r requirements/ci.txt, cffi
 pyflakes==2.2.0           # via -r requirements/ci.txt, flake8
-pygments==2.4.2           # via django-silk, sphinx
+pygments==2.4.2           # via django-silk, sphinx, sphinx-tabs
 pyjwt==1.6.4              # via -r requirements/ci.txt, django-auth-adfs, gemma-zds-client, vng-api-common
 pyparsing==2.4.2          # via packaging
 pyrsistent==0.17.3        # via jsonschema
@@ -126,7 +126,8 @@ snowballstemmer==2.0.0    # via sphinx
 soupsieve==1.9.5          # via -r requirements/ci.txt, beautifulsoup4
 sphinx-markdown-tables==0.0.14  # via -r requirements/dev.in
 sphinx-rtd-theme==0.4.3   # via -r requirements/dev.in
-sphinx==2.2.0             # via -r requirements/dev.in, recommonmark, sphinx-rtd-theme
+sphinx-tabs==1.3.0        # via -r requirements/dev.in
+sphinx==2.2.0             # via -r requirements/dev.in, recommonmark, sphinx-rtd-theme, sphinx-tabs
 sphinxcontrib-applehelp==1.0.1  # via sphinx
 sphinxcontrib-devhelp==1.0.1  # via sphinx
 sphinxcontrib-htmlhelp==1.0.2  # via sphinx


### PR DESCRIPTION
No issue created for this, sorry!

**Changes**

- Added a documentation section aimed at developers of client applications
- Added basic documentation on the JWT setup
- Added two recipes in Python and Javascript
    - creating a zaak, document and relating them
    - retrieving the documents related to a zaak in a performant way

