### PR TITLE
Added missing CMIS tag

### DIFF
--- a/src/openzaak/components/documenten/tests/test_cmis_queries.py
+++ b/src/openzaak/components/documenten/tests/test_cmis_queries.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
 from django.contrib.sites.models import Site
-from django.test import override_settings
+from django.test import override_settings, tag
 
 from openzaak.utils.tests import APICMISTestCase
 
@@ -9,6 +9,7 @@ from ..models import EnkelvoudigInformatieObject
 from .factories import EnkelvoudigInformatieObjectFactory
 
 
+@tag("cmis")
 @override_settings(CMIS_ENABLED=True)
 class QueryTests(APICMISTestCase):
     """


### PR DESCRIPTION
A CMIS tag was missing from one of the tests that require Alfresco to be running in order to pass.

