### PR TITLE
Fixes #713 Removing a zaaktype removes the related autorisatie

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 1.3.2 (2020-11-06)
 ------------------
 
-.. warn::
+.. warning::
 
     Manual intervention required!
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,28 @@
 Changelog
 =========
 
+1.3.2 (2020-11-06)
+------------------
+
+.. warn::
+
+    Manual intervention required!
+
+    Some cleanup is required because of a synchronization bug. You need to run
+    the following ``sync_autorisaties`` management command.
+
+    Plain Docker:
+
+    .. code-block:: bash
+
+        docker exec openzaak-0 src/manage.py sync_autorisaties
+
+    Kubernetes:
+
+    .. code-block:: bash
+
+        kubectl exec <pod> -- src/manage.py sync_autorisaties
+
 1.3.1 (2020-08-31)
 ------------------
 

--- a/src/openzaak/components/autorisaties/management/__init__.py
+++ b/src/openzaak/components/autorisaties/management/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2019 - 2020 Dimpact

--- a/src/openzaak/components/autorisaties/management/commands/__init__.py
+++ b/src/openzaak/components/autorisaties/management/commands/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2019 - 2020 Dimpact

--- a/src/openzaak/components/autorisaties/management/commands/sync_autorisaties.py
+++ b/src/openzaak/components/autorisaties/management/commands/sync_autorisaties.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2019 - 2020 Dimpact
+from urllib.parse import urlparse
+
+from django.apps import apps
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.management import BaseCommand
+from django.utils.translation import ugettext_lazy as _
+
+from django_loose_fk.loaders import BaseLoader
+from vng_api_common.utils import get_resource_for_path
+
+Autorisatie = apps.get_model("authorizations", "Autorisatie")
+is_local_url = BaseLoader().is_local_url
+
+
+class Command(BaseCommand):
+    help = _(
+        "Remove any existing authorisations related to zaaktypen that have been removed"
+    )
+
+    def handle(self, *args, **options):
+
+        to_delete = []
+
+        for autorisatie in Autorisatie.objects.all():
+            if not is_local_url(autorisatie.zaaktype):
+                continue
+
+            parsed = urlparse(autorisatie.zaaktype)
+
+            try:
+                get_resource_for_path(parsed.path)
+            except ObjectDoesNotExist:
+                to_delete.append(autorisatie)
+
+        Autorisatie.objects.filter(pk__in=[obj.pk for obj in to_delete]).delete()

--- a/src/openzaak/components/autorisaties/management/commands/sync_autorisaties.py
+++ b/src/openzaak/components/autorisaties/management/commands/sync_autorisaties.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
+from typing import List
 from urllib.parse import urlparse
 
 from django.apps import apps
@@ -14,24 +15,30 @@ Autorisatie = apps.get_model("authorizations", "Autorisatie")
 is_local_url = BaseLoader().is_local_url
 
 
+def get_out_of_sync_autorisaties(field: str) -> List[Autorisatie]:
+    to_delete = []
+    for autorisatie in Autorisatie.objects.exclude(**{field: ""}):
+        value = getattr(autorisatie, field)
+        if not is_local_url(value):
+            continue
+
+        parsed = urlparse(value)
+
+        try:
+            get_resource_for_path(parsed.path)
+        except ObjectDoesNotExist:
+            to_delete.append(autorisatie)
+    return to_delete
+
+
 class Command(BaseCommand):
     help = _(
         "Remove any existing authorisations related to zaaktypen that have been removed"
     )
 
     def handle(self, *args, **options):
-
         to_delete = []
-
-        for autorisatie in Autorisatie.objects.all():
-            if not is_local_url(autorisatie.zaaktype):
-                continue
-
-            parsed = urlparse(autorisatie.zaaktype)
-
-            try:
-                get_resource_for_path(parsed.path)
-            except ObjectDoesNotExist:
-                to_delete.append(autorisatie)
+        for field in ["zaaktype", "informatieobjecttype", "besluittype"]:
+            to_delete += get_out_of_sync_autorisaties(field)
 
         Autorisatie.objects.filter(pk__in=[obj.pk for obj in to_delete]).delete()

--- a/src/openzaak/components/autorisaties/models.py
+++ b/src/openzaak/components/autorisaties/models.py
@@ -126,7 +126,9 @@ class AutorisatieSpec(models.Model):
                 )
                 to_add.append(autorisatie)
 
-        Autorisatie.objects.filter(pk__in=[autorisatie.pk for autorisatie in to_delete])
+        Autorisatie.objects.filter(
+            pk__in=[autorisatie.pk for autorisatie in to_delete]
+        ).delete()
 
         # de-duplicate - whatever is in to_keep should not be added again
         existing_urls = defaultdict(list)

--- a/src/openzaak/components/autorisaties/tests/management/__init__.py
+++ b/src/openzaak/components/autorisaties/tests/management/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2019 - 2020 Dimpact

--- a/src/openzaak/components/autorisaties/tests/management/test_sync_zaaktype_autorisatie.py
+++ b/src/openzaak/components/autorisaties/tests/management/test_sync_zaaktype_autorisatie.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2019 - 2020 Dimpact
+import uuid
+
+from django.contrib.sites.models import Site
+from django.core.management import call_command
+from django.test import TestCase
+
+from vng_api_common.authorizations.models import Autorisatie
+
+from openzaak.components.autorisaties.tests.factories import AutorisatieFactory
+from openzaak.components.catalogi.tests.factories import ZaakTypeFactory
+from openzaak.utils import build_absolute_url
+
+
+class ZaaktypeSyncAutorisatieTests(TestCase):
+    def test_management_sync_autorisatie_delete_all(self):
+        domain = Site.objects.get_current().domain
+        # Create 5 Autorisaties for non existing ZaakTypen
+        for i in range(5):
+            AutorisatieFactory.create(
+                zaaktype=f"http://{domain}/catalogi/api/v1/zaaktypen/{str(uuid.uuid4())}",
+            )
+
+        self.assertEqual(Autorisatie.objects.all().count(), 5)
+
+        call_command("sync_autorisaties")
+
+        self.assertEqual(Autorisatie.objects.all().count(), 0)
+
+    def test_management_sync_autorisatie_delete_some(self):
+        domain = Site.objects.get_current().domain
+        # Create 5 Autorisaties for non existing ZaakTypen
+        for i in range(5):
+            AutorisatieFactory.create(
+                zaaktype=f"http://{domain}/catalogi/api/v1/zaaktypen/{str(uuid.uuid4())}",
+            )
+
+        # Add an Autorisatie for an existing Zaaktype
+        zaaktype = ZaakTypeFactory.create()
+        AutorisatieFactory.create(
+            zaaktype=build_absolute_url(zaaktype.get_absolute_api_url()),
+        )
+
+        self.assertEqual(Autorisatie.objects.all().count(), 6)
+
+        call_command("sync_autorisaties")
+
+        self.assertEqual(Autorisatie.objects.all().count(), 1)
+        autorisatie = Autorisatie.objects.get()
+        self.assertEqual(
+            autorisatie.zaaktype, build_absolute_url(zaaktype.get_absolute_api_url())
+        )

--- a/src/openzaak/components/autorisaties/tests/test_autorisatiespec.py
+++ b/src/openzaak/components/autorisaties/tests/test_autorisatiespec.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2019 - 2020 Dimpact
+from django.test import TestCase
+
+from vng_api_common.authorizations.models import Autorisatie
+from vng_api_common.constants import ComponentTypes, VertrouwelijkheidsAanduiding
+
+from openzaak.components.autorisaties.tests.factories import (
+    ApplicatieFactory,
+    AutorisatieFactory,
+    AutorisatieSpecFactory,
+)
+from openzaak.components.catalogi.tests.factories import ZaakTypeFactory
+from openzaak.utils import build_absolute_url
+
+
+class DeleteAutorisatieTest(TestCase):
+    def test_autorisaties_are_deleted(self):
+        applicatie = ApplicatieFactory.create()
+        zaaktype = ZaakTypeFactory.create()
+        AutorisatieFactory.create(
+            applicatie=applicatie,
+            component=ComponentTypes.zrc,
+            zaaktype=build_absolute_url(zaaktype.get_absolute_api_url()),
+            max_vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.openbaar,
+        )
+        # Different max_vertrouwelijkheidaanduiding compared to the Autorisatie
+        autorisatie_spec = AutorisatieSpecFactory.create(
+            applicatie=applicatie,
+            component=ComponentTypes.zrc,
+            max_vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.geheim,
+        )
+
+        self.assertEqual(Autorisatie.objects.all().count(), 1)
+        autorisatie = Autorisatie.objects.get()
+        self.assertEqual(
+            autorisatie.max_vertrouwelijkheidaanduiding,
+            VertrouwelijkheidsAanduiding.openbaar,
+        )
+
+        autorisatie_spec.sync()
+
+        # Check that the autorisatie that doesn't match the AutorisatieSpec is deleted and replaced with a correct one
+        self.assertEqual(Autorisatie.objects.all().count(), 1)
+        autorisatie = Autorisatie.objects.get()
+        self.assertEqual(
+            autorisatie.max_vertrouwelijkheidaanduiding,
+            VertrouwelijkheidsAanduiding.geheim,
+        )

--- a/src/openzaak/components/catalogi/__init__.py
+++ b/src/openzaak/components/catalogi/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
+
+default_app_config = "openzaak.components.catalogi.apps.CatalogiConfig"

--- a/src/openzaak/components/catalogi/apps.py
+++ b/src/openzaak/components/catalogi/apps.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2019 - 2020 Dimpact
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class CatalogiConfig(AppConfig):
+    name = "openzaak.components.catalogi"
+    verbose_name = _("Catalogi")
+
+    def ready(self):
+        # load the signal receivers
+        from . import signals  # noqa

--- a/src/openzaak/components/catalogi/signals.py
+++ b/src/openzaak/components/catalogi/signals.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2019 - 2020 Dimpact
+import logging
+
+from django.conf import settings
+from django.contrib.sites.models import Site
+from django.db.models.base import ModelBase
+from django.db.models.signals import ModelSignal, post_delete
+from django.dispatch import receiver
+
+from vng_api_common.authorizations.models import Autorisatie
+
+from openzaak.components.catalogi.models.zaaktype import ZaakType
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(post_delete, dispatch_uid="catalogi.sync_autorisaties")
+def sync_autorisaties(
+    sender: ModelBase, signal: ModelSignal, instance: ZaakType, **kwargs
+) -> None:
+    logger.debug("Received signal %r, from sender %r", signal, sender)
+
+    if sender is not ZaakType:
+        return
+
+    instance_path = instance.get_absolute_api_url()
+    site = Site.objects.get_current()
+    protocol = "https" if getattr(settings, "IS_HTTPS", True) else "http"
+    instance_url = f"{protocol}://{site.domain}{instance_path}"
+    Autorisatie.objects.filter(zaaktype=instance_url).delete()

--- a/src/openzaak/components/catalogi/signals.py
+++ b/src/openzaak/components/catalogi/signals.py
@@ -1,31 +1,42 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
 import logging
+from typing import Union
 
-from django.conf import settings
-from django.contrib.sites.models import Site
 from django.db.models.base import ModelBase
 from django.db.models.signals import ModelSignal, post_delete
 from django.dispatch import receiver
 
 from vng_api_common.authorizations.models import Autorisatie
 
-from openzaak.components.catalogi.models.zaaktype import ZaakType
+from openzaak.utils import build_absolute_url
+
+from .models import BesluitType, InformatieObjectType, ZaakType
 
 logger = logging.getLogger(__name__)
 
 
-@receiver(post_delete, dispatch_uid="catalogi.sync_autorisaties")
+@receiver(
+    post_delete, sender=ZaakType, dispatch_uid="catalogi.sync_autorisaties_zaaktype"
+)
+@receiver(
+    post_delete,
+    sender=InformatieObjectType,
+    dispatch_uid="catalogi.sync_autorisaties_informatieobjecttype",
+)
+@receiver(
+    post_delete,
+    sender=BesluitType,
+    dispatch_uid="catalogi.sync_autorisaties_besluittype",
+)
 def sync_autorisaties(
-    sender: ModelBase, signal: ModelSignal, instance: ZaakType, **kwargs
+    sender: ModelBase,
+    signal: ModelSignal,
+    instance: Union[ZaakType, InformatieObjectType, BesluitType],
+    **kwargs
 ) -> None:
     logger.debug("Received signal %r, from sender %r", signal, sender)
 
-    if sender is not ZaakType:
-        return
-
     instance_path = instance.get_absolute_api_url()
-    site = Site.objects.get_current()
-    protocol = "https" if getattr(settings, "IS_HTTPS", True) else "http"
-    instance_url = f"{protocol}://{site.domain}{instance_path}"
+    instance_url = build_absolute_url(instance_path)
     Autorisatie.objects.filter(zaaktype=instance_url).delete()


### PR DESCRIPTION
Fixes #713 

**Changes**
When a `ZaakType` is removed, now there is a receiver for the post delete signal which checks for existing `Autorisaties` and removes them.

A management command was also added to sync existing `Autorisaties` for `ZaakType` instances that have previously been deleted.

