### PR TITLE
Add Helm chart for Open Zaak

### DIFF
--- a/deployment/helm/.helmignore
+++ b/deployment/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployment/helm/Chart.lock
+++ b/deployment/helm/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.2.0
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 12.2.2
+digest: sha256:16a08ffd3a03cb2410415d090889ea07584977d3f19eef94d2df7daa35317f8b
+generated: "2020-12-15T13:23:50.038387+01:00"

--- a/deployment/helm/Chart.yaml
+++ b/deployment/helm/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: open-zaak
+description: Productiewaardige API's voor Zaakgericht Werken
+
+type: application
+version: 0.1.0
+appVersion: 1.3.0
+
+dependencies:
+  - name: postgresql
+    version: ~10.2.0
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - postgresql
+  - name: redis
+    version: ~12.2.2
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - redis

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -1,0 +1,66 @@
+# Open Zaak chart
+
+The Helm chart installs Open Zaak and by default the following dependencies using subcharts:
+
+- [PostgreSQL](https://github.com/bitnami/charts/tree/master/bitnami/postgresql)
+- [Redis](https://github.com/bitnami/charts/tree/master/bitnami/redis)
+
+## Installation
+
+Install the Helm chart with:
+
+```bash
+helm install open-zaak ./helm \
+    --set "settings.allowedHosts=open-zaak.gemeente.nl" \
+    --set "ingress.enabled=true" \
+    --set "ingress.hosts={open-zaak.gemeente.nl}"
+```
+
+:warning: The default settings are unsafe for production usage. Configure proper secrets, enable persistency and consider High Availability (HA) for the database and the application.
+
+## Configuration
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `tags.postgresql` | Install PostgreSQL subchart | `true` |
+| `tags.redis` | Install Redis subchart | `true` |
+| `image.repository` | The repository of the Docker image | `openzaak/open-zaak` |
+| `image.tag` | The tag of the Docker image | `latest` |
+| `replicaCount` | The number of replicas | `1` |
+| `ingress.enabled` | Expose the application through an ingress | `false` |
+| `ingress.annotations` | Additional annotations on the API ingress | `{}` |
+| `ingress.hosts` | Ingress hosts | `"{open-zaak.gemeente.nl}"` |
+| `ingress.tls` | Ingress TLS settings | `"[]"` |
+| `persistence.enabled` | Enable persistency for application media | `false` |
+| `persistence.size` | The size of the application media persistent volume | `"1Gi"` |
+| `persistence.existingClaim` | Use an existing claim for application media | `null` |
+| `settings.allowedHosts` | A comma-separated list of hosts allowed by the application | `"open-zaak.gemeente.nl"` |
+| `settings.secretKey` | The secret key of the application | `"SOME-RANDOM-SECRET"` |
+| `settings.database.host` | The hostname of PostgreSQL | `"open-zaak-postgresql"` |
+| `settings.database.port` | The port of PostgreSQL | `5432` |
+| `settings.database.username` | The username of PostgreSQL | `"postgres"` |
+| `settings.database.password` | The password of PostgreSQL | `"SUPER-SECRET"` |
+| `settings.database.name` | The database name of PostgreSQL | `"open-zaak"` |
+| `settings.cache.default` | The Redis cache for the default cache | `"open-zaak-redis-master:6379/0"` |
+| `settings.cache.axes` | The Redis cache for the axes cache | `"open-zaak-redis-master:6379/0"` |
+| `settings.email.host` | The hostname of the SMTP server | `"localhost"` |
+| `settings.email.port` | The port of the SMTP server | `25` |
+| `settings.email.username` | The username of the SMTP server | `""` |
+| `settings.email.password` | The password of the SMTP server | `""` |
+| `settings.email.useTLS` | Use TLS for connecting to SMTP server | `false` |
+| `settings.jwtExpiry` | The expiry time for JWT tokens | `3600` |
+| `settings.cmis.enabled` | Enable CMIS | `false` |
+| `settings.cmis.mapperFile` | The CMIS mapper file | `""` |
+| `settings.sentry.dsn` | The DSN for Sentry Logging | `""` |
+| `postgresql.persistence.enabled` | Enable PostgreSQL persistency | `false` |
+| `postgresql.persistence.size` | Configure PostgreSQL size | `"1Gi"` |
+| `postgresql.persistence.existingClaim` | Use an existing persistent volume claim | `null` |
+| `postgresql.postgresqlDatabase` | The PostgreSQL database name | `"open-zaak"` |
+| `postgresql.postgresqlPassword` | The PostgreSQL administrative password | `"SUPER-SECRET"` |
+| `redis.usePassword` | Use a Redis password | `false` |
+| `redis.cluster.enabled` | Enable Redis cluster | `false` |
+| `redis.persistence.existingClaim` | Use existing persistent volume claim for Redis | `""` |
+| `redis.master.persistence.enabled` | Enable persistency for Redis master | `false` |
+| `redis.master.persistence.size` | The size of the Redis master persistent volume | `"1Gi"` |
+
+Check [values.yaml](./values.yaml) for all the possible configuration options.

--- a/deployment/helm/templates/_helpers.tpl
+++ b/deployment/helm/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "open-zaak.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "open-zaak.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "open-zaak.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "open-zaak.labels" -}}
+helm.sh/chart: {{ include "open-zaak.chart" . }}
+{{ include "open-zaak.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "open-zaak.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "open-zaak.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "open-zaak.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "open-zaak.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deployment/helm/templates/configmap.yaml
+++ b/deployment/helm/templates/configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "open-zaak.fullname" . }}
+  labels:
+    {{- include "open-zaak.labels" . | nindent 4 }}
+data:
+  ALLOWED_HOSTS: "{{ include "open-zaak.fullname" . }},{{ .Values.settings.allowedHosts | toString }}"
+  DB_HOST: {{ .Values.settings.database.host | toString | quote }}
+  DB_PORT: {{ .Values.settings.database.port | toString | quote }}
+  DB_USER: {{ .Values.settings.database.username | toString | quote }}
+  DB_NAME: {{ .Values.settings.database.name | toString | quote }}
+  CACHE_DEFAULT: {{ .Values.settings.cache.default | toString | quote }}
+  CACHE_AXES: {{ .Values.settings.cache.axes | toString | quote }}
+  EMAIL_HOST: {{ .Values.settings.email.host | toString | quote }}
+  {{- if .Values.settings.email.username }}
+  EMAIL_USER: {{ .Values.settings.email.username | toString | quote }}
+  {{- end }}
+  {{- if .Values.settings.email.useTLS }}
+  EMAIL_USE_TLS: "True"
+  {{- end }}
+  JWT_EXPIRY: {{ .Values.settings.jwtExpiry | toString | quote }}
+  {{- if .Values.settings.cmis.enabled }}
+  CMIS_ENABLED: "True"
+  {{- end }}
+  {{- if .Values.settings.cmis.mapperFile }}
+  CMIS_MAPPER_FILE: {{ .Values.settings.cmis.mapperFile | toString | quote }}
+  {{- end }}

--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "open-zaak.fullname" . }}
+  labels:
+    {{- include "open-zaak.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "open-zaak.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "open-zaak.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "open-zaak.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: {{ include "open-zaak.fullname" . }}
+            - configMapRef:
+                name: {{ include "open-zaak.fullname" . }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ include "open-zaak.fullname" . | quote }}
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ include "open-zaak.fullname" . | quote }}
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: media
+              mountPath: /media
+      volumes:
+        - name: media
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ include "open-zaak.fullname" . }}{{- end }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deployment/helm/templates/hpa.yaml
+++ b/deployment/helm/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "open-zaak.fullname" . }}
+  labels:
+    {{- include "open-zaak.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "open-zaak.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deployment/helm/templates/ingress.yaml
+++ b/deployment/helm/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "open-zaak.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "open-zaak.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+    {{- end }}
+  {{- end }}

--- a/deployment/helm/templates/pvc.yaml
+++ b/deployment/helm/templates/pvc.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "open-zaak.fullname" . }}
+  labels:
+    {{- include "open-zaak.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/deployment/helm/templates/secret.yaml
+++ b/deployment/helm/templates/secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "open-zaak.fullname" . }}
+  labels:
+    {{- include "open-zaak.labels" . | nindent 4 }}
+type: Opaque
+data:
+  SECRET_KEY: {{ .Values.settings.secretKey | toString | b64enc | quote }}
+  DB_PASSWORD: {{ .Values.settings.database.password | toString | b64enc | quote }}
+  {{- if .Values.settings.sentry.dsn }}
+  SENTRY_DSN: {{ .Values.settings.sentry.dsn | toString | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.settings.email.password }}
+  EMAIL_PASSWORD: {{ .Values.settings.email.password | toString | b64enc | quote }}
+  {{- end }}

--- a/deployment/helm/templates/service.yaml
+++ b/deployment/helm/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "open-zaak.fullname" . }}
+  labels:
+    {{- include "open-zaak.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "open-zaak.selectorLabels" . | nindent 4 }}

--- a/deployment/helm/templates/serviceaccount.yaml
+++ b/deployment/helm/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "open-zaak.serviceAccountName" . }}
+  labels:
+    {{- include "open-zaak.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deployment/helm/templates/tests/test-connection.yaml
+++ b/deployment/helm/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "open-zaak.fullname" . }}-test-connection"
+  labels:
+    {{- include "open-zaak.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "open-zaak.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -1,0 +1,155 @@
+tags:
+  postgresql: true
+  redis: true
+
+replicaCount: 1
+
+image:
+  repository: openzaak/open-zaak
+  pullPolicy: IfNotPresent
+  tag: latest
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+livenessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+readinessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - open-zaak.gemeente.nl
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+persistence:
+  enabled: false
+  size: 1Gi
+  existingClaim: null
+
+settings:
+  allowedHosts: open-zaak.gemeente.nl
+
+  secretKey: SOME-RANDOM-SECRET
+
+  database:
+    host: open-zaak-postgresql
+    port: 5432
+    username: postgres
+    password: SUPER-SECRET
+    name: open-zaak
+
+  email:
+    host: localhost
+    port: 25
+    username: ""
+    password: ""
+    useTLS: false
+
+  cache:
+    default: open-zaak-redis-master:6379/0
+    axes: open-zaak-redis-master:6379/0
+
+  sentry:
+    dsn: ""
+
+  jwtExpiry: 3600
+
+  cmis:
+    enabled: false
+    mapperFile: ""
+
+#######################
+# PostgreSQL subchart #
+#######################
+
+postgresql:
+  persistence:
+    enabled: false
+    size: 1Gi
+    existingClaim: null
+
+  postgresqlDatabase: open-zaak
+  postgresqlPassword: SUPER-SECRET
+
+##################
+# Redis subchart #
+##################
+
+redis:
+  usePassword: false
+
+  cluster:
+    enabled: false
+
+  persistence:
+    existingClaim: null
+
+  master:
+    persistence:
+      enabled: false
+      size: 1Gi


### PR DESCRIPTION
**Changes**

This PR contains a Helm chart for Open Zaak. It follows the structure of `helm create` as closely as possible.

- PostgreSQL and Redis are dependent charts and can be deactivated with `tags.*`
- Contains a smoke-test with wget

This could live in a separate repository as well (e.g. open-zaak/charts). Would also be a great place to configure the [chart-releaser-action](https://github.com/helm/chart-releaser-action).

Tested this chart with multiple end-users, currently hosted [here](https://github.com/bartjkdp/open-zaak-charts).