### PR TITLE
:goal_net: Raise proper error if NRC is not configured when testing notifs send

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,6 +82,8 @@ linkcheck_ignore = [
     r"https?://.*\.gemeente.nl",
     r"http://localhost:\d+/",
     r"https://.*sentry\.openzaak\.nl.*",
+    # TODO temporary workaround for issue #6218 with Pleio
+    r"https://commonground.nl/groups/view/d9c2f667-2f3e-4153-a79b-57dde7f56cc2/team-open-zaak",
 ]
 
 sphinx_tabs_valid_builders = ["linkcheck"]

--- a/src/openzaak/management/commands/send_test_notification.py
+++ b/src/openzaak/management/commands/send_test_notification.py
@@ -12,6 +12,12 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         nrc_client = NotificationsConfig.get_client()
 
+        if not nrc_client:
+            raise CommandError(
+                "Notifications are not properly configured. Please configure "
+                "them via the admin interface"
+            )
+
         kanaal_name = "test"
         Kanaal(kanaal_name, "test")
 


### PR DESCRIPTION
Fixes #667

**Changes**

* When using the `send_test_notification` command, a `CommandError` is now raised if Notifications are not configured properly

