### PR TITLE
Dont create documents with same identificatie and bronorganisatie

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -37,7 +37,7 @@ django==2.2.10            # via -r requirements/base.in, django-auth-adfs, djang
 djangorestframework-camel-case==0.2.0  # via -r requirements/base.in, vng-api-common
 djangorestframework-gis==0.14  # via -r requirements/base.in
 djangorestframework==3.9.4  # via -r requirements/base.in, django-extra-fields, django-loose-fk, djangorestframework-gis, drf-nested-routers, drf-yasg, vng-api-common
-drc-cmis==1.1.1           # via -r requirements/base.in
+drc-cmis==1.1.2           # via -r requirements/base.in
 drf-flex-fields==0.5.0    # via -r requirements/base.in
 drf-nested-routers==0.90.2  # via vng-api-common
 drf-writable-nested==0.4.3  # via -r requirements/base.in
@@ -69,6 +69,7 @@ pytz==2019.1              # via django, django-axes
 pyyaml==5.1               # via gemma-zds-client, oyaml, vng-api-common
 redis==3.3.8              # via django-redis
 requests==2.21.0          # via -r requirements/base.in, coreapi, django-auth-adfs, gemma-zds-client, vng-api-common, zgw-consumers
+ruamel.yaml.clib==0.2.2   # via ruamel.yaml
 ruamel.yaml==0.16.7       # via drf-yasg
 sentry-sdk==0.16.5        # via -r requirements/base.in
 six==1.11.0               # via cmislib-maykin, cryptography, django-extra-views, django-markup, drf-yasg, isodate, python-dateutil

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -44,7 +44,7 @@ django==2.2.10            # via -r requirements/base.txt, django-auth-adfs, djan
 djangorestframework-camel-case==0.2.0  # via -r requirements/base.txt, vng-api-common
 djangorestframework-gis==0.14  # via -r requirements/base.txt
 djangorestframework==3.9.4  # via -r requirements/base.txt, django-extra-fields, django-loose-fk, djangorestframework-gis, drf-nested-routers, drf-yasg, vng-api-common
-drc-cmis==1.1.1           # via -r requirements/base.txt
+drc-cmis==1.1.2           # via -r requirements/base.txt
 drf-flex-fields==0.5.0    # via -r requirements/base.txt
 drf-nested-routers==0.90.2  # via -r requirements/base.txt, vng-api-common
 drf-writable-nested==0.4.3  # via -r requirements/base.txt
@@ -59,6 +59,7 @@ gitpython==3.1.7          # via -r requirements/base.txt
 httplib2==0.18.1          # via -r requirements/base.txt, cmislib-maykin
 humanize==0.5.1           # via -r requirements/base.txt
 idna==2.6                 # via -r requirements/base.txt, requests
+importlib-metadata==3.1.1  # via flake8
 inflection==0.3.1         # via -r requirements/base.txt, drf-yasg
 iso-639==0.4.5            # via -r requirements/base.txt, vng-api-common
 iso8601==0.1.12           # via -r requirements/base.txt, cmislib-maykin, drc-cmis
@@ -87,6 +88,7 @@ redis==3.3.8              # via -r requirements/base.txt, django-redis
 regex==2020.6.8           # via black
 requests-mock==1.6.0      # via -r requirements/test-tools.in
 requests==2.21.0          # via -r requirements/base.txt, coreapi, django-auth-adfs, gemma-zds-client, requests-mock, vng-api-common, zgw-consumers
+ruamel.yaml.clib==0.2.2   # via -r requirements/base.txt, ruamel.yaml
 ruamel.yaml==0.16.7       # via -r requirements/base.txt, drf-yasg
 sentry-sdk==0.16.5        # via -r requirements/base.txt
 six==1.11.0               # via -r requirements/base.txt, cmislib-maykin, cryptography, django-extra-views, django-markup, drf-yasg, faker, freezegun, isodate, python-dateutil, requests-mock, webtest
@@ -106,3 +108,4 @@ waitress==1.4.3           # via webtest
 webob==1.8.5              # via webtest
 webtest==2.0.33           # via django-webtest
 zgw-consumers==0.12.2     # via -r requirements/base.txt
+zipp==3.4.0               # via importlib-metadata

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -55,7 +55,7 @@ djangorestframework-camel-case==0.2.0  # via -r requirements/ci.txt, vng-api-com
 djangorestframework-gis==0.14  # via -r requirements/ci.txt
 djangorestframework==3.9.4  # via -r requirements/ci.txt, django-extra-fields, django-loose-fk, djangorestframework-gis, drf-nested-routers, drf-yasg, vng-api-common
 docutils==0.15.2          # via recommonmark, sphinx
-drc-cmis==1.1.1           # via -r requirements/ci.txt
+drc-cmis==1.1.2           # via -r requirements/ci.txt
 drf-flex-fields==0.5.0    # via -r requirements/ci.txt
 drf-nested-routers==0.90.2  # via -r requirements/ci.txt, vng-api-common
 drf-writable-nested==0.4.3  # via -r requirements/ci.txt
@@ -73,6 +73,7 @@ httplib2==0.18.1          # via -r requirements/ci.txt, cmislib-maykin
 humanize==0.5.1           # via -r requirements/ci.txt
 idna==2.6                 # via -r requirements/ci.txt, requests
 imagesize==1.1.0          # via sphinx
+importlib-metadata==3.1.1  # via -r requirements/ci.txt, flake8, jsonschema
 inflection==0.3.1         # via -r requirements/ci.txt, drf-yasg
 iso-639==0.4.5            # via -r requirements/ci.txt, vng-api-common
 iso8601==0.1.12           # via -r requirements/ci.txt, cmislib-maykin, drc-cmis
@@ -118,6 +119,7 @@ requests-mock==1.6.0      # via -r requirements/ci.txt
 requests-oauthlib==1.3.0  # via kubernetes
 requests==2.21.0          # via -r requirements/ci.txt, coreapi, django-auth-adfs, django-silk, gemma-zds-client, kubernetes, requests-mock, requests-oauthlib, sphinx, vng-api-common, zgw-consumers
 rsa==4.6                  # via google-auth
+ruamel.yaml.clib==0.2.2   # via -r requirements/ci.txt, ruamel.yaml
 ruamel.yaml==0.16.7       # via -r requirements/ci.txt, drf-yasg, openshift
 sentry-sdk==0.16.5        # via -r requirements/ci.txt
 six==1.11.0               # via -r requirements/ci.txt, cmislib-maykin, cryptography, django-extensions, django-extra-views, django-markup, drf-yasg, faker, freezegun, google-auth, isodate, jsonschema, kubernetes, openshift, packaging, pip-tools, python-dateutil, requests-mock, websocket-client, webtest
@@ -150,6 +152,7 @@ websocket-client==0.57.0  # via kubernetes
 webtest==2.0.33           # via -r requirements/ci.txt, django-webtest
 whitenoise==5.1.0         # via -r requirements/dev.in
 zgw-consumers==0.12.2     # via -r requirements/ci.txt
+zipp==3.4.0               # via -r requirements/ci.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/src/openzaak/components/documenten/api/serializers.py
+++ b/src/openzaak/components/documenten/api/serializers.py
@@ -187,14 +187,6 @@ class EnkelvoudigInformatieObjectSerializer(serializers.HyperlinkedModelSerializ
     Serializer for the EnkelvoudigInformatieObject model
     """
 
-    identificatie = serializers.CharField(
-        max_length=40,
-        default="",
-        help_text=_(
-            "Een binnen een gegeven context ondubbelzinnige referentie "
-            "naar het INFORMATIEOBJECT."
-        ),
-    )
     url = serializers.HyperlinkedIdentityField(
         view_name="enkelvoudiginformatieobject-detail", lookup_field="uuid"
     )

--- a/src/openzaak/components/documenten/api/serializers.py
+++ b/src/openzaak/components/documenten/api/serializers.py
@@ -43,7 +43,11 @@ from ..models import (
 )
 from ..query.django import InformatieobjectRelatedQuerySet
 from ..utils import PrivateMediaStorageWithCMIS
-from .validators import InformatieObjectUniqueValidator, StatusValidator
+from .validators import (
+    InformatieObjectUniqueValidator,
+    StatusValidator,
+    UniekeIdentificatieValidator,
+)
 
 
 class AnyFileType:
@@ -271,7 +275,10 @@ class EnkelvoudigInformatieObjectSerializer(serializers.HyperlinkedModelSerializ
             },
         }
         read_only_fields = ["versie", "begin_registratie"]
-        validators = [StatusValidator()]
+        validators = [
+            StatusValidator(),
+            UniekeIdentificatieValidator(),
+        ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -393,6 +400,10 @@ class EnkelvoudigInformatieObjectWithLockSerializer(
     class Meta(EnkelvoudigInformatieObjectSerializer.Meta):
         # Use the same fields as the parent class and add the lock to it
         fields = EnkelvoudigInformatieObjectSerializer.Meta.fields + ("lock",)
+
+        # Removing the validator that checks for identificatie/bronorganisatie being unique together, because for a
+        # PATCH request to update a document all the data from the previous document version is used.
+        validators = [StatusValidator()]
 
     def validate(self, attrs):
         valid_attrs = super().validate(attrs)

--- a/src/openzaak/components/documenten/api/serializers.py
+++ b/src/openzaak/components/documenten/api/serializers.py
@@ -187,6 +187,14 @@ class EnkelvoudigInformatieObjectSerializer(serializers.HyperlinkedModelSerializ
     Serializer for the EnkelvoudigInformatieObject model
     """
 
+    identificatie = serializers.CharField(
+        max_length=40,
+        default="",
+        help_text=_(
+            "Een binnen een gegeven context ondubbelzinnige referentie "
+            "naar het INFORMATIEOBJECT."
+        ),
+    )
     url = serializers.HyperlinkedIdentityField(
         view_name="enkelvoudiginformatieobject-detail", lookup_field="uuid"
     )

--- a/src/openzaak/components/documenten/api/validators.py
+++ b/src/openzaak/components/documenten/api/validators.py
@@ -6,6 +6,9 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import serializers
+from vng_api_common.validators import (
+    UniekeIdentificatieValidator as _UniekeIdentificatieValidator,
+)
 
 from ..models import ObjectInformatieObject
 from ..validators import validate_status
@@ -51,3 +54,15 @@ class InformatieObjectUniqueValidator:
 
         if oios:
             raise serializers.ValidationError(detail=self.message, code=self.code)
+
+
+class UniekeIdentificatieValidator(_UniekeIdentificatieValidator):
+    """
+    Valideer dat de combinatie van bronorganisatie en
+    identificatie uniek is.
+    """
+
+    message = _("Deze identificatie bestaat al voor deze bronorganisatie")
+
+    def __init__(self):
+        super().__init__("bronorganisatie", "identificatie")

--- a/src/openzaak/components/documenten/management/__init__.py
+++ b/src/openzaak/components/documenten/management/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2020 Dimpact

--- a/src/openzaak/components/documenten/management/commands/__init__.py
+++ b/src/openzaak/components/documenten/management/commands/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2020 Dimpact

--- a/src/openzaak/components/documenten/management/commands/detect_duplicate_eio.py
+++ b/src/openzaak/components/documenten/management/commands/detect_duplicate_eio.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2020 Dimpact
+from typing import List
+
+from django.conf import settings
+from django.core.management import BaseCommand, CommandError
+from django.db import transaction
+from django.utils.translation import gettext_lazy as _
+
+from openzaak.components.documenten.models import EnkelvoudigInformatieObject
+
+
+class Command(BaseCommand):
+    help = _(
+        "Check for any duplicate documents (with same identificatie, bronorganisatie and versie)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--noinput",
+            "--no-input",
+            action="store_false",
+            dest="interactive",
+            help=_("Delete automatically any duplicates"),
+        )
+
+    def handle(self, *args, **options):
+        if settings.CMIS_ENABLED:
+            self.stdout.write(_("This command does not run with CMIS enabled."))
+            return
+
+        msg = _(f"Checking {EnkelvoudigInformatieObject.objects.count()} records ...")
+        self.stdout.write(msg)
+
+        duplicates = find_duplicate_eios()
+
+        if len(duplicates) == 0:
+            self.stdout.write(_("Found no duplicate records."))
+            return
+
+        msg = _(f"Found {len(duplicates)} duplicate records.")
+        self.stdout.write(msg)
+
+        if not options["interactive"]:
+            delete_duplicates(duplicates)
+            self.stdout.write(self.style.SUCCESS(_("Deleted all the duplicates.")))
+            return
+
+        while True:
+            option = self.get_option()
+
+            if option == 3:
+                self.stdout.write(_("Exiting."))
+                return
+            elif option == 2:
+                try:
+                    delete_duplicates(duplicates)
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            _(f"Deleted {len(duplicates)} duplicate document(s).")
+                        )
+                    )
+                    return
+                except Exception as e:
+                    self.stderr.write(
+                        _("An error occurred. No documents were deleted.")
+                    )
+                    raise e
+            elif option == 1:
+                for document in duplicates:
+                    self.stdout.write(
+                        f"* RSIN: {document.bronorganisatie}, "
+                        f"Identificatie: {document.identificatie}, "
+                        f"UUID: {document.uuid}"
+                    )
+            else:
+                raise CommandError(_("Invalid option chosen."))
+
+    def get_option(self) -> int:
+        message = _(
+            "\n1) Show duplicate records\n"
+            "2) Delete duplicate records (the oldest record(s) will be deleted).\n"
+            "3) Quit\n\n"
+            "Choose your action [1-3]:\n"
+        )
+
+        raw_value = input(message)
+        try:
+            value = int(raw_value)
+        except ValueError:
+            raise CommandError(_("Invalid option chosen."))
+
+        return value
+
+
+def find_duplicate_eios() -> List[EnkelvoudigInformatieObject]:
+    all_documents = EnkelvoudigInformatieObject.objects.order_by("creatiedatum")
+
+    already_seen = set()
+    duplicates = []
+    for document in all_documents:
+        unique_data = (
+            document.identificatie,
+            document.bronorganisatie,
+            document.versie,
+        )
+        if unique_data in already_seen:
+            duplicates.append(document)
+        else:
+            already_seen.add(unique_data)
+
+    return duplicates
+
+
+@transaction.atomic
+def delete_duplicates(duplicates: List) -> None:
+    for document in duplicates:
+        document.delete()
+    return

--- a/src/openzaak/components/documenten/management/commands/detect_duplicate_eio.py
+++ b/src/openzaak/components/documenten/management/commands/detect_duplicate_eio.py
@@ -29,7 +29,9 @@ class Command(BaseCommand):
             self.stdout.write(_("This command does not run with CMIS enabled."))
             return
 
-        msg = _(f"Checking {EnkelvoudigInformatieObject.objects.count()} records ...")
+        msg = _("Checking {count} records ...").format(
+            count=EnkelvoudigInformatieObject.objects.count()
+        )
         self.stdout.write(msg)
 
         duplicates = find_duplicate_eios()
@@ -38,7 +40,7 @@ class Command(BaseCommand):
             self.stdout.write(_("Found no duplicate records."))
             return
 
-        msg = _(f"Found {len(duplicates)} duplicate records.")
+        msg = _("Found {count} duplicate records.").format(count=len(duplicates))
         self.stdout.write(msg)
 
         if not options["interactive"]:
@@ -57,7 +59,9 @@ class Command(BaseCommand):
                     delete_duplicates(duplicates)
                     self.stdout.write(
                         self.style.SUCCESS(
-                            _(f"Deleted {len(duplicates)} duplicate document(s).")
+                            _("Deleted {count} duplicate document(s).").format(
+                                count=len(duplicates)
+                            )
                         )
                     )
                     return

--- a/src/openzaak/components/documenten/models.py
+++ b/src/openzaak/components/documenten/models.py
@@ -382,7 +382,9 @@ class EnkelvoudigInformatieObject(
     objects = AdapterManager()
 
     class Meta:
-        unique_together = ("uuid", "versie")
+        # No bronorganisatie/identificatie unique-together constraint, otherwise new versions of a document cannot be
+        # saved to the database.
+        unique_together = [("uuid", "versie")]
         verbose_name = _("Document")
         verbose_name_plural = _("Documenten")
         indexes = [models.Index(fields=["canonical", "-versie"])]

--- a/src/openzaak/components/documenten/query/cmis.py
+++ b/src/openzaak/components/documenten/query/cmis.py
@@ -532,6 +532,7 @@ class CMISQuerySet(InformatieobjectQuerySet, CMISClientMixin):
             kwargs.setdefault("versie", "1")
             new_cmis_document = self.cmis_client.create_document(
                 identification=kwargs.get("identificatie"),
+                bronorganisatie=kwargs.get("bronorganisatie"),
                 data=kwargs,
                 content=content,
             )

--- a/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject_cmis.py
@@ -189,6 +189,38 @@ class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APICMISTestCase, OioMixi
         # Test that identificatie is set to the same as the uuid
         self.assertEqual(stored_object.identificatie, str(stored_object.uuid))
 
+    def test_create_two_docs_with_same_identificatie_and_bronorganisatie(self):
+        informatieobjecttype = InformatieObjectTypeFactory.create(concept=False)
+        informatieobjecttype_url = reverse(informatieobjecttype)
+        content = {
+            "identificatie": "12345",
+            "bronorganisatie": "159351741",
+            "creatiedatum": "2018-06-27",
+            "titel": "detailed summary",
+            "auteur": "test_auteur",
+            "formaat": "txt",
+            "taal": "eng",
+            "bestandsnaam": "dummy.txt",
+            "inhoud": b64encode(b"some file content").decode("utf-8"),
+            "link": "http://een.link",
+            "beschrijving": "test_beschrijving",
+            "informatieobjecttype": f"http://testserver{informatieobjecttype_url}",
+            "vertrouwelijkheidaanduiding": "openbaar",
+        }
+
+        # Send to the API
+        response = self.client.post(self.list_url, content)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+
+        response = self.client.post(self.list_url, content)
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+        )
+        self.assertEqual(len(response.data["invalid_params"]), 1)
+        self.assertEqual(
+            response.data["invalid_params"][0]["code"], "identificatie-niet-uniek"
+        )
+
     def test_create_fail_informatieobjecttype_max_length(self):
         informatieobjecttype = InformatieObjectTypeFactory.create()
         informatieobjecttype_url = reverse(informatieobjecttype)


### PR DESCRIPTION
Fixes #768 

**Changes**

Previously, documents with the same `identificatie` and `bronorganisatie` could be created through the API. There was no unique-together constraint in the database or validator in the document serializer.

A unique-together constraint only on `identificatie` and `bronorganisatie` cannot be added at the database level, because there *can* be multiple documents with same `identificatie` and `bronorganisatie` but different `versie`.

So, for now I only added a `UniekeIdentificatieValidator` [validator](https://github.com/VNG-Realisatie/vng-api-common/blob/master/vng_api_common/validators.py#L301) which checks for the uniqueness of the identificatie within an organisation. I added this validator *only* to the `EnkelvoudigInformatieObjectSerializer` and not to the `EnkelvoudigInformatieObjectWithLockSerializer`. This is because the PATCH request to update a document raises a validation error for when a document is updated (since the `identificatie`/`bronorganisatie` are not unique..).

