### PR TITLE
Fixing duplicate ObjectInformatieObject creation with CMIS

### DIFF
--- a/src/openzaak/components/besluiten/api/serializers.py
+++ b/src/openzaak/components/besluiten/api/serializers.py
@@ -194,8 +194,8 @@ class BesluitInformatieObjectSerializer(serializers.HyperlinkedModelSerializer):
         with transaction.atomic():
             bio = super().create(validated_data)
 
-        # local FK - nothing to do -> our signals create the OIO
-        if bio.informatieobject.pk:
+        # local FK or CMIS - nothing to do -> our signals create the OIO
+        if bio.informatieobject.pk or settings.CMIS_ENABLED:
             return bio
 
         # we know that we got valid URLs in the initial data

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -553,8 +553,8 @@ class ZaakInformatieObjectSerializer(serializers.HyperlinkedModelSerializer):
         with transaction.atomic():
             zio = super().create(validated_data)
 
-        # local FK - nothing to do -> our signals create the OIO
-        if zio.informatieobject.pk:
+        # local FK or CMIS - nothing to do -> our signals create the OIO
+        if zio.informatieobject.pk or settings.CMIS_ENABLED:
             return zio
 
         # we know that we got valid URLs in the initial data

--- a/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten_cmis.py
@@ -20,6 +20,7 @@ from openzaak.components.documenten.tests.factories import (
 )
 from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin, OioMixin, serialise_eio
 
+from ...documenten.models import EnkelvoudigInformatieObject, ObjectInformatieObject
 from ..models import Zaak, ZaakInformatieObject
 from .factories import ZaakFactory, ZaakInformatieObjectFactory
 
@@ -89,6 +90,9 @@ class ZaakInformatieObjectCMISAPITests(JWTAuthMixin, APICMISTestCase, OioMixin):
         )
 
         self.assertEqual(response.json(), expected_response)
+
+        self.assertEqual(ObjectInformatieObject.objects.count(), 1)
+        self.assertEqual(EnkelvoudigInformatieObject.objects.count(), 1)
 
     @freeze_time("2018-09-20 12:00:00")
     def test_registratiedatum_ignored(self):

--- a/src/openzaak/utils/tests.py
+++ b/src/openzaak/utils/tests.py
@@ -317,19 +317,15 @@ class APICMISTestCase(MockSchemasMixin, CMISMixin, APITestCase):
             config = CMISConfig.objects.get()
             config.client_url = "http://localhost:8082/alfresco/cmisws"
             config.binding = "WEBSERVICE"
-            config.other_folder_path = (
-                "/DRC/{{ zaaktype }}/{{ year }}/{{ month }}/{{ day }}/{{ zaak }}/"
-            )
-            config.zaak_folder_path = "/DRC/{{ year }}/{{ month }}/{{ day }}/"
+            config.other_folder_path = "/DRC/"
+            config.zaak_folder_path = "/ZRC/{{ zaaktype }}/{{ zaak }}"
             config.save()
         elif binding == "BROWSER":
             config = CMISConfig.objects.get()
             config.client_url = "http://localhost:8082/alfresco/api/-default-/public/cmis/versions/1.1/browser"
             config.binding = "BROWSER"
-            config.other_folder_path = (
-                "/DRC/{{ zaaktype }}/{{ year }}/{{ month }}/{{ day }}/{{ zaak }}/"
-            )
-            config.zaak_folder_path = "/DRC/{{ year }}/{{ month }}/{{ day }}/"
+            config.other_folder_path = "/DRC/"
+            config.zaak_folder_path = "/ZRC/{{ zaaktype }}/{{ zaak }}/"
             config.save()
         else:
             raise Exception("No CMIS binding specified")


### PR DESCRIPTION
Fixes #778 

**Changes**
When CMIS is enabled, the `ZaakInformatieObjectSerializer` and `BesluitInformatieObjectSerializer` method `create()` returns after creating a new object in the same way as for local `ZaakInformatieObject` and `BesluitInformatieObject`.


