### PR TITLE
Fixes #822 Cant delete documents unrelated to Zaak

### DIFF
--- a/src/openzaak/components/besluiten/tests/test_besluitinformatieobjecten_cmis.py
+++ b/src/openzaak/components/besluiten/tests/test_besluitinformatieobjecten_cmis.py
@@ -235,3 +235,26 @@ class BesluitInformatieObjectCMISAPITests(JWTAuthMixin, APICMISTestCase, OioMixi
         # Relation is gone, besluit still exists.
         self.assertFalse(BesluitInformatieObject.objects.exists())
         self.assertTrue(Besluit.objects.exists())
+
+    def test_delete_document_unrelated_to_besluit(self):
+        self.create_zaak_besluit_services()
+
+        # Create a document related to a besluit
+        eio_related = EnkelvoudigInformatieObjectFactory.create()
+        eio_related_url = eio_related.get_url()
+        self.adapter.get(
+            eio_related_url, json=serialise_eio(eio_related, eio_related_url)
+        )
+
+        besluit = self.create_besluit()
+        BesluitInformatieObjectFactory.create(
+            informatieobject=eio_related_url, besluit=besluit
+        )
+
+        # Create a document unrelated to a besluit
+        eio_unrelated = EnkelvoudigInformatieObjectFactory.create()
+        eio_unrelated_url = eio_unrelated.get_url()
+
+        response = self.client.delete(eio_unrelated_url)
+
+        self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)

--- a/src/openzaak/components/documenten/models.py
+++ b/src/openzaak/components/documenten/models.py
@@ -453,10 +453,10 @@ class EnkelvoudigInformatieObject(
         if settings.CMIS_ENABLED:
             if (
                 BesluitInformatieObject.objects.filter(
-                    _informatieobject=self.canonical
+                    _informatieobject_url=self.get_url()
                 ).exists()
                 or ZaakInformatieObject.objects.filter(
-                    _informatieobject=self.canonical
+                    _informatieobject_url=self.get_url()
                 ).exists()
             ):
                 return True

--- a/src/openzaak/components/documenten/tests/test_audittrails.py
+++ b/src/openzaak/components/documenten/tests/test_audittrails.py
@@ -150,7 +150,9 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
 
         informatieobject_response = self.client.put(informatieobject_url, content).data
 
-        audittrails = AuditTrail.objects.filter(hoofd_object=informatieobject_url)
+        audittrails = AuditTrail.objects.filter(
+            hoofd_object=informatieobject_url
+        ).order_by("pk")
         self.assertEqual(audittrails.count(), 2)
 
         # Verify that the audittrail for the EnkelvoudigInformatieObject update

--- a/src/openzaak/components/documenten/tests/test_audittrails_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_audittrails_cmis.py
@@ -187,7 +187,9 @@ class AuditTrailTests(JWTAuthMixin, APICMISTestCase):
             informatieobject_url, {"titel": "changed", "lock": eio_canonical.lock},
         ).data
 
-        audittrails = AuditTrail.objects.filter(hoofd_object=informatieobject_url)
+        audittrails = AuditTrail.objects.filter(
+            hoofd_object=informatieobject_url
+        ).order_by("pk")
         self.assertEqual(audittrails.count(), 2)
 
         # Verify that the audittrail for the EnkelvoudigInformatieObject

--- a/src/openzaak/components/documenten/tests/test_eio_delete_cascade_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_eio_delete_cascade_cmis.py
@@ -10,12 +10,7 @@ from vng_api_common.tests import get_validation_errors, reverse
 
 from openzaak.components.besluiten.tests.factories import BesluitInformatieObjectFactory
 from openzaak.components.zaken.tests.factories import ZaakInformatieObjectFactory
-from openzaak.utils.tests import (
-    APICMISTestCase,
-    JWTAuthMixin,
-    OioMixin,
-    get_eio_response,
-)
+from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin, OioMixin
 
 from ..models import EnkelvoudigInformatieObject, Gebruiksrechten
 from .factories import EnkelvoudigInformatieObjectFactory, GebruiksrechtenCMISFactory
@@ -53,12 +48,7 @@ class US349TestCase(JWTAuthMixin, APICMISTestCase, OioMixin):
     def test_delete_document_fail_exising_relations_besluit(self):
         eio = EnkelvoudigInformatieObjectFactory.create()
         eio_uuid = eio.uuid
-        eio_path = reverse(eio)
-        eio_url = f"https://external.documenten.nl/{eio_path}"
-
-        self.adapter.register_uri(
-            "GET", eio_url, json=get_eio_response(eio_path),
-        )
+        eio_url = eio.get_url()
 
         self.create_zaak_besluit_services()
         besluit = self.create_besluit()
@@ -81,12 +71,7 @@ class US349TestCase(JWTAuthMixin, APICMISTestCase, OioMixin):
 
         eio = EnkelvoudigInformatieObjectFactory.create()
         eio_uuid = eio.uuid
-        eio_path = reverse(eio)
-        eio_url = f"https://external.documenten.nl/{eio_path}"
-
-        self.adapter.register_uri(
-            "GET", eio_url, json=get_eio_response(eio_path),
-        )
+        eio_url = eio.get_url()
 
         self.create_zaak_besluit_services()
         zaak = self.create_zaak()

--- a/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject_cmis.py
@@ -14,12 +14,7 @@ from vng_api_common.tests import get_validation_errors, reverse, reverse_lazy
 
 from openzaak.components.catalogi.tests.factories import InformatieObjectTypeFactory
 from openzaak.components.zaken.tests.factories import ZaakInformatieObjectFactory
-from openzaak.utils.tests import (
-    APICMISTestCase,
-    JWTAuthMixin,
-    OioMixin,
-    get_eio_response,
-)
+from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin, OioMixin
 
 from ..models import EnkelvoudigInformatieObject, EnkelvoudigInformatieObjectCanonical
 from .factories import EnkelvoudigInformatieObjectFactory
@@ -431,11 +426,7 @@ class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APICMISTestCase, OioMixi
         """
         eio = EnkelvoudigInformatieObjectFactory.create()
         eio_path = reverse(eio)
-        eio_url = f"https://external.documenten.nl/{eio_path}"
-
-        self.adapter.register_uri(
-            "GET", eio_url, json=get_eio_response(eio_path),
-        )
+        eio_url = eio.get_url()
 
         self.create_zaak_besluit_services()
         zaak = self.create_zaak()

--- a/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten_cmis.py
@@ -379,3 +379,24 @@ class ZaakInformatieObjectCMISAPITests(JWTAuthMixin, APICMISTestCase, OioMixin):
         zio_representation = str(zio)
         expected_representation = f"{zaak.identificatie} - {io_url}"
         self.assertEqual(expected_representation, zio_representation)
+
+    def test_delete_document_unrelated_to_zaak(self):
+        self.create_zaak_besluit_services()
+        zaak = self.create_zaak()
+
+        # Create a document related to a zaak
+        eio_related = EnkelvoudigInformatieObjectFactory.create()
+        eio_related_url = f"http://openzaak.nl{reverse(eio_related)}"
+        self.adapter.get(
+            eio_related_url, json=serialise_eio(eio_related, eio_related_url)
+        )
+
+        ZaakInformatieObjectFactory.create(informatieobject=eio_related_url, zaak=zaak)
+
+        # Create a document unrelated to a zaak
+        eio_unrelated = EnkelvoudigInformatieObjectFactory.create()
+        eio_unrelated_url = f"http://openzaak.nl{reverse(eio_unrelated)}"
+
+        response = self.client.delete(eio_unrelated_url)
+
+        self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)


### PR DESCRIPTION
Fixes #822 

**Changes**
Before, the reference to the documents were checked by filtering on canonical objects. This however doesn't work with CMIS is enabled and the filtering should be done on the document URLs.

