### PR TITLE
Gebruiksrechten get updated when CMIS is enabled

### DIFF
--- a/src/openzaak/components/documenten/query/cmis.py
+++ b/src/openzaak/components/documenten/query/cmis.py
@@ -706,6 +706,21 @@ class GebruiksrechtenQuerySet(InformatieobjectRelatedQuerySet, CMISClientMixin):
 
         return converted_data
 
+    def update(self, **kwargs):
+        gebruiksrechten_to_update = super().iterator()
+
+        updated = 0
+
+        for django_gebruiksrechten in gebruiksrechten_to_update:
+            self.cmis_client.update_gebruiksrechten(
+                drc_uuid=django_gebruiksrechten.uuid, data=kwargs,
+            )
+
+            updated += 1
+
+        # Should return the number of rows in the database table that have been modified
+        return updated
+
 
 class ObjectInformatieObjectCMISQuerySet(
     ObjectInformatieObjectQuerySet, CMISClientMixin

--- a/src/openzaak/components/documenten/tests/test_gebruiksrechten.py
+++ b/src/openzaak/components/documenten/tests/test_gebruiksrechten.py
@@ -105,3 +105,69 @@ class GebruiksrechtenTests(JWTAuthMixin, APITestCase):
 
         error = get_validation_errors(response, "nonFieldErrors")
         self.assertEqual(error["code"], "unknown-parameters")
+
+    def test_complete_edit(self):
+        gebruiksrechten = GebruiksrechtenFactory.create(
+            omschrijving_voorwaarden="Test omschrijving voorwaarden"
+        )
+
+        url = reverse(gebruiksrechten)
+
+        gebruiksrechten_data = self.client.get(url).json()
+        self.assertEqual(
+            "Test omschrijving voorwaarden",
+            gebruiksrechten_data["omschrijvingVoorwaarden"],
+        )
+
+        response = self.client.put(
+            url,
+            {
+                "informatieobject": reverse(gebruiksrechten.get_informatieobject()),
+                "startdatum": "2018-12-24T00:00:00Z",
+                "omschrijvingVoorwaarden": "Aangepaste omschrijving voorwaarden",
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            "Aangepaste omschrijving voorwaarden",
+            response.data["omschrijving_voorwaarden"],
+        )
+
+        updated_gebruiksrechten_data = self.client.get(url).json()
+        self.assertEqual(
+            "Aangepaste omschrijving voorwaarden",
+            updated_gebruiksrechten_data["omschrijvingVoorwaarden"],
+        )
+
+    def test_partial_edit(self):
+        gebruiksrechten = GebruiksrechtenFactory.create(
+            omschrijving_voorwaarden="Test omschrijving voorwaarden"
+        )
+
+        url = reverse(gebruiksrechten)
+
+        gebruiksrechten_data = self.client.get(url).json()
+        self.assertEqual(
+            "Test omschrijving voorwaarden",
+            gebruiksrechten_data["omschrijvingVoorwaarden"],
+        )
+
+        response = self.client.put(
+            url,
+            {
+                "informatieobject": reverse(gebruiksrechten.get_informatieobject()),
+                "startdatum": "2018-12-24T00:00:00Z",
+                "omschrijvingVoorwaarden": "Aangepaste omschrijving voorwaarden",
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            "Aangepaste omschrijving voorwaarden",
+            response.data["omschrijving_voorwaarden"],
+        )
+
+        updated_gebruiksrechten_data = self.client.get(url).json()
+        self.assertEqual(
+            "Aangepaste omschrijving voorwaarden",
+            updated_gebruiksrechten_data["omschrijvingVoorwaarden"],
+        )

--- a/src/openzaak/components/documenten/tests/test_gebruiksrechten_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_gebruiksrechten_cmis.py
@@ -138,3 +138,70 @@ class GebruiksrechtenTests(JWTAuthMixin, APICMISTestCase):
             eio_2_url == response.data[0]["informatieobject"]
             or eio_2_url == response.data[1]["informatieobject"]
         )
+
+    def test_complete_edit(self):
+        eio = EnkelvoudigInformatieObjectFactory.create()
+        eio_url = f"http://testserver{reverse(eio)}"
+        gebruiksrechten = GebruiksrechtenCMISFactory(
+            informatieobject=eio_url,
+            omschrijving_voorwaarden="Test omschrijving voorwaarden",
+        )
+
+        url = reverse(gebruiksrechten)
+
+        gebruiksrechten_data = self.client.get(url).json()
+        self.assertEqual(
+            "Test omschrijving voorwaarden",
+            gebruiksrechten_data["omschrijvingVoorwaarden"],
+        )
+
+        response = self.client.put(
+            url,
+            {
+                "informatieobject": reverse(gebruiksrechten.get_informatieobject()),
+                "startdatum": "2018-12-24T00:00:00Z",
+                "omschrijvingVoorwaarden": "Aangepaste omschrijving voorwaarden",
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            "Aangepaste omschrijving voorwaarden",
+            response.data["omschrijving_voorwaarden"],
+        )
+
+        updated_gebruiksrechten_data = self.client.get(url).json()
+        self.assertEqual(
+            "Aangepaste omschrijving voorwaarden",
+            updated_gebruiksrechten_data["omschrijvingVoorwaarden"],
+        )
+
+    def test_partial_edit(self):
+        eio = EnkelvoudigInformatieObjectFactory.create()
+        eio_url = f"http://testserver{reverse(eio)}"
+        gebruiksrechten = GebruiksrechtenCMISFactory(
+            informatieobject=eio_url,
+            omschrijving_voorwaarden="Test omschrijving voorwaarden",
+        )
+
+        url = reverse(gebruiksrechten)
+
+        gebruiksrechten_data = self.client.get(url).json()
+        self.assertEqual(
+            "Test omschrijving voorwaarden",
+            gebruiksrechten_data["omschrijvingVoorwaarden"],
+        )
+
+        response = self.client.patch(
+            url, {"omschrijvingVoorwaarden": "Aangepaste omschrijving voorwaarden",},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            "Aangepaste omschrijving voorwaarden",
+            response.data["omschrijving_voorwaarden"],
+        )
+
+        updated_gebruiksrechten_data = self.client.get(url).json()
+        self.assertEqual(
+            "Aangepaste omschrijving voorwaarden",
+            updated_gebruiksrechten_data["omschrijvingVoorwaarden"],
+        )


### PR DESCRIPTION
Fixes #811 

**Changes**
The `save()` method of Gebruiksrechten now actually calls functions in the CMIS adapter to save the modification of the gebruiksrechten. 

The PR is marked as WIP only because the `drc_cmis` requirement is pinned to a commit rather than a released version.