### PR TITLE
Modified ZaakInformatieObject and UniqueTogetherValidator representations

### DIFF
--- a/src/openzaak/components/besluiten/api/serializers.py
+++ b/src/openzaak/components/besluiten/api/serializers.py
@@ -10,7 +10,6 @@ from django.utils.translation import ugettext_lazy as _
 from django_loose_fk.virtual_models import ProxyMixin
 from rest_framework import serializers
 from rest_framework.reverse import reverse
-from rest_framework.validators import UniqueTogetherValidator
 from vng_api_common.serializers import add_choice_values_help_text
 from vng_api_common.utils import get_help_text
 from vng_api_common.validators import IsImmutableValidator, validate_rsin
@@ -26,6 +25,7 @@ from openzaak.utils.validators import (
     LooseFkResourceValidator,
     ObjecttypeInformatieobjecttypeRelationValidator,
     PublishValidator,
+    UniqueTogetherValidator,
 )
 
 from ..constants import VervalRedenen

--- a/src/openzaak/components/catalogi/api/serializers/besluittype.py
+++ b/src/openzaak/components/catalogi/api/serializers/besluittype.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
 from rest_framework import serializers
-from rest_framework.validators import UniqueTogetherValidator
 from vng_api_common.utils import get_help_text
+
+from openzaak.utils.validators import UniqueTogetherValidator
 
 from ...models import BesluitType, InformatieObjectType, ZaakType
 from ..validators import (

--- a/src/openzaak/components/catalogi/api/serializers/eigenschap.py
+++ b/src/openzaak/components/catalogi/api/serializers/eigenschap.py
@@ -2,8 +2,9 @@
 # Copyright (C) 2019 - 2020 Dimpact
 from drf_writable_nested import NestedCreateMixin, NestedUpdateMixin
 from rest_framework import serializers
-from rest_framework.validators import UniqueTogetherValidator
 from vng_api_common.serializers import add_choice_values_help_text
+
+from openzaak.utils.validators import UniqueTogetherValidator
 
 from ...constants import FormaatChoices
 from ...models import Eigenschap, EigenschapSpecificatie

--- a/src/openzaak/components/catalogi/api/serializers/informatieobjecttype.py
+++ b/src/openzaak/components/catalogi/api/serializers/informatieobjecttype.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
 from rest_framework import serializers
-from rest_framework.validators import UniqueTogetherValidator
 from vng_api_common.constants import VertrouwelijkheidsAanduiding
 from vng_api_common.serializers import add_choice_values_help_text
+
+from openzaak.utils.validators import UniqueTogetherValidator
 
 from ...models import InformatieObjectType
 from ..validators import (

--- a/src/openzaak/components/catalogi/api/serializers/relatieklassen.py
+++ b/src/openzaak/components/catalogi/api/serializers/relatieklassen.py
@@ -3,8 +3,9 @@
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import serializers
-from rest_framework.validators import UniqueTogetherValidator
 from vng_api_common.serializers import add_choice_values_help_text
+
+from openzaak.utils.validators import UniqueTogetherValidator
 
 from ...constants import RichtingChoices
 from ...models import ZaakTypeInformatieObjectType

--- a/src/openzaak/components/catalogi/api/serializers/resultaattype.py
+++ b/src/openzaak/components/catalogi/api/serializers/resultaattype.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import serializers
-from rest_framework.validators import UniqueTogetherValidator
 from vng_api_common.constants import (
     Archiefnominatie,
     BrondatumArchiefprocedureAfleidingswijze as Afleidingswijze,
@@ -16,6 +15,8 @@ from vng_api_common.serializers import (
     add_choice_values_help_text,
 )
 from vng_api_common.validators import ResourceValidator
+
+from openzaak.utils.validators import UniqueTogetherValidator
 
 from ...models import ResultaatType
 from ..validators import (

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -10,7 +10,6 @@ from django.utils.translation import ugettext_lazy as _
 from django_loose_fk.virtual_models import ProxyMixin
 from drf_writable_nested import NestedCreateMixin, NestedUpdateMixin
 from rest_framework import serializers
-from rest_framework.validators import UniqueTogetherValidator
 from rest_framework_gis.fields import GeometryField
 from rest_framework_nested.relations import NestedHyperlinkedRelatedField
 from rest_framework_nested.serializers import NestedHyperlinkedModelSerializer
@@ -43,6 +42,7 @@ from openzaak.utils.validators import (
     LooseFkResourceValidator,
     ObjecttypeInformatieobjecttypeRelationValidator,
     PublishValidator,
+    UniqueTogetherValidator,
 )
 
 from ...brondatum import BrondatumCalculator

--- a/src/openzaak/components/zaken/models/zaken.py
+++ b/src/openzaak/components/zaken/models/zaken.py
@@ -4,6 +4,7 @@ import logging
 import uuid
 from datetime import date
 
+from django.conf import settings
 from django.contrib.gis.db.models import GeometryField
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import RegexValidator
@@ -844,6 +845,10 @@ class ZaakInformatieObject(models.Model):
         ]
 
     def __str__(self) -> str:
+        # Avoid making a query to the DMS for the representation
+        if settings.CMIS_ENABLED:
+            return f"{self.zaak} - {self._informatieobject_url}"
+
         # In case of an external informatieobject, use the URL as fallback
         try:
             return f"{self.zaak} - {self.informatieobject}"

--- a/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten.py
+++ b/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten.py
@@ -791,3 +791,9 @@ class ExternalDocumentDestroyTests(JWTAuthMixin, APITestCase):
 
         error = get_validation_errors(response, "informatieobject")
         self.assertEqual(error["code"], "pending-relations")
+
+    def test_representation(self):
+        zio = ZaakInformatieObjectFactory.create()
+        zio_representation = str(zio)
+        expected_representation = f"{zio.zaak.identificatie} - {zio.informatieobject.latest_version.identificatie}"
+        self.assertEqual(expected_representation, zio_representation)

--- a/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten_cmis.py
@@ -362,3 +362,20 @@ class ZaakInformatieObjectCMISAPITests(JWTAuthMixin, APICMISTestCase, OioMixin):
         # Relation is gone, zaak still exists.
         self.assertFalse(ZaakInformatieObject.objects.exists())
         self.assertTrue(Zaak.objects.exists())
+
+    def test_representation(self):
+        self.create_zaak_besluit_services()
+        zaak = self.create_zaak()
+        io = EnkelvoudigInformatieObjectFactory.create(
+            informatieobjecttype__concept=False
+        )
+        io_url = f"http://testserver{reverse(io)}"
+        self.adapter.get(io_url, json=serialise_eio(io, io_url))
+
+        ZaakTypeInformatieObjectTypeFactory.create(
+            informatieobjecttype=io.informatieobjecttype, zaaktype=zaak.zaaktype
+        )
+        zio = ZaakInformatieObjectFactory.create(zaak=zaak, informatieobject=io_url,)
+        zio_representation = str(zio)
+        expected_representation = f"{zaak.identificatie} - {io_url}"
+        self.assertEqual(expected_representation, zio_representation)

--- a/src/openzaak/utils/validators.py
+++ b/src/openzaak/utils/validators.py
@@ -8,6 +8,11 @@ from django.utils.translation import ugettext_lazy as _
 from django_loose_fk.drf import FKOrURLField, FKOrURLValidator
 from django_loose_fk.virtual_models import ProxyMixin
 from rest_framework import serializers
+from rest_framework.compat import unicode_to_repr
+from rest_framework.utils.representation import smart_repr
+from rest_framework.validators import (
+    UniqueTogetherValidator as _UniqueTogetherValidator,
+)
 from vng_api_common.oas import fetcher, obj_has_shape
 from vng_api_common.utils import get_uuid_from_path
 from vng_api_common.validators import IsImmutableValidator
@@ -202,3 +207,16 @@ class ObjecttypeInformatieobjecttypeRelationValidator:
             )
             if iotype_url not in objecttype_data.get("informatieobjecttypen", []):
                 raise serializers.ValidationError(message, code=code)
+
+
+class UniqueTogetherValidator(_UniqueTogetherValidator):
+    def __repr__(self):
+        """
+        The parent representation function iterates through the queryset and
+        generates a representation for every object in the queryset. This is particularly
+        problematic when CMIS is enabled and for each object a query to the DMS
+        has to be done.
+        """
+        return unicode_to_repr(
+            "<%s(fields=%s)>" % (self.__class__.__name__, smart_repr(self.fields))
+        )


### PR DESCRIPTION
**Changes**

When debugging open-zaak with the CMIS-adapter, we noticed that during handling of exceptions many queries to the DMS were performed. These came from the representations of `ZaakInformatieObject` and the `UniqueTogetherValidator` in the `ZaakInformatieObjectSerializer` (https://github.com/open-zaak/open-zaak/blob/master/src/openzaak/components/zaken/api/serializers/zaken.py#L540).
So, the following changes were made:

1. The `__repr__` method of the `UniqueTogetherValidator` (from django rest framework) was over written. Now it no longer iterates over its queryset and creats a representation for each item in the queryset. Now it only prints the name of the validator and on which fields the unique-together constraint applies. All the models in openzaak which used the `UniqueTogetherValidator` now use the new version of it.

2. In the `ZaakInformatieObject` model, the representation used the `identificatie` of a local document or the URL of an external document to form its representation. Now in the CMIS case it does the same as for the external documents, i.e. it uses the URL of the document.


