### PR TITLE
Improve CMIS tests performance

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -37,7 +37,8 @@ django==2.2.17            # via -r requirements/base.in, django-auth-adfs, djang
 djangorestframework-camel-case==0.2.0  # via -r requirements/base.in, vng-api-common
 djangorestframework-gis==0.14  # via -r requirements/base.in
 djangorestframework==3.9.4  # via -r requirements/base.in, django-extra-fields, django-loose-fk, djangorestframework-gis, drf-nested-routers, drf-yasg, vng-api-common
-drc-cmis==1.2.1           # via -r requirements/base.in
+#drc-cmis==1.2.1           # via -r requirements/base.in
+git+https://github.com/open-zaak/cmis-adapter.git@f9ef6199acb76fd46794280153a0e3250655e474#egg=drc_cmis
 drf-flex-fields==0.5.0    # via -r requirements/base.in
 drf-nested-routers==0.90.2  # via vng-api-common
 drf-writable-nested==0.4.3  # via -r requirements/base.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -37,8 +37,7 @@ django==2.2.17            # via -r requirements/base.in, django-auth-adfs, djang
 djangorestframework-camel-case==0.2.0  # via -r requirements/base.in, vng-api-common
 djangorestframework-gis==0.14  # via -r requirements/base.in
 djangorestframework==3.9.4  # via -r requirements/base.in, django-extra-fields, django-loose-fk, djangorestframework-gis, drf-nested-routers, drf-yasg, vng-api-common
-#drc-cmis==1.2.1           # via -r requirements/base.in
-git+https://github.com/open-zaak/cmis-adapter.git@f9ef6199acb76fd46794280153a0e3250655e474#egg=drc_cmis
+drc-cmis==1.2.2           # via -r requirements/base.in
 drf-flex-fields==0.5.0    # via -r requirements/base.in
 drf-nested-routers==0.90.2  # via vng-api-common
 drf-writable-nested==0.4.3  # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -45,8 +45,7 @@ django==2.2.17            # via -r requirements/base.txt, django-auth-adfs, djan
 djangorestframework-camel-case==0.2.0  # via -r requirements/base.txt, vng-api-common
 djangorestframework-gis==0.14  # via -r requirements/base.txt
 djangorestframework==3.9.4  # via -r requirements/base.txt, django-extra-fields, django-loose-fk, djangorestframework-gis, drf-nested-routers, drf-yasg, vng-api-common
-#drc-cmis==1.2.1           # via -r requirements/base.txt
-git+https://github.com/open-zaak/cmis-adapter.git@f9ef6199acb76fd46794280153a0e3250655e474#egg=drc_cmis
+drc-cmis==1.2.2           # via -r requirements/base.txt
 drf-flex-fields==0.5.0    # via -r requirements/base.txt
 drf-nested-routers==0.90.2  # via -r requirements/base.txt, vng-api-common
 drf-writable-nested==0.4.3  # via -r requirements/base.txt

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -45,7 +45,8 @@ django==2.2.17            # via -r requirements/base.txt, django-auth-adfs, djan
 djangorestframework-camel-case==0.2.0  # via -r requirements/base.txt, vng-api-common
 djangorestframework-gis==0.14  # via -r requirements/base.txt
 djangorestframework==3.9.4  # via -r requirements/base.txt, django-extra-fields, django-loose-fk, djangorestframework-gis, drf-nested-routers, drf-yasg, vng-api-common
-drc-cmis==1.2.1           # via -r requirements/base.txt
+#drc-cmis==1.2.1           # via -r requirements/base.txt
+git+https://github.com/open-zaak/cmis-adapter.git@f9ef6199acb76fd46794280153a0e3250655e474#egg=drc_cmis
 drf-flex-fields==0.5.0    # via -r requirements/base.txt
 drf-nested-routers==0.90.2  # via -r requirements/base.txt, vng-api-common
 drf-writable-nested==0.4.3  # via -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -56,8 +56,7 @@ djangorestframework-camel-case==0.2.0  # via -r requirements/ci.txt, vng-api-com
 djangorestframework-gis==0.14  # via -r requirements/ci.txt
 djangorestframework==3.9.4  # via -r requirements/ci.txt, django-extra-fields, django-loose-fk, djangorestframework-gis, drf-nested-routers, drf-yasg, vng-api-common
 docutils==0.15.2          # via recommonmark, sphinx
-#drc-cmis==1.2.1           # via -r requirements/ci.txt
-git+https://github.com/open-zaak/cmis-adapter.git@f9ef6199acb76fd46794280153a0e3250655e474#egg=drc_cmis
+drc-cmis==1.2.2           # via -r requirements/ci.txt
 drf-flex-fields==0.5.0    # via -r requirements/ci.txt
 drf-nested-routers==0.90.2  # via -r requirements/ci.txt, vng-api-common
 drf-writable-nested==0.4.3  # via -r requirements/ci.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -56,7 +56,8 @@ djangorestframework-camel-case==0.2.0  # via -r requirements/ci.txt, vng-api-com
 djangorestframework-gis==0.14  # via -r requirements/ci.txt
 djangorestframework==3.9.4  # via -r requirements/ci.txt, django-extra-fields, django-loose-fk, djangorestframework-gis, drf-nested-routers, drf-yasg, vng-api-common
 docutils==0.15.2          # via recommonmark, sphinx
-drc-cmis==1.2.1           # via -r requirements/ci.txt
+#drc-cmis==1.2.1           # via -r requirements/ci.txt
+git+https://github.com/open-zaak/cmis-adapter.git@f9ef6199acb76fd46794280153a0e3250655e474#egg=drc_cmis
 drf-flex-fields==0.5.0    # via -r requirements/ci.txt
 drf-nested-routers==0.90.2  # via -r requirements/ci.txt, vng-api-common
 drf-writable-nested==0.4.3  # via -r requirements/ci.txt

--- a/src/openzaak/utils/tests.py
+++ b/src/openzaak/utils/tests.py
@@ -321,6 +321,11 @@ class APICMISTestCase(MockSchemasMixin, CMISMixin, APITestCase):
             config.other_folder_path = "/DRC/"
             config.zaak_folder_path = "/ZRC/{{ zaaktype }}/{{ zaak }}"
             config.save()
+
+            # Configure the main_repo_id
+            client = get_cmis_client()
+            config.main_repo_id = client.get_main_repo_id()
+            config.save()
         elif binding == "BROWSER":
             config = CMISConfig.objects.get()
             config.client_url = "http://localhost:8082/alfresco/api/-default-/public/cmis/versions/1.1/browser"


### PR DESCRIPTION
**Changes**
The `main_repo_id` is configured before the tests start. 
With the improved handling of `main_repo_id` in the CMIS adapter, this speeds up running tests with the WEBSERVICE binding.

(This PR is a draft because it requires https://github.com/open-zaak/cmis-adapter/pull/43 to be released)



