### PR TITLE
Fix Open Zaak handling of remote DRCs

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,7 +24,7 @@ django-extra-fields==1.2.4  # via -r requirements/base.in
 django-extra-views==0.13.0  # via -r requirements/base.in
 django-filter==2.0        # via -r requirements/base.in, django-loose-fk, vng-api-common
 django-ipware==2.1.0      # via django-axes
-django-loose-fk==0.7.1    # via -r requirements/base.in
+django-loose-fk==0.7.3    # via -r requirements/base.in
 django-markup==1.3        # via -r requirements/base.in
 django-ordered-model==2.1.0  # via django-admin-index
 django-privates==1.2.1    # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -31,7 +31,7 @@ django-extra-fields==1.2.4  # via -r requirements/base.txt
 django-extra-views==0.13.0  # via -r requirements/base.txt
 django-filter==2.0.0      # via -r requirements/base.txt, django-loose-fk, vng-api-common
 django-ipware==2.1.0      # via -r requirements/base.txt, django-axes
-django-loose-fk==0.7.1    # via -r requirements/base.txt
+django-loose-fk==0.7.3    # via -r requirements/base.txt
 django-markup==1.3        # via -r requirements/base.txt
 django-ordered-model==2.1.0  # via -r requirements/base.txt, django-admin-index
 django-privates==1.2.1    # via -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -40,7 +40,7 @@ django-extra-fields==1.2.4  # via -r requirements/ci.txt
 django-extra-views==0.13.0  # via -r requirements/ci.txt
 django-filter==2.0.0      # via -r requirements/ci.txt, django-loose-fk, vng-api-common
 django-ipware==2.1.0      # via -r requirements/ci.txt, django-axes
-django-loose-fk==0.7.1    # via -r requirements/ci.txt
+django-loose-fk==0.7.3    # via -r requirements/ci.txt
 django-markup==1.3        # via -r requirements/ci.txt
 django-ordered-model==2.1.0  # via -r requirements/ci.txt, django-admin-index
 django-privates==1.2.1    # via -r requirements/ci.txt

--- a/src/openzaak/components/besluiten/api/serializers.py
+++ b/src/openzaak/components/besluiten/api/serializers.py
@@ -72,7 +72,12 @@ class BesluitSerializer(ConvertNoneMixin, serializers.HyperlinkedModelSerializer
                 ],
             },
             # per BRC API spec!
-            "zaak": {"lookup_field": "uuid", "max_length": 200, "allow_null": False,},
+            "zaak": {
+                "lookup_field": "uuid",
+                "max_length": 200,
+                "allow_null": False,
+                "allow_blank": True,
+            },
             "identificatie": {"validators": [IsImmutableValidator()]},
             "verantwoordelijke_organisatie": {
                 "validators": [IsImmutableValidator(), validate_rsin]

--- a/src/openzaak/components/besluiten/api/serializers.py
+++ b/src/openzaak/components/besluiten/api/serializers.py
@@ -20,6 +20,7 @@ from openzaak.components.zaken.api.utils import (
     delete_remote_zaakbesluit,
 )
 from openzaak.utils.api import create_remote_oio
+from openzaak.utils.serializers import ConvertNoneMixin
 from openzaak.utils.validators import (
     LooseFkIsImmutableValidator,
     LooseFkResourceValidator,
@@ -33,7 +34,7 @@ from ..models import Besluit, BesluitInformatieObject
 from .validators import BesluittypeZaaktypeValidator, UniekeIdentificatieValidator
 
 
-class BesluitSerializer(serializers.HyperlinkedModelSerializer):
+class BesluitSerializer(ConvertNoneMixin, serializers.HyperlinkedModelSerializer):
     vervalreden_weergave = serializers.CharField(
         source="get_vervalreden_display", read_only=True
     )
@@ -71,7 +72,7 @@ class BesluitSerializer(serializers.HyperlinkedModelSerializer):
                 ],
             },
             # per BRC API spec!
-            "zaak": {"lookup_field": "uuid", "max_length": 200},
+            "zaak": {"lookup_field": "uuid", "max_length": 200, "allow_null": False,},
             "identificatie": {"validators": [IsImmutableValidator()]},
             "verantwoordelijke_organisatie": {
                 "validators": [IsImmutableValidator(), validate_rsin]

--- a/src/openzaak/components/besluiten/tests/test_audittrails.py
+++ b/src/openzaak/components/besluiten/tests/test_audittrails.py
@@ -61,6 +61,8 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         modified_data["toelichting"] = "aangepast"
 
         response = self.client.put(url, modified_data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         besluit_response = response.data
 
         audittrails = AuditTrail.objects.filter(hoofd_object=besluit_response["url"])

--- a/src/openzaak/components/besluiten/tests/test_besluit_read.py
+++ b/src/openzaak/components/besluiten/tests/test_besluit_read.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2019 - 2020 Dimpact
+from rest_framework.test import APITestCase
+from vng_api_common.tests import TypeCheckMixin, reverse
+
+from openzaak.utils.tests import JWTAuthMixin
+
+from .factories import BesluitFactory
+
+
+class BesluitReadTests(TypeCheckMixin, JWTAuthMixin, APITestCase):
+    heeft_alle_autorisaties = True
+
+    def test_besluit_zaak_null_regression(self):
+        """
+        Assert that a besluit without zaak returns an empty string in the API.
+
+        Uncovered in the tests with remote DRC integration, which performs validation
+        of the Besluit resource. Open Zaak should not return `null`, but an empty
+        string instead.
+        """
+        besluit = BesluitFactory.create(zaak=None)
+
+        response = self.client.get(reverse(besluit))
+
+        self.assertResponseTypes(
+            response.data,
+            (
+                ("url", str),
+                ("identificatie", str),
+                ("verantwoordelijke_organisatie", str),
+                ("besluittype", str),
+                ("zaak", str),
+                ("datum", str),
+                ("toelichting", str),
+                ("bestuursorgaan", str),
+                ("ingangsdatum", str),
+                ("vervaldatum", type(None)),
+                ("vervalreden", str),
+                ("publicatiedatum", type(None)),
+                ("verzenddatum", type(None)),
+                ("uiterlijke_reactiedatum", type(None)),
+            ),
+        )

--- a/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten.py
+++ b/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten.py
@@ -538,7 +538,6 @@ class ExternalDocumentsAPITests(JWTAuthMixin, APITestCase):
         error = get_validation_errors(response, "informatieobject")
         self.assertEqual(error["code"], "invalid-resource")
 
-    @tag("this")
     @requests_mock.Mocker()
     def test_update_zio_metadata(self, m):
         mock_service_oas_get(m, APITypes.drc, self.base, oas_url=settings.DRC_API_SPEC)

--- a/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten.py
+++ b/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten.py
@@ -538,6 +538,43 @@ class ExternalDocumentsAPITests(JWTAuthMixin, APITestCase):
         error = get_validation_errors(response, "informatieobject")
         self.assertEqual(error["code"], "invalid-resource")
 
+    @tag("this")
+    @requests_mock.Mocker()
+    def test_update_zio_metadata(self, m):
+        mock_service_oas_get(m, APITypes.drc, self.base, oas_url=settings.DRC_API_SPEC)
+        document = f"{self.base}enkelvoudiginformatieobjecten/{uuid.uuid4()}"
+        zio_type = ZaakTypeInformatieObjectTypeFactory.create(
+            informatieobjecttype__concept=False, zaaktype__concept=False
+        )
+        zaak = ZaakFactory.create(zaaktype=zio_type.zaaktype)
+        zaak_url = f"http://openzaak.nl{reverse(zaak)}"
+        eio_response = get_eio_response(
+            document,
+            informatieobjecttype=f"http://testserver{reverse(zio_type.informatieobjecttype)}",
+        )
+        m.get(document, json=eio_response)
+        zio = ZaakInformatieObjectFactory.create(zaak=zaak, informatieobject=document)
+        zio_detail_url = reverse(zio)
+
+        response = self.client.put(
+            zio_detail_url,
+            {
+                "zaak": zaak_url,
+                "informatieobject": document,
+                "titel": "updated title",
+                "beschrijving": "same",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+
+        self.assertEqual(response.data["titel"], "updated title")
+        self.assertEqual(response.data["beschrijving"], "same")
+
+        zio.refresh_from_db()
+        self.assertEqual(zio.titel, "updated title")
+        self.assertEqual(zio.beschrijving, "same")
+
 
 @tag("external-urls")
 class ExternalDocumentsAPITransactionTests(JWTAuthMixin, APITransactionTestCase):

--- a/src/openzaak/utils/serializers.py
+++ b/src/openzaak/utils/serializers.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2019 - 2020 Dimpact
+from rest_framework import fields as drf_fields
+
+
+class ConvertNoneMixin:
+    """
+    Convert None values to the empty-value field type.
+
+    DRF skips the :meth:`rest_framework.fields.Field.to_representation` call if the
+    value of the instance is ``None``. However, fields can be not-nullable (indicated
+    by ``allow_null=False``), which means the value must be converted to the empty value
+    for that particular field type.
+    """
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        fields = self._readable_fields
+
+        for field in fields:
+            if representation[field.field_name] is not None:
+                continue
+
+            if field.allow_null:
+                continue
+
+            if isinstance(field, drf_fields.CharField):
+                representation[field.field_name] = ""
+
+        return representation

--- a/src/openzaak/utils/validators.py
+++ b/src/openzaak/utils/validators.py
@@ -89,20 +89,22 @@ class LooseFkIsImmutableValidator(FKOrURLValidator):
 
             new_value = self.resolver.resolve(self.host, new_value)
 
-        if settings.CMIS_ENABLED:
-            if (
-                isinstance(current_value, ProxyMixin)
-                and isinstance(current_value, EnkelvoudigInformatieObject)
-                and isinstance(new_value, EnkelvoudigInformatieObject)
-            ):
-                current_value_url = current_value._initial_data["url"]
+        if (
+            isinstance(current_value, ProxyMixin)
+            and isinstance(current_value, EnkelvoudigInformatieObject)
+            and isinstance(new_value, EnkelvoudigInformatieObject)
+        ):
+            current_value_url = current_value._initial_data["url"]
+            if settings.CMIS_ENABLED:
                 new_value_url = new_value.get_url()
+            else:
+                new_value_url = new_value._initial_data["url"]
 
-                if new_value_url != current_value_url:
-                    raise serializers.ValidationError(
-                        IsImmutableValidator.message, code=IsImmutableValidator.code
-                    )
-                return
+            if new_value_url != current_value_url:
+                raise serializers.ValidationError(
+                    IsImmutableValidator.message, code=IsImmutableValidator.code
+                )
+            return
 
         if self.instance_path:
             for bit in self.instance_path.split("."):


### PR DESCRIPTION
Relates to #819

While testing the remote DRC integration with the DRC reference implementation service, it turns out that there were more defects in Open Zaak that prevented this from working correctly.

All the issues were uncovered by the test suite on api-test.nl, in combination with the `vngr/gemma-drc:1.0.1.post0` reference implementation of a DRC.

**Changes**

* added regression test for (partial) update validation of `ZaakInformatieObject` where the remote Documents API url does not change
* fixed validation bug where instance comparison happened rather than URL comparison if CMIS is not enabled
* added regression test and fix for remote OIO `DELETE` call on cascading zaak-destroy operations
* added regression test and fix for `Besluit.zaak` being output as `null` in the API, which should be empty string instead according to the API spec
