### PR TITLE
Changed ordering of cloning/filtering CMISQuerySet

### DIFF
--- a/src/openzaak/components/documenten/query/cmis.py
+++ b/src/openzaak/components/documenten/query/cmis.py
@@ -547,6 +547,17 @@ class CMISQuerySet(InformatieobjectQuerySet, CMISClientMixin):
         return django_document
 
     def filter(self, *args, **kwargs):
+
+        clone = super().filter(*args, **kwargs)
+
+        filters = self._construct_filters(**kwargs)
+
+        # keep track of all the filters when chaining
+        clone._cmis_query += [tuple(x) for x in filters.items()]
+
+        return clone
+
+    def _construct_filters(self, **kwargs) -> dict:
         filters = {}
 
         # Limit filter to just exact lookup for now (until implemented in drc_cmis)
@@ -579,10 +590,7 @@ class CMISQuerySet(InformatieobjectQuerySet, CMISClientMixin):
             else:
                 filters[key_bits[0]] = value
 
-        # keep track of all the filters when chaining
-        self._cmis_query += [tuple(x) for x in filters.items()]
-
-        return super().filter(*args, **kwargs)
+        return filters
 
     def update(self, **kwargs):
         docs_to_update = super().iterator()

--- a/src/openzaak/components/documenten/tests/test_cmis_queries.py
+++ b/src/openzaak/components/documenten/tests/test_cmis_queries.py
@@ -63,3 +63,21 @@ class QueryTests(APICMISTestCase):
             {eio.identificatie for eio in eios},
             {eio1.identificatie, eio2.identificatie},
         )
+
+    def test_multiple_filters(self):
+        eio1 = EnkelvoudigInformatieObjectFactory.create(identificatie="001")
+        eio2 = EnkelvoudigInformatieObjectFactory.create(identificatie="002")
+
+        eios = EnkelvoudigInformatieObject.objects.all()
+
+        first_filter = eios.filter(identificatie="001")
+
+        self.assertEqual(
+            [eio.identificatie for eio in first_filter], [eio1.identificatie],
+        )
+
+        second_filter = eios.filter(identificatie="002")
+
+        self.assertEqual(
+            [eio.identificatie for eio in second_filter], [eio2.identificatie],
+        )


### PR DESCRIPTION
Fixes #782 

**Changes**

Before, when filtering a `CMISQuerySet`, the `_cmis_query` of the original queryset was updated.
Now, the `_cmis_query` property of the clone of the original queryset is updated.

