### PR TITLE
Fix potentially unsafe external link

### DIFF
--- a/src/openzaak/config/templates/admin/config_detail.html
+++ b/src/openzaak/config/templates/admin/config_detail.html
@@ -99,7 +99,10 @@
                         <td>{{ service.api_type|show_api_type }}</td>
                         <td>{{ service.api_root|urlize }}</td>
                         <td>{{ service.nlx|urlize }}</td>
-                        <td><a href="{{ service.oas }}" target="_blank">{% trans "Externe link" %}</a></td>
+                        <td>
+                            <a href="{{ service.oas }}" target="_blank" rel="noreferrer noopener">
+                            {% trans "Externe link" %}</a>
+                        </td>
                         <td>
                             <strong>{{ service.get_auth_type_display}}</strong>
                             {% if service.auth_type == 'zgw' %}


### PR DESCRIPTION
Links that open in a new tab/window without link type `noopener`
or `noreferrer` specified are vulnerable to DOM mutation via
`window.opener`.

Fixes an issue from the _Code scanning alerts_.
