### PR TITLE
Issue/protocol auth notifs

### DIFF
--- a/src/openzaak/components/autorisaties/tests/admin/test_autorisaties_admin.py
+++ b/src/openzaak/components/autorisaties/tests/admin/test_autorisaties_admin.py
@@ -585,7 +585,6 @@ class ManageAutorisatiesAdmin(NotificationServiceMixin, TransactionTestCase):
         self.assertEqual(self.applicatie.autorisaties.count(), 1)
         self.assertTrue(m.called)
 
-    @tag("this")
     @override_settings(NOTIFICATIONS_DISABLED=False, IS_HTTPS=True)
     @requests_mock.Mocker()
     def test_notification_body_current_and_future(self, m):

--- a/src/openzaak/components/autorisaties/tests/test_autorisatiespec.py
+++ b/src/openzaak/components/autorisaties/tests/test_autorisatiespec.py
@@ -5,13 +5,10 @@ from django.test import TestCase
 from vng_api_common.authorizations.models import Autorisatie
 from vng_api_common.constants import ComponentTypes, VertrouwelijkheidsAanduiding
 
-from openzaak.components.autorisaties.tests.factories import (
-    ApplicatieFactory,
-    AutorisatieFactory,
-    AutorisatieSpecFactory,
-)
 from openzaak.components.catalogi.tests.factories import ZaakTypeFactory
 from openzaak.utils import build_absolute_url
+
+from .factories import ApplicatieFactory, AutorisatieFactory, AutorisatieSpecFactory
 
 
 class DeleteAutorisatieTest(TestCase):

--- a/src/openzaak/components/autorisaties/utils.py
+++ b/src/openzaak/components/autorisaties/utils.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2019 - 2020 Dimpact
 from typing import Any, Dict, Optional, Union
 
+from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db.models.base import ModelBase
 from django.http import HttpRequest
@@ -91,13 +92,18 @@ def versions_equivalent(version1: Dict[str, Any], version2: Dict[str, Any]) -> b
     return not any(dictdiffer.diff(version1, version2))
 
 
+class MockRequest(HttpRequest):
+    def _get_scheme(self):
+        return "https" if settings.IS_HTTPS else "http"
+
+
 def send_applicatie_changed_notification(
     applicatie: Applicatie, new_version: Optional[Dict[str, Any]] = None
 ):
     viewset = ApplicatieViewSet()
     viewset.action = "update"
     if new_version is None:
-        request = HttpRequest()
+        request = MockRequest()
         request.META["HTTP_HOST"] = Site.objects.get_current().domain
         new_version = get_applicatie_serializer(applicatie, request).data
     viewset.notify(status_code=200, data=new_version, instance=applicatie)


### PR DESCRIPTION
Fixes #802

**Changes**

* Added regression test
* Implemented mock request context for serializer that respects the `settings.IS_HTTPS` setting

