### PR TITLE
Fixes #717 -- rewrite single-server README

### DIFF
--- a/deployment/single-server/README.md
+++ b/deployment/single-server/README.md
@@ -1,40 +1,37 @@
 # Single-server deployment
 
-This directory contains the tooling to deploy Open Zaak against a single
-server. It has been tested with Debian 9 and 10.
+The [official documentation][docs] documents the installation procedure of Open Zaak. If you're looking
+to install Open Zaak, please follow that documentation.
 
-The application is deployed as docker containers, and the playbook will
-set up all the required dependencies.
+## For maintainers, power-users and devops engineers
+
+This directory contains example [Ansible][Ansible] playbooks to deploy Open Zaak and
+(optionally) [NLX][NLX].
+
+The playbooks are built around roles published on [Ansible Galaxy][Galaxy] by the
+community. This is also were we published the [Open Zaak Collection][collection],
+which provides Open Zaak-specific roles.
 
 ## Requirements
 
-* Debian 9/10 server with root access (see [testserver](#testserver))
+* A server with a supported Linux distribution (see the Ansible Collection docs for
+  supported distros).
+* Root access to the server
 * SSH access (with the root user)
 * A python virtualenv with the [requirements](../requirements.txt) installed
-* Ansible-vault password to decrypt `vars/secrets.yml`
 
 ## Testserver
 
 You can spin up a Debian 'VM' if you don't have a VPS/DDS (yet) to test the
-deployment procedure. See the [VM Readme](./vm/README.md)
+deployment procedure. See the [VM Readme](./vm/README.md).
 
-## Deploying
-Add secrets to the `vars/secrets.yml` encrypted with Ansible-vault.
-You can use `vars/secrets.yml.example` as an example of the content.
+## Deployment
 
-```shell
-[user@host]$ ansible-vault create vars/secrets.yml
-```
+Follow the guide in the [official documentation][docs] - the steps still apply.
 
-Install Ansible requirements:
 
-```shell
-[user@host]$ ansible-galaxy role install -r requirements.yml
-[user@host]$ ansible-galaxy collection install -r requirements.yml
-```
-
-Run the Ansible playbook:
-
-```shell
-[user@host]$ ansible-playbook open-zaak.yml --ask-vault-pass
-```
+[docs]: https://open-zaak.readthedocs.io/en/stable/installation/deployment/single_server.html
+[NLX]: https://nlx.io
+[Ansible]: https://www.ansible.com/
+[Galaxy]: https://galaxy.ansible.com/
+[collection]: https://github.com/open-zaak/ansible-collection


### PR DESCRIPTION
Fixes #717

Instead of providing a short summary with instructions, the README
now refers to the documentation on readthedocs. The target users
of the code itself is now mentioned clearly.
