### PR TITLE
Fix invalid applications showing up in the Autorisaties API

### DIFF
--- a/src/openzaak/components/autorisaties/admin.py
+++ b/src/openzaak/components/autorisaties/admin.py
@@ -19,6 +19,7 @@ from vng_api_common.constants import ComponentTypes
 from vng_api_common.models import JWTSecret
 from zds_client import ClientAuth
 
+from .admin_filters import InvalidApplicationsFilter
 from .admin_views import AutorisatiesView
 from .forms import ApplicatieForm, CredentialsFormSet
 from .models import AutorisatieSpec
@@ -164,6 +165,10 @@ class ApplicatieAdmin(admin.ModelAdmin):
         "heeft_alle_autorisaties",
         "ready",
         "hints",
+    )
+    list_filter = (
+        "heeft_alle_autorisaties",
+        InvalidApplicationsFilter,
     )
     readonly_fields = ("uuid",)
     form = ApplicatieForm

--- a/src/openzaak/components/autorisaties/admin_filters.py
+++ b/src/openzaak/components/autorisaties/admin_filters.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2021 Dimpact
+from django.contrib import admin
+from django.db.models import Q
+from django.utils.translation import gettext_lazy as _
+
+
+class InvalidApplicationsFilter(admin.SimpleListFilter):
+    title = _("readiness")
+    parameter_name = "readiness"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("valid", _("Valid only")),
+            ("invalid", _("Invalid only")),
+        )
+
+    def queryset(self, request, queryset):
+        invalid = Q(heeft_alle_autorisaties=False, has_authorizations=False) | Q(
+            heeft_alle_autorisaties=True, has_authorizations=True
+        )
+
+        if self.value() == "invalid":
+            return queryset.filter(invalid)
+
+        if self.value() == "valid":
+            return queryset.exclude(invalid)

--- a/src/openzaak/components/autorisaties/api/viewsets.py
+++ b/src/openzaak/components/autorisaties/api/viewsets.py
@@ -95,7 +95,13 @@ class ApplicatieViewSet(
     Na het verwijderen wordt een notificatie verstuurd.
     """
 
-    queryset = Applicatie.objects.prefetch_related("autorisaties").order_by("-pk")
+    queryset = (
+        Applicatie.objects.exclude(
+            heeft_alle_autorisaties=False, autorisaties__isnull=True
+        )
+        .prefetch_related("autorisaties")
+        .order_by("-pk")
+    )
     serializer_class = ApplicatieSerializer
     _filterset_class = ApplicatieFilter
     pagination_class = PageNumberPagination

--- a/src/openzaak/components/autorisaties/api/viewsets.py
+++ b/src/openzaak/components/autorisaties/api/viewsets.py
@@ -99,6 +99,7 @@ class ApplicatieViewSet(
         Applicatie.objects.exclude(
             heeft_alle_autorisaties=False, autorisaties__isnull=True
         )
+        .exclude(heeft_alle_autorisaties=True, autorisaties__isnull=False)
         .prefetch_related("autorisaties")
         .order_by("-pk")
     )

--- a/src/openzaak/components/autorisaties/tests/test_authorizations_api.py
+++ b/src/openzaak/components/autorisaties/tests/test_authorizations_api.py
@@ -329,7 +329,9 @@ class ReadAuthorizationsTests(JWTAuthMixin, APITestCase):
         Retrieve THE application object, using a client ID as lookup.
         """
         url = get_operation_url("applicatie_consumer")
-        app = ApplicatieFactory.create(client_ids=["client id"])
+        app = ApplicatieFactory.create(
+            client_ids=["client id"], heeft_alle_autorisaties=True
+        )
 
         response = self.client.get(url, {"clientId": "client id"})
 

--- a/src/openzaak/components/autorisaties/tests/test_notifications_send.py
+++ b/src/openzaak/components/autorisaties/tests/test_notifications_send.py
@@ -137,7 +137,7 @@ class FailedNotificationTests(NotificationServiceMixin, JWTAuthMixin, APITestCas
         self.assertEqual(failed.message, message)
 
     def test_applicatie_delete_fail_send_notification_create_db_entry(self):
-        applicatie = ApplicatieFactory.create()
+        applicatie = ApplicatieFactory.create(heeft_alle_autorisaties=True)
         url = reverse(applicatie)
 
         with capture_on_commit_callbacks(execute=True):

--- a/src/openzaak/components/catalogi/signals.py
+++ b/src/openzaak/components/catalogi/signals.py
@@ -7,13 +7,19 @@ from django.db.models.base import ModelBase
 from django.db.models.signals import ModelSignal, post_delete
 from django.dispatch import receiver
 
-from vng_api_common.authorizations.models import Autorisatie
+from vng_api_common.authorizations.models import Applicatie, Autorisatie
 
 from openzaak.utils import build_absolute_url
 
 from .models import BesluitType, InformatieObjectType, ZaakType
 
 logger = logging.getLogger(__name__)
+
+FIELD_MAP = {
+    ZaakType: "zaaktype",
+    InformatieObjectType: "informatieobjecttype",
+    BesluitType: "besluittype",
+}
 
 
 @receiver(
@@ -39,4 +45,26 @@ def sync_autorisaties(
 
     instance_path = instance.get_absolute_api_url()
     instance_url = build_absolute_url(instance_path)
-    Autorisatie.objects.filter(zaaktype=instance_url).delete()
+
+    filter_kwargs = {FIELD_MAP[type(instance)]: instance_url}
+
+    autorisaties = Autorisatie.objects.filter(**filter_kwargs)
+    app_ids = list(autorisaties.values_list("applicatie_id", flat=True))
+    autorisaties.delete()
+
+    # well, this is a tricky one! it can happen that this handler deletes the last
+    # Autorisatie related to an Applicatie, which essentially makes the Applicatie
+    # invalid according to the standard - an application either is superuser, or has
+    # autorisaties. Left-overs here would be none of those two options (no superuser, no
+    # autorisaties). With #835, this also hides those applications in the API, since
+    # they're not valid, which means they cannot be deleted either. This caused the
+    # zwg-api-tests postman suite to fail, since there's a call deleting the zaaktype
+    # and then a 404'ing call deleting the applicatie.
+    #
+    # For this reason, since it's effectively deleted in terms of API, we might as well
+    # hard-delete the applicatie completely.
+    apps_to_delete = Applicatie.objects.filter(
+        heeft_alle_autorisaties=False, autorisaties__isnull=True, id__in=app_ids,
+    )
+    logger.info("Deleting applications: %s", apps_to_delete)
+    apps_to_delete.delete()


### PR DESCRIPTION
Fixes #835

**Changes**

* Prevent invalid/not-ready applications from showing up in the API (missing authorizations / superuser flag, or having both)
* Display readiness in admin list + hints on how to resolve un-readiness
* Added filter in admin so that invalid apps can quickly be retrieved

Preview:

![image](https://user-images.githubusercontent.com/5518550/107786961-c7174600-6d4e-11eb-84db-220cc0241fa7.png)

