### PR TITLE
Fixes #681 -- Documenting the < 1.0.0 dependency versions

### DIFF
--- a/docs/introduction/open-source/dependencies.rst
+++ b/docs/introduction/open-source/dependencies.rst
@@ -1,0 +1,126 @@
+.. _introduction_open-source_deps:
+
+Open Source dependencies
+========================
+
+Open Zaak would not be possible without a number of other Open Source dependencies.
+
+Most notably, the backend is written in the Python_ programming language. We use the
+Django_ framework to build the web-application (which includes the API of course) that
+is Open Zaak.
+
+The core elements for the API implementation are:
+
+* `Django REST framework`_ (DRF), to implement the RESTful API
+* `drf-yasg`_ to generate the API documentation in the form of OAS 3.0 specification
+* `VNG-API-common`_, a re-usable library with some specific VNG/Dutch API tooling, built
+  on top of DRF and drf-yasg
+
+.. _Python: https://www.python.org/
+.. _Django: https://www.djangoproject.com/
+.. _Django REST framework: https://www.django-rest-framework.org/
+.. _VNG-API-common: https://vng-api-common.readthedocs.io/en/latest/
+.. _drf-yasg: https://drf-yasg.readthedocs.io/en/stable/
+
+What about the dependencies that don't have a 1.0.0 version (yet)?
+------------------------------------------------------------------
+
+Good question!
+
+Most libraries follow semantic versioning, which takes the form of ``A.B.c`` version
+numbering. In this pattern, ``A`` is the major version, ``B`` is the minor version and
+``c`` is the patch version. Roughly speaking, if ``A`` increments, you can expect
+breaking changes. If ``B`` increments, the changes are backwards compatible fixes and
+new features, and if ``c`` changes, it's purely a bugfix release.
+
+Libraries with a version like ``0.x.y`` are usually considering not-stable yet - as long
+as no ``1.0.0`` release has happened, the internal API can change, or the project may
+never reach that "maturity" you'd want.
+
+If you look at our requirements_, you will see a couple of libraries that don't have a
+1.0.0 version (yet). So, why do we depend on them, and is there a risk of depending on
+them? Below, you can find the mitigations/reasoning why we decided to depend on them
+anyway, in alphabetical order.
+
+
+* ``cmislib-maykin==0.7.4`` - this package is a fork of a Python 2 library implementing
+  the CMIS bindings. Maykin Media (one of the Open Zaak service providers) ported it to
+  Python 3 and maintains this fork.
+
+* ``coreschema==0.0.4`` is a transitive dependency of ``coreapi`` and ``drf-yasg``,
+  which are both well-maintained. It is made by the same author as DRF itself.
+
+* ``dictdiffer==0.8.0`` is not mission-critical and can easily be swapped out if needed.
+  It's currently used to visualize changes obtained from audit trail records in the
+  admin interface. The library is Open Source on Github, and could be forked if needed.
+
+* ``django-auth-adfs-db==0.2.0`` is an add-on for ``django-auth-adfs``. Maykin Media is
+  one of the maintainers.
+
+* ``django-db-logger==0.1.7`` is a package authored and maintained by Maykin Media, and
+  used in various other projects.
+
+* ``django-extra-views==0.13.0`` is a popular Django package with a large community
+  behind it. The original author is still active as well.
+
+* ``django-loose-fk==0.7.1`` is a package authored by Maykin Media to serve Open Zaak. It
+  can be considered an integral part of Open Zaak, but the code was separated out in a
+  standalone package for easier maintenance.
+
+* ``django-sendfile2==0.6.0`` is a fork of django-sendfile, focusing on Python 3 support.
+  The core functionality is very stable and unlikely to cause problems.
+
+* ``djangorestframework-camel-case==0.2.0`` is a fairly popular and standard DRF add-on.
+  Schema generators like drf-yasg, drf-spectacular and DRF even have explicit support
+  for this package.
+
+* ``djangorestframework-gis==0.14`` is used for the GeoJSON serialization. We only use
+  a small set of features, but it's the go-to GIS library in combination with DRF, and
+  very stable despite the version numbering.
+
+* ``drf-nested-routers==0.90.2`` sees regular maintenance and activity on Github, with
+  high popularity.
+
+* ``drf-writable-nested==0.4.3`` sees regular maintenance and activity on Github, with
+  high popularity.
+
+* ``gemma-zds-client==0.13.0`` originally developed by Maykin Media for the demo's of
+  the VNG standard, this package is now used by multiple municipalities. VNG has been
+  requested to transfer the package to Maykin Media, and 1.0 preparations are in
+  progress at the time of writing.
+
+* ``httplib2==0.19.0`` transitive dependency of the CMIS binding. Recently saw a
+  security release and is still maintained.
+
+* ``inflection==0.3.1`` transitive dependency of drf-yasg, which is quite a popular
+  project.
+
+* ``iso-639==0.4.5`` stable package that just happens to never have been named 1.0.
+  ISO-639 is an international standard, which don't tend to change.
+
+* ``iso8601==0.1.12`` transitive dependency of the CMIS bindings. Appears to still be
+  maintained.
+
+* ``isodate==0.6.0`` yet another library to parse ISO-8601 dates. Transitive dependency
+  of ``vng-api-common``.
+
+* ``nlx-url-rewriter==0.1.2`` no longer actively used, only here for historical reasons
+  (migrations).
+
+* ``python-dotenv==0.8.2`` is a popular, actively maintained project on Github
+
+* ``ruamel.yaml.clib==0.2.2`` transitive dependency of ``ruamel.yaml``, by the same author
+
+* ``ruamel.yaml==0.16.7`` transitive dependency of drf-yasg, actively maintained.
+
+* ``sentry-sdk==0.16.5`` SDK maintained by the Sentry.io team, it replaces raven. Sentry
+  is widely adapted and has a large community of developers making use of the
+  error-monitoring services through the SDK.
+
+* ``sqlparse==0.3.0`` direct dependency of Django. Given the widespreak use of Django,
+  this should not pose any problems.
+
+* ``zgw-consumers==0.12.2`` library maintained by Maykin Media. Together with
+  gemma-zds-client, preparations are in the works for a 1.0 version.
+
+.. _`requirements`: https://github.com/open-zaak/open-zaak/blob/master/requirements/base.txt

--- a/docs/introduction/open-source/index.rst
+++ b/docs/introduction/open-source/index.rst
@@ -5,15 +5,15 @@ Open-source
 
 Open Zaak is open-source and available under the `EUPL license`_.
 
-In addition, this project makes use of various open-source `Python libraries`_ 
+In addition, this project makes use of various open-source `Python libraries`_
 and `npm packages`_ under the hood.
 
 Public Code
 -----------
 
-The Open Zaak project benefits from the expertise of the `Foundation for Public 
+The Open Zaak project benefits from the expertise of the `Foundation for Public
 Code`_ who helps to scale our codebase, community and development proces. With
-their codebase stewardship program, we are working on becomming fully 
+their codebase stewardship program, we are working on becomming fully
 compliant.
 
 
@@ -26,3 +26,4 @@ compliant.
    :maxdepth: 1
 
    public_code
+   dependencies

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -58,7 +58,7 @@ markdown==3.0.1           # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 maykin-django-better-admin-arrayfield==1.0.5  # via -r requirements/base.in
 nlx-url-rewriter==0.1.2   # via -r requirements/base.in
-oyaml==0.7                # via vng-api-common
+oyaml==1.0                # via vng-api-common
 psycopg2==2.8.4           # via -r requirements/base.in
 pycparser==2.19           # via cffi
 pyjwt==1.6.4              # via django-auth-adfs, gemma-zds-client, vng-api-common

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -46,7 +46,7 @@ gemma-zds-client==0.13.0  # via vng-api-common, zgw-consumers
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.7          # via -r requirements/base.in
 httplib2==0.19.0          # via cmislib-maykin
-humanize==0.5.1           # via -r requirements/base.in
+humanize==3.2.0           # via -r requirements/base.in
 idna==2.6                 # via requests
 inflection==0.3.1         # via drf-yasg
 iso-639==0.4.5            # via vng-api-common
@@ -82,3 +82,6 @@ urllib3==1.24.3           # via requests, sentry-sdk
 uwsgi==2.0.18             # via -r requirements/base.in
 vng-api-common==1.0.57    # via -r requirements/base.in, drc-cmis
 zgw-consumers==0.12.2     # via -r requirements/base.in
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -73,7 +73,7 @@ markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 maykin-django-better-admin-arrayfield==1.0.5  # via -r requirements/base.txt
 mccabe==0.6.1             # via flake8
 nlx-url-rewriter==0.1.2   # via -r requirements/base.txt
-oyaml==0.7                # via -r requirements/base.txt, vng-api-common
+oyaml==1.0                # via -r requirements/base.txt, vng-api-common
 pathspec==0.8.0           # via black
 psycopg2==2.8.4           # via -r requirements/base.txt
 pycodestyle==2.6.0        # via flake8

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -58,7 +58,7 @@ gemma-zds-client==0.13.0  # via -r requirements/base.txt, vng-api-common, zgw-co
 gitdb==4.0.5              # via -r requirements/base.txt, gitpython
 gitpython==3.1.7          # via -r requirements/base.txt
 httplib2==0.19.0          # via -r requirements/base.txt, cmislib-maykin
-humanize==0.5.1           # via -r requirements/base.txt
+humanize==3.2.0           # via -r requirements/base.txt
 idna==2.6                 # via -r requirements/base.txt, requests
 importlib-metadata==3.1.1  # via flake8
 inflection==0.3.1         # via -r requirements/base.txt, drf-yasg
@@ -111,3 +111,6 @@ webob==1.8.5              # via webtest
 webtest==2.0.33           # via django-webtest
 zgw-consumers==0.12.2     # via -r requirements/base.txt
 zipp==3.4.0               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -71,7 +71,7 @@ gitpython==3.1.7          # via -r requirements/ci.txt
 google-auth==1.21.2       # via kubernetes
 gprof2dot==2019.11.30     # via django-silk
 httplib2==0.19.0          # via -r requirements/ci.txt, cmislib-maykin
-humanize==0.5.1           # via -r requirements/ci.txt
+humanize==3.2.0           # via -r requirements/ci.txt
 idna==2.6                 # via -r requirements/ci.txt, requests
 imagesize==1.1.0          # via sphinx
 importlib-metadata==3.1.1  # via -r requirements/ci.txt, flake8, jsonschema

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -92,7 +92,7 @@ mccabe==0.6.1             # via -r requirements/ci.txt, flake8
 nlx-url-rewriter==0.1.2   # via -r requirements/ci.txt
 oauthlib==3.1.0           # via requests-oauthlib
 openshift==0.11.2         # via -r requirements/../deployment/requirements.in
-oyaml==0.7                # via -r requirements/ci.txt, vng-api-common
+oyaml==1.0                # via -r requirements/ci.txt, vng-api-common
 packaging==19.2           # via sphinx
 passlib==1.7.2            # via -r requirements/../deployment/requirements.in
 pathspec==0.8.0           # via -r requirements/ci.txt, black


### PR DESCRIPTION
Fixes #681

* Bumped a couple of dependencies that have since reached a 1.0 version or higher
* Documented the < 1.0 dependencies with the mitigations for the risks