### PR TITLE
Fixes #790 -- Mock HTTP 200, 204 and 404 responses with nginx container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,11 @@ jobs:
           node-version: '12'
 
       - name: Install system packages
-        run: sudo apt-get install libgdal-dev gdal-bin
+        run: |
+          sudo apt-get update \
+          && sudo apt-get install -y --no-install-recommends \
+            libgdal-dev \
+            gdal-bin
 
       - name: Bring up Alfresco
         run: |

--- a/bin/postman_tests.sh
+++ b/bin/postman_tests.sh
@@ -40,7 +40,7 @@ node bin/newman_tests.js \
     --nrc_url=$nrc_url/api/v1 \
     --ac_url=$openzaak_url/autorisaties/api/v1 \
     --referentielijst_url=https://referentielijsten-api.vng.cloud/api/v1 \
-    --mock_url=https://c9ac80e5-f4f6-46f9-9e64-a164c03b5f25.mock.pstmn.io \
+    --mock_url=http://mock-endpoints.local \
     --client_id=$client_id \
     --secret=$secret \
     --client_id_limited=$client_id_limited \

--- a/docker-compose.travis.yml
+++ b/docker-compose.travis.yml
@@ -58,6 +58,13 @@ services:
   redis:
     image: redis
 
+  mock-endpoints.local:
+    image: nginx:1.19
+    volumes:
+      - ./mocks.conf:/etc/nginx/conf.d/default.conf
+    ports:
+      - 9000:80
+
   web:
     build: .
     environment:

--- a/mocks.conf
+++ b/mocks.conf
@@ -1,0 +1,19 @@
+server {
+    listen       80 default_server;
+    server_name  _;
+
+    location /200 {
+        add_header Content-Type text/html;
+        return 200;
+    }
+
+    location /204 {
+        add_header Content-Type application/json;
+        return 204;
+    }
+
+    location /404 {
+        add_header Content-Type text/html;
+        return 404 "";
+    }
+}


### PR DESCRIPTION
…nginx container

Fixes #790

**Changes**

* Replaced the mock postman requests with local "endpoints" using static nginx configuration.
* Fix package installation on Github runners for libgdal

Checklist based on https://github.com/VNG-Realisatie/gemma-postman-tests/blob/master/ZGW_mocks.json

- [x] 200
- [x] 204
- [x] 404
