### PR TITLE
Prevent exception when doing PUT and ZaakTypenRelatie already exists

### DIFF
--- a/src/openzaak/components/catalogi/api/viewsets/zaaktype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/zaaktype.py
@@ -125,12 +125,13 @@ class ZaakTypeViewSet(
 
     def perform_update(self, serializer):
 
-        for zaaktypenrelaties in serializer.validated_data["zaaktypenrelaties"]:
-            # Delete any ZaakTypenRelatie so they can be recreated
-            ZaakTypenRelatie.objects.filter(
-                zaaktype=serializer.instance,
-                gerelateerd_zaaktype=zaaktypenrelaties["gerelateerd_zaaktype"],
-            ).delete()
+        if not serializer.partial:
+            for zaaktypenrelaties in serializer.validated_data["zaaktypenrelaties"]:
+                # Delete any ZaakTypenRelatie so they can be recreated
+                ZaakTypenRelatie.objects.filter(
+                    zaaktype=serializer.instance,
+                    gerelateerd_zaaktype=zaaktypenrelaties["gerelateerd_zaaktype"],
+                ).delete()
 
         super().perform_update(serializer)
 

--- a/src/openzaak/components/catalogi/api/viewsets/zaaktype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/zaaktype.py
@@ -15,7 +15,7 @@ from vng_api_common.viewsets import CheckQueryParamsMixin
 from openzaak.utils.permissions import AuthRequired
 from openzaak.utils.schema import COMMON_ERROR_RESPONSES, use_ref
 
-from ...models import ZaakType
+from ...models import ZaakType, ZaakTypenRelatie
 from ..filters import ZaakTypeFilter
 from ..kanalen import KANAAL_ZAAKTYPEN
 from ..scopes import (
@@ -122,6 +122,17 @@ class ZaakTypeViewSet(
     }
     notifications_kanaal = KANAAL_ZAAKTYPEN
     concept_related_fields = ["besluittypen", "informatieobjecttypen"]
+
+    def perform_update(self, serializer):
+
+        for zaaktypenrelaties in serializer.validated_data["zaaktypenrelaties"]:
+            # Delete any ZaakTypenRelatie so they can be recreated
+            ZaakTypenRelatie.objects.filter(
+                zaaktype=serializer.instance,
+                gerelateerd_zaaktype=zaaktypenrelaties["gerelateerd_zaaktype"],
+            ).delete()
+
+        super().perform_update(serializer)
 
     @swagger_auto_schema(
         request_body=no_body,

--- a/src/openzaak/components/catalogi/api/viewsets/zaaktype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/zaaktype.py
@@ -15,7 +15,7 @@ from vng_api_common.viewsets import CheckQueryParamsMixin
 from openzaak.utils.permissions import AuthRequired
 from openzaak.utils.schema import COMMON_ERROR_RESPONSES, use_ref
 
-from ...models import ZaakType, ZaakTypenRelatie
+from ...models import ZaakType
 from ..filters import ZaakTypeFilter
 from ..kanalen import KANAAL_ZAAKTYPEN
 from ..scopes import (

--- a/src/openzaak/components/catalogi/api/viewsets/zaaktype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/zaaktype.py
@@ -126,12 +126,7 @@ class ZaakTypeViewSet(
     def perform_update(self, serializer):
 
         if not serializer.partial:
-            for zaaktypenrelaties in serializer.validated_data["zaaktypenrelaties"]:
-                # Delete any ZaakTypenRelatie so they can be recreated
-                ZaakTypenRelatie.objects.filter(
-                    zaaktype=serializer.instance,
-                    gerelateerd_zaaktype=zaaktypenrelaties["gerelateerd_zaaktype"],
-                ).delete()
+            serializer.instance.zaaktypenrelaties.all().delete()
 
         super().perform_update(serializer)
 

--- a/src/openzaak/components/catalogi/tests/test_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/test_zaaktype.py
@@ -549,6 +549,54 @@ class ZaakTypeAPITests(TypeCheckMixin, APITestCase):
         zaaktype.refresh_from_db()
         self.assertEqual(zaaktype.aanleiding, "aangepast")
 
+    def test_update_zaaktype_with_existing_zaaktyperelatie(self):
+        zaaktype = ZaakTypeFactory.create()
+        zaaktype_url = reverse(zaaktype)
+
+        ZaakTypenRelatieFactory.create(
+            zaaktype=zaaktype, gerelateerd_zaaktype="http://example.com/zaaktype/1"
+        )
+
+        data = {
+            "identificatie": 0,
+            "doel": "some test",
+            "aanleiding": "aangepast",
+            "indicatieInternOfExtern": InternExtern.extern,
+            "handelingInitiator": "indienen",
+            "onderwerp": "Klacht",
+            "handelingBehandelaar": "uitvoeren",
+            "doorlooptijd": "P30D",
+            "opschortingEnAanhoudingMogelijk": False,
+            "verlengingMogelijk": True,
+            "verlengingstermijn": "P30D",
+            "publicatieIndicatie": True,
+            "verantwoordingsrelatie": [],
+            "productenOfDiensten": ["https://example.com/product/123"],
+            "vertrouwelijkheidaanduiding": VertrouwelijkheidsAanduiding.openbaar,
+            "omschrijving": "some test",
+            "gerelateerdeZaaktypen": [
+                {
+                    "zaaktype": "http://example.com/zaaktype/1",
+                    "aard_relatie": AardRelatieChoices.bijdrage,
+                    "toelichting": "test relations",
+                }
+            ],
+            "referentieproces": {"naam": "ReferentieProces 0", "link": ""},
+            "catalogus": f"http://testserver{self.catalogus_detail_url}",
+            # 'informatieobjecttypen': [f'http://testserver{informatieobjecttype_url}'],
+            "besluittypen": [],
+            "beginGeldigheid": "2018-01-01",
+            "versiedatum": "2018-01-01",
+        }
+
+        response = self.client.put(zaaktype_url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["aanleiding"], "aangepast")
+
+        zaaktype.refresh_from_db()
+        self.assertEqual(zaaktype.aanleiding, "aangepast")
+
     def test_update_zaaktype_fail_not_concept(self):
         zaaktype = ZaakTypeFactory.create(concept=False)
         zaaktype_url = reverse(zaaktype)

--- a/src/openzaak/components/catalogi/tests/test_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/test_zaaktype.py
@@ -23,7 +23,7 @@ from ..api.validators import (
     VerlengingsValidator,
 )
 from ..constants import AardRelatieChoices, InternExtern
-from ..models import ZaakType
+from ..models import ZaakType, ZaakTypenRelatie
 from .base import APITestCase
 from .factories import (
     BesluitTypeFactory,
@@ -595,6 +595,58 @@ class ZaakTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(response.data["aanleiding"], "aangepast")
 
         zaaktype.refresh_from_db()
+        self.assertEqual(zaaktype.aanleiding, "aangepast")
+
+    def test_update_zaaktype_with_two_existing_zaaktyperelatie(self):
+        zaaktype = ZaakTypeFactory.create()
+        zaaktype_url = reverse(zaaktype)
+
+        ZaakTypenRelatieFactory.create(
+            zaaktype=zaaktype, gerelateerd_zaaktype="http://example.com/zaaktype/1"
+        )
+        ZaakTypenRelatieFactory.create(
+            zaaktype=zaaktype, gerelateerd_zaaktype="http://example.com/zaaktype/2"
+        )
+
+        data = {
+            "identificatie": 0,
+            "doel": "some test",
+            "aanleiding": "aangepast",
+            "indicatieInternOfExtern": InternExtern.extern,
+            "handelingInitiator": "indienen",
+            "onderwerp": "Klacht",
+            "handelingBehandelaar": "uitvoeren",
+            "doorlooptijd": "P30D",
+            "opschortingEnAanhoudingMogelijk": False,
+            "verlengingMogelijk": True,
+            "verlengingstermijn": "P30D",
+            "publicatieIndicatie": True,
+            "verantwoordingsrelatie": [],
+            "productenOfDiensten": ["https://example.com/product/123"],
+            "vertrouwelijkheidaanduiding": VertrouwelijkheidsAanduiding.openbaar,
+            "omschrijving": "some test",
+            "gerelateerdeZaaktypen": [
+                {
+                    "zaaktype": "http://example.com/zaaktype/1",
+                    "aard_relatie": AardRelatieChoices.bijdrage,
+                    "toelichting": "test relations",
+                }
+            ],
+            "referentieproces": {"naam": "ReferentieProces 0", "link": ""},
+            "catalogus": f"http://testserver{self.catalogus_detail_url}",
+            # 'informatieobjecttypen': [f'http://testserver{informatieobjecttype_url}'],
+            "besluittypen": [],
+            "beginGeldigheid": "2018-01-01",
+            "versiedatum": "2018-01-01",
+        }
+
+        response = self.client.put(zaaktype_url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["aanleiding"], "aangepast")
+
+        zaaktype.refresh_from_db()
+        self.assertEqual(ZaakTypenRelatie.objects.filter(zaaktype=zaaktype).count(), 1)
         self.assertEqual(zaaktype.aanleiding, "aangepast")
 
     def test_update_zaaktype_fail_not_concept(self):


### PR DESCRIPTION
Fixes #851 

**Changes**

When doing a `PUT` on the `zaaktypen` endpoint we want to delete `ZaakTypenRelatie` that were previously created so that they can be recreated in this `PUT` request. 

