### PR TITLE
:wrench: Increase DATA_UPLOAD_MAX_NUMBER_FIELDS for large auth operations

### DIFF
--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -384,6 +384,11 @@ X_FRAME_OPTIONS = "DENY"
 SILENCED_SYSTEM_CHECKS = ["rest_framework.W001"]
 
 #
+# Increase number of parameters for GET/POST requests
+#
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
+
+#
 # Custom settings
 #
 PROJECT_NAME = "Open Zaak"


### PR DESCRIPTION
Fixes #807

**Changes**
* Increase `DATA_UPLOAD_MAX_NUMBER_FIELDS` to 10000 to allow large auth operations (for many zaaktypen for example)

