### PR TITLE
Making debugging of CMIS-adapter easier

### DIFF
--- a/src/openzaak/conf/dev.py
+++ b/src/openzaak/conf/dev.py
@@ -33,6 +33,7 @@ EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 LOGGING["loggers"].update(
     {
         "openzaak": {"handlers": ["console"], "level": "DEBUG", "propagate": True},
+        "drc_cmis": {"handlers": ["console"], "level": "DEBUG", "propagate": True},
         "django": {"handlers": ["console"], "level": "DEBUG", "propagate": True},
         "django.utils.autoreload": {
             "handlers": ["console"],


### PR DESCRIPTION
**Changes**
When Open Zaak is in debug mode, the logging of the CMIS-adapter is shown in the console by default. 

