### PR TITLE
Add validator in serializer to prevent 500 error

### DIFF
--- a/src/openzaak/components/catalogi/api/serializers/zaaktype.py
+++ b/src/openzaak/components/catalogi/api/serializers/zaaktype.py
@@ -25,6 +25,7 @@ from ..validators import (
     M2MConceptCreateValidator,
     M2MConceptUpdateValidator,
     RelationCatalogValidator,
+    VerlengingsValidator,
     ZaaktypeGeldigheidValidator,
 )
 
@@ -194,6 +195,7 @@ class ZaakTypeSerializer(
             M2MConceptCreateValidator(["besluittypen", "informatieobjecttypen"]),
             M2MConceptUpdateValidator(["besluittypen", "informatieobjecttypen"]),
             DeelzaaktypeCatalogusValidator(),
+            VerlengingsValidator(),
         ]
 
     def __init__(self, *args, **kwargs):

--- a/src/openzaak/components/catalogi/api/validators.py
+++ b/src/openzaak/components/catalogi/api/validators.py
@@ -389,6 +389,15 @@ class ConceptUpdateValidator:
             raise ValidationError(self.message, code=self.code)
 
 
+class VerlengingsValidator:
+    message = _("Verlengingstermijn must be set if verlengingMogelijk is true")
+    code = "verlenging-mismatch"
+
+    def __call__(self, attrs):
+        if attrs.get("verlenging_mogelijk") and not attrs.get("verlengingstermijn"):
+            raise ValidationError(self.message, code=self.code)
+
+
 class ZaakTypeConceptValidator:
     """
     Validator that checks for related non-concept zaaktype when doing

--- a/src/openzaak/components/catalogi/tests/test_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/test_zaaktype.py
@@ -20,6 +20,7 @@ from ..api.validators import (
     ConceptUpdateValidator,
     M2MConceptCreateValidator,
     M2MConceptUpdateValidator,
+    VerlengingsValidator,
 )
 from ..constants import AardRelatieChoices, InternExtern
 from ..models import ZaakType
@@ -241,6 +242,47 @@ class ZaakTypeAPITests(TypeCheckMixin, APITestCase):
             "http://example.com/zaaktype/1",
         )
         self.assertEqual(zaaktype.concept, True)
+
+    def test_create_zaaktype_without_verlengingstermijn(self):
+        besluittype = BesluitTypeFactory.create(catalogus=self.catalogus)
+        besluittype_url = get_operation_url("besluittype_read", uuid=besluittype.uuid)
+
+        zaaktype_list_url = get_operation_url("zaaktype_list")
+        data = {
+            "identificatie": 0,
+            "doel": "some test",
+            "aanleiding": "some test",
+            "indicatieInternOfExtern": InternExtern.extern,
+            "handelingInitiator": "indienen",
+            "onderwerp": "Klacht",
+            "handelingBehandelaar": "uitvoeren",
+            "doorlooptijd": "P30D",
+            "opschortingEnAanhoudingMogelijk": False,
+            "verlengingMogelijk": True,
+            "publicatieIndicatie": True,
+            "verantwoordingsrelatie": [],
+            "productenOfDiensten": ["https://example.com/product/123"],
+            "vertrouwelijkheidaanduiding": VertrouwelijkheidsAanduiding.openbaar,
+            "omschrijving": "some test",
+            "gerelateerdeZaaktypen": [
+                {
+                    "zaaktype": "http://example.com/zaaktype/1",
+                    "aard_relatie": AardRelatieChoices.bijdrage,
+                    "toelichting": "test relations",
+                }
+            ],
+            "referentieproces": {"naam": "ReferentieProces 0"},
+            "catalogus": f"http://testserver{self.catalogus_detail_url}",
+            "besluittypen": [f"http://testserver{besluittype_url}"],
+            "beginGeldigheid": "2018-01-01",
+            "versiedatum": "2018-01-01",
+        }
+        response = self.client.post(zaaktype_list_url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], VerlengingsValidator.code)
 
     def test_create_zaaktype_generate_unique_identificatie(self):
         zaaktype1 = ZaakTypeFactory.create(catalogus=self.catalogus)


### PR DESCRIPTION
Fixes #850 

**Changes**

This adds a new validation check in the serializer to prevent a 500 error.  

We were doing this check on the `save` method of the model here https://github.com/open-zaak/open-zaak/blob/master/src/openzaak/components/catalogi/models/zaaktype.py#L305-L307 however if this exception is raised then the API responds with a 500 error while we want a 400 error to be returned.

By adding the validator the API will now return a user friendly 400 error.