### PR TITLE
improve documentation links

### DIFF
--- a/src/openzaak/templates/index.html
+++ b/src/openzaak/templates/index.html
@@ -54,7 +54,25 @@
 
     {% endblock %}
 
-    {% block extra_content %}{% endblock %}
+    {% block extra_content %}
+      <div class="row justify-content-md-center">
+        <div class="col-sm-4 .col-sm-offset-4">
+
+          <div class="card">
+            <div class="card-body">
+              <h5 class="card-title"><i class="fas fa-cogs"></i> Runtime gedrag</h5>
+              <p class="card-text">Beschrijving van de business logica (VNG Standaard).</p>
+              <a href="https://vng-realisatie.github.io/gemma-zaken/standaard/{{ component }}/index" class="btn btn-primary">
+                {{ component|capfirst }} API
+                &nbsp;&nbsp;
+                <i class="fas fa-external-link-alt"></i>
+            </a>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    {% endblock %}
 
     {% block admin_link %}
       <p></p>

--- a/src/openzaak/templates/master.html
+++ b/src/openzaak/templates/master.html
@@ -49,7 +49,7 @@
             <h5>Overige</h5>
             <ul class="list-unstyled text-small">
               <li><a class="text-muted" href="https://www.vngrealisatie.nl/ondersteuningsmiddelen/zaakgericht-werken">Zaakgericht werken volgen VNG</a></li>
-              <li><a class="text-muted" href="https://zaakgerichtwerken.vng.cloud/">API's voor Zaakgericht werken</a></li>
+              <li><a class="text-muted" href="https://www.vngrealisatie.nl/producten/api-standaarden-zaakgericht-werken">API's voor Zaakgericht werken</a></li>
               <li><a class="text-muted" href="https://commonground.nl/">Common Ground</a></li>
             </ul>
           </div>

--- a/src/openzaak/templates/master.html
+++ b/src/openzaak/templates/master.html
@@ -43,6 +43,7 @@
             <ul class="list-unstyled text-small">
               <li><a class="text-muted" href="https://open-zaak.readthedocs.io/en/latest/">Documentatie</a></li>
               <li><a class="text-muted" href="https://github.com/open-zaak/open-zaak">Code op Github</a></li>
+              <li><a class="text-muted" href="https://vng-realisatie.github.io/gemma-zaken/">Standaard "API's voor Zaakgericht werken"</a></li>
             </ul>
           </div>
           <div class="col-4 col-md">


### PR DESCRIPTION
Fixes #753

**Changes**

* linked to gemma-zaken github pages in footer
* changed zaakgerichtwerken.vng.cloud link to the redirect target
* for each component, include a block/link to the runtime behaviour documentation
