### PR TITLE
Fixes #791 Retrieve OIOs with CMIS enabled

### DIFF
--- a/src/openzaak/components/documenten/api/serializers.py
+++ b/src/openzaak/components/documenten/api/serializers.py
@@ -154,10 +154,10 @@ class EnkelvoudigInformatieObjectHyperlinkedRelatedField(LengthHyperlinkedRelate
                 self.parent.instance, ObjectInformatieObject
             ):
                 eio_latest_version = self.parent.instance.get_informatieobject()
-            # When .to_representation() is called from a list comprehension in ListSerializer
-            # self.parent.instance is a queryset.
+            # If self.parent.parent is a ListSerializer, self.parent.instance is a queryset rather than a
+            # gebruiksrechten/oio. The informatieobject URL cannot be retrieved. See issue #791
             elif isinstance(self.parent.instance, InformatieobjectRelatedQuerySet):
-                eio_latest_version = self.parent.instance.get().get_informatieobject()
+                return ""
         else:
             eio_latest_version = obj.latest_version
 

--- a/src/openzaak/components/documenten/query/cmis.py
+++ b/src/openzaak/components/documenten/query/cmis.py
@@ -653,9 +653,7 @@ class GebruiksrechtenQuerySet(InformatieobjectRelatedQuerySet, CMISClientMixin):
             if isinstance(value, datetime.datetime) or isinstance(value, datetime.date):
                 kwargs[key] = value.strftime("%Y-%m-%dT%H:%M:%S.%f")
 
-        cmis_gebruiksrechten = self.cmis_client.create_content_object(
-            data=kwargs, object_type="gebruiksrechten"
-        )
+        cmis_gebruiksrechten = self.cmis_client.create_gebruiksrechten(data=kwargs)
 
         # Get EnkelvoudigInformatieObject uuid from URL
         uuid = kwargs.get("informatieobject").split("/")[-1]

--- a/src/openzaak/components/documenten/tests/test_gebruiksrechten_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_gebruiksrechten_cmis.py
@@ -115,3 +115,26 @@ class GebruiksrechtenTests(JWTAuthMixin, APICMISTestCase):
 
         error = get_validation_errors(response, "nonFieldErrors")
         self.assertEqual(error["code"], "unknown-parameters")
+
+    def test_retrieve_multiple_gebruiksrechten(self):
+        eio_1 = EnkelvoudigInformatieObjectFactory.create()
+        eio_1_url = f"http://example.com{reverse(eio_1)}"
+
+        eio_2 = EnkelvoudigInformatieObjectFactory.create()
+        eio_2_url = f"http://example.com{reverse(eio_2)}"
+
+        GebruiksrechtenCMISFactory(informatieobject=eio_1_url)
+        GebruiksrechtenCMISFactory(informatieobject=eio_2_url)
+
+        response = self.client.get(reverse("gebruiksrechten-list"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(len(response.data), 2)
+        self.assertTrue(
+            eio_1_url == response.data[0]["informatieobject"]
+            or eio_1_url == response.data[1]["informatieobject"]
+        )
+        self.assertTrue(
+            eio_2_url == response.data[0]["informatieobject"]
+            or eio_2_url == response.data[1]["informatieobject"]
+        )


### PR DESCRIPTION
Fixes #791 

**Problem description**
After OIOs have been retrieved, they are serialized. The fields `informatieobject` and `zaak` need to be turned into URLs.
For the `informatieobject` field, this is done by passing the canonical object to the `get_url()` function of `EnkelvoudigInformatieObjectHyperlinkedRelatedField`.

```python
def get_url(self, obj, view_name, request, format):
    # obj is a EIOCanonical. If CMIS is enabled, it can't be used to retrieve the EIO latest version.
    if settings.CMIS_ENABLED:
        # self.parent is a serialiser, with instance Oio/Gebruiksrechten. These can be used to retrieve the EIO
        if isinstance(self.parent.instance, Gebruiksrechten) or isinstance(
            self.parent.instance, ObjectInformatieObject
        ):
            eio_latest_version = self.parent.instance.get_informatieobject()
        # When .to_representation() is called from a list comprehension in ListSerializer
        # self.parent.instance is a ObjectInformatieObject queryset.
        elif isinstance(self.parent.instance, InformatieobjectRelatedQuerySet):
            eio_latest_version = self.parent.instance.get().get_informatieobject()    # <====== PROBLEM
    else:
        eio_latest_version = obj.latest_version

    return super().get_url(eio_latest_version, view_name, request, format)
```

With the CMIS adapter, the canonical object cant be used to retrieve the document url. In the case of retrieving a single `gebruiksrechten`/`objectinformatieobject` the field `self.parent.instance` is a `gebruiksrechten` or a `objectinformatieobject` and these can be used to retrieve the URL of the informatieobject.

However, when retrieving *multiple* `gebruiksrechten`/`objectinformatieobject`, `self.parent.parent` is a `ListSerializer`, which means that `self.parent.instance` is a queryset with all the retrieved `gebruiksrechten`/`objectinformatieobject`. Because we don't know which `gebruiksrechten`/`objectinformatieobject` is being serialized, we can't find which document URL should be returned.

**Suggested Solution**
Return `""` for the `informatieobject` URL, because in the `to_representation()` method of the `ObjectInformatieObjectSerializer` (and similar for the `GebruiksrechtenSerializer`), there is a [line](https://github.com/open-zaak/open-zaak/blob/master/src/openzaak/components/documenten/api/serializers.py#L600) that retrieves the `informatieobject` URL and adds it to the representation:

```python
def to_representation(self, instance):
    object_type = instance.object_type
    self.set_object_properties(object_type)
    ret = super().to_representation(instance)	   #<==== Inside here problematic call to get_url()
    if settings.CMIS_ENABLED:
        # Objects without a primary key will have 'None' as the URL, so it is added manually
        path = reverse(
            "objectinformatieobject-detail",
            kwargs={"version": 1, "uuid": instance.uuid},
        )
        ret["url"] = make_absolute_uri(path, request=self.context.get("request"))
        ret["informatieobject"] = instance.get_informatieobject_url()	#<====== HERE

    return ret
``` 

