### PR TITLE
Change CharFilter to a ChoiceFilter 

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,7 @@ django-cors-headers==3.5.0  # via -r requirements/base.in
 django-db-logger==0.1.7   # via -r requirements/base.in
 django-extra-fields==1.2.4  # via -r requirements/base.in
 django-extra-views==0.13.0  # via -r requirements/base.in
-django-filter==2.0        # via -r requirements/base.in, django-loose-fk, vng-api-common
+django-filter==2.4.0        # via -r requirements/base.in, django-loose-fk, vng-api-common
 django-ipware==2.1.0      # via django-axes
 django-loose-fk==0.7.3    # via -r requirements/base.in
 django-markup==1.3        # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -29,7 +29,7 @@ django-cors-headers==3.5.0  # via -r requirements/base.txt
 django-db-logger==0.1.7   # via -r requirements/base.txt
 django-extra-fields==1.2.4  # via -r requirements/base.txt
 django-extra-views==0.13.0  # via -r requirements/base.txt
-django-filter==2.0.0      # via -r requirements/base.txt, django-loose-fk, vng-api-common
+django-filter==2.4.0      # via -r requirements/base.txt, django-loose-fk, vng-api-common
 django-ipware==2.1.0      # via -r requirements/base.txt, django-axes
 django-loose-fk==0.7.3    # via -r requirements/base.txt
 django-markup==1.3        # via -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -38,7 +38,7 @@ django-debug-toolbar==2.0  # via -r requirements/dev.in
 django-extensions==2.2.1  # via -r requirements/dev.in
 django-extra-fields==1.2.4  # via -r requirements/ci.txt
 django-extra-views==0.13.0  # via -r requirements/ci.txt
-django-filter==2.0.0      # via -r requirements/ci.txt, django-loose-fk, vng-api-common
+django-filter==2.4.0      # via -r requirements/ci.txt, django-loose-fk, vng-api-common
 django-ipware==2.1.0      # via -r requirements/ci.txt, django-axes
 django-loose-fk==0.7.3    # via -r requirements/ci.txt
 django-markup==1.3        # via -r requirements/ci.txt

--- a/src/openzaak/components/catalogi/api/filters.py
+++ b/src/openzaak/components/catalogi/api/filters.py
@@ -30,13 +30,23 @@ STATUS_HELP_TEXT = """filter objects depending on their concept status:
 * `definitief`: Toon objecten waarvan het attribuut `concept` false is (standaard).
 """
 
+ALLES = "alles"
+DEFINITIEF = "definitief"
+CONCEPT = "concept"
+
+STATUS_CHOICES = (
+    (ALLES, "Alles"),
+    (DEFINITIEF, "Definitief"),
+    (CONCEPT, "Concept"),
+)
+
 
 def status_filter(queryset, name, value):
-    if value == "concept":
+    if value == CONCEPT:
         return queryset.filter(**{name: True})
-    elif value == "definitief":
+    elif value == DEFINITIEF:
         return queryset.filter(**{name: False})
-    elif value == "alles":
+    elif value == ALLES:
         return queryset
 
 
@@ -55,8 +65,11 @@ class CharArrayFilter(filters.BaseInFilter, filters.CharFilter):
 
 
 class RolTypeFilter(FilterSet):
-    status = filters.CharFilter(
-        field_name="zaaktype__concept", method=status_filter, help_text=STATUS_HELP_TEXT
+    status = filters.ChoiceFilter(
+        field_name="zaaktype__concept",
+        method=status_filter,
+        help_text=STATUS_HELP_TEXT,
+        choices=STATUS_CHOICES,
     )
 
     class Meta:
@@ -90,8 +103,11 @@ class ZaakTypeInformatieObjectTypeFilter(FilterSet):
 
 
 class ResultaatTypeFilter(FilterSet):
-    status = filters.CharFilter(
-        field_name="zaaktype__concept", method=status_filter, help_text=STATUS_HELP_TEXT
+    status = filters.ChoiceFilter(
+        field_name="zaaktype__concept",
+        method=status_filter,
+        help_text=STATUS_HELP_TEXT,
+        choices=STATUS_CHOICES,
     )
 
     class Meta:
@@ -100,8 +116,11 @@ class ResultaatTypeFilter(FilterSet):
 
 
 class StatusTypeFilter(FilterSet):
-    status = filters.CharFilter(
-        field_name="zaaktype__concept", method=status_filter, help_text=STATUS_HELP_TEXT
+    status = filters.ChoiceFilter(
+        field_name="zaaktype__concept",
+        method=status_filter,
+        help_text=STATUS_HELP_TEXT,
+        choices=STATUS_CHOICES,
     )
 
     class Meta:
@@ -110,8 +129,11 @@ class StatusTypeFilter(FilterSet):
 
 
 class EigenschapFilter(FilterSet):
-    status = filters.CharFilter(
-        field_name="zaaktype__concept", method=status_filter, help_text=STATUS_HELP_TEXT
+    status = filters.ChoiceFilter(
+        field_name="zaaktype__concept",
+        method=status_filter,
+        help_text=STATUS_HELP_TEXT,
+        choices=STATUS_CHOICES,
     )
 
     class Meta:
@@ -120,8 +142,11 @@ class EigenschapFilter(FilterSet):
 
 
 class ZaakTypeFilter(FilterSet):
-    status = filters.CharFilter(
-        field_name="concept", method=status_filter, help_text=STATUS_HELP_TEXT
+    status = filters.ChoiceFilter(
+        field_name="concept",
+        method=status_filter,
+        help_text=STATUS_HELP_TEXT,
+        choices=STATUS_CHOICES,
     )
     trefwoorden = CharArrayFilter(field_name="trefwoorden", lookup_expr="contains")
 
@@ -131,8 +156,11 @@ class ZaakTypeFilter(FilterSet):
 
 
 class InformatieObjectTypeFilter(FilterSet):
-    status = filters.CharFilter(
-        field_name="concept", method=status_filter, help_text=STATUS_HELP_TEXT
+    status = filters.ChoiceFilter(
+        field_name="concept",
+        method=status_filter,
+        help_text=STATUS_HELP_TEXT,
+        choices=STATUS_CHOICES,
     )
 
     class Meta:
@@ -158,8 +186,11 @@ class BesluitTypeFilter(FilterSet):
         ),
         validators=[URLValidator()],
     )
-    status = filters.CharFilter(
-        field_name="concept", method=status_filter, help_text=STATUS_HELP_TEXT
+    status = filters.ChoiceFilter(
+        field_name="concept",
+        method=status_filter,
+        help_text=STATUS_HELP_TEXT,
+        choices=STATUS_CHOICES,
     )
 
     class Meta:

--- a/src/openzaak/components/catalogi/api/filters.py
+++ b/src/openzaak/components/catalogi/api/filters.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.validators import URLValidator
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
+from djchoices import ChoiceItem, DjangoChoices
 
 from django_filters import rest_framework as filters
 from vng_api_common.filtersets import FilterSet
@@ -30,23 +31,19 @@ STATUS_HELP_TEXT = """filter objects depending on their concept status:
 * `definitief`: Toon objecten waarvan het attribuut `concept` false is (standaard).
 """
 
-ALLES = "alles"
-DEFINITIEF = "definitief"
-CONCEPT = "concept"
 
-STATUS_CHOICES = (
-    (ALLES, "Alles"),
-    (DEFINITIEF, "Definitief"),
-    (CONCEPT, "Concept"),
-)
+class StatusChoices(DjangoChoices):
+    alles = ChoiceItem("alles", _("Alles"))
+    definitief = ChoiceItem("definitief", _("Definitief"))
+    concept = ChoiceItem("concept", _("Concept"))
 
 
 def status_filter(queryset, name, value):
-    if value == CONCEPT:
+    if value == StatusChoices.concept:
         return queryset.filter(**{name: True})
-    elif value == DEFINITIEF:
+    elif value == StatusChoices.definitief:
         return queryset.filter(**{name: False})
-    elif value == ALLES:
+    elif value == StatusChoices.alles:
         return queryset
 
 
@@ -69,7 +66,7 @@ class RolTypeFilter(FilterSet):
         field_name="zaaktype__concept",
         method=status_filter,
         help_text=STATUS_HELP_TEXT,
-        choices=STATUS_CHOICES,
+        choices=StatusChoices.choices,
     )
 
     class Meta:
@@ -107,7 +104,7 @@ class ResultaatTypeFilter(FilterSet):
         field_name="zaaktype__concept",
         method=status_filter,
         help_text=STATUS_HELP_TEXT,
-        choices=STATUS_CHOICES,
+        choices=StatusChoices.choices,
     )
 
     class Meta:
@@ -120,7 +117,7 @@ class StatusTypeFilter(FilterSet):
         field_name="zaaktype__concept",
         method=status_filter,
         help_text=STATUS_HELP_TEXT,
-        choices=STATUS_CHOICES,
+        choices=StatusChoices.choices,
     )
 
     class Meta:
@@ -133,7 +130,7 @@ class EigenschapFilter(FilterSet):
         field_name="zaaktype__concept",
         method=status_filter,
         help_text=STATUS_HELP_TEXT,
-        choices=STATUS_CHOICES,
+        choices=StatusChoices.choices,
     )
 
     class Meta:
@@ -146,7 +143,7 @@ class ZaakTypeFilter(FilterSet):
         field_name="concept",
         method=status_filter,
         help_text=STATUS_HELP_TEXT,
-        choices=STATUS_CHOICES,
+        choices=StatusChoices.choices,
     )
     trefwoorden = CharArrayFilter(field_name="trefwoorden", lookup_expr="contains")
 
@@ -160,7 +157,7 @@ class InformatieObjectTypeFilter(FilterSet):
         field_name="concept",
         method=status_filter,
         help_text=STATUS_HELP_TEXT,
-        choices=STATUS_CHOICES,
+        choices=StatusChoices.choices,
     )
 
     class Meta:
@@ -190,7 +187,7 @@ class BesluitTypeFilter(FilterSet):
         field_name="concept",
         method=status_filter,
         help_text=STATUS_HELP_TEXT,
-        choices=STATUS_CHOICES,
+        choices=StatusChoices.choices,
     )
 
     class Meta:

--- a/src/openzaak/components/catalogi/api/filters.py
+++ b/src/openzaak/components/catalogi/api/filters.py
@@ -6,9 +6,9 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.validators import URLValidator
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-from djchoices import ChoiceItem, DjangoChoices
 
 from django_filters import rest_framework as filters
+from djchoices import ChoiceItem, DjangoChoices
 from vng_api_common.filtersets import FilterSet
 from vng_api_common.utils import get_resource_for_path
 

--- a/src/openzaak/components/catalogi/tests/test_filters.py
+++ b/src/openzaak/components/catalogi/tests/test_filters.py
@@ -80,6 +80,17 @@ class EigenschapFilterTests(JWTAuthMixin, APITestCase):
             response.data, {"count": 0, "next": None, "previous": None, "results": []}
         )
 
+    def test_filter_with_invalid_status_query_param(self):
+        EigenschapFactory.create(zaaktype__concept=False)
+
+        url = f"{reverse(Eigenschap)}?status=alle"
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "status")
+        self.assertEqual(error["code"], "invalid_choice")
+
 
 class InformatieObjectTypeFilterTests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
@@ -105,6 +116,18 @@ class InformatieObjectTypeFilterTests(JWTAuthMixin, APITestCase):
             response.data, {"count": 0, "next": None, "previous": None, "results": []}
         )
 
+    def test_filter_with_invalid_status_query_param(self):
+        informatieobjecttype = InformatieObjectTypeFactory.create(concept=False)
+        informatieobjecttype.zaaktypen.clear()
+
+        url = f"{reverse(InformatieObjectType)}?status=alle"
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "status")
+        self.assertEqual(error["code"], "invalid_choice")
+
 
 class ResultaatTypeFilterTests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
@@ -128,6 +151,17 @@ class ResultaatTypeFilterTests(JWTAuthMixin, APITestCase):
             response.data, {"count": 0, "next": None, "previous": None, "results": []}
         )
 
+    def test_filter_with_invalid_status_query_param(self):
+        ResultaatTypeFactory.create(zaaktype__concept=False)
+
+        url = f"{reverse(ResultaatType)}?status=alle"
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "status")
+        self.assertEqual(error["code"], "invalid_choice")
+
 
 class RolTypeFilterTests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
@@ -148,6 +182,17 @@ class RolTypeFilterTests(JWTAuthMixin, APITestCase):
         self.assertEqual(
             response.data, {"count": 0, "next": None, "previous": None, "results": []}
         )
+
+    def test_filter_with_invalid_status_query_param(self):
+        RolTypeFactory.create(zaaktype__concept=False)
+
+        url = f"{reverse(RolType)}?status=alle"
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "status")
+        self.assertEqual(error["code"], "invalid_choice")
 
 
 class StatusTypeFilterTests(JWTAuthMixin, APITestCase):
@@ -171,6 +216,17 @@ class StatusTypeFilterTests(JWTAuthMixin, APITestCase):
         self.assertEqual(
             response.data, {"count": 0, "next": None, "previous": None, "results": []}
         )
+
+    def test_filter_with_invalid_status_query_param(self):
+        StatusTypeFactory.create(zaaktype__concept=False)
+
+        url = f"{reverse(StatusType)}?status=alle"
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "status")
+        self.assertEqual(error["code"], "invalid_choice")
 
 
 class ZaakTypeInformatieObjectTypeFilterTests(JWTAuthMixin, APITestCase):
@@ -229,3 +285,15 @@ class ZaakTypeFilterTests(JWTAuthMixin, APITestCase):
         self.assertEqual(
             response.data, {"count": 0, "next": None, "previous": None, "results": []}
         )
+
+    def test_filter_with_invalid_status_query_param(self):
+        zaaktype = ZaakTypeFactory.create(concept=False)
+        zaaktype.informatieobjecttypen.clear()
+
+        url = f"{reverse(ZaakType)}?status=alle"
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "status")
+        self.assertEqual(error["code"], "invalid_choice")


### PR DESCRIPTION
Fixes #870 

**Changes**

By changing the CharFilter to a ChoiceFilter the user will receive a 400 error response and the following data back rather than a 500 error

```
{
    "type": "http://localhost:8000/ref/fouten/ValidationError/",
    "code": "invalid",
    "title": "Invalid input.",
    "status": 400,
    "detail": "",
    "instance": "urn:uuid:48c051dc-0064-4529-b899-e3b0bd83367b",
    "invalidParams": [
        {
            "name": "status",
            "code": "invalid_choice",
            "reason": "Selecteer een geldige keuze. %(value)s is geen beschikbare keuze."
        }
    ]
}
```

The only thing I don't like is that `%(value)s` is returned instead of the value they passed in.  This happens because `django-filter`  here https://github.com/carltongibson/django-filter/blob/2.0.0/django_filters/utils.py#L320 uses `e.message` without passing in  the proper `e.params`.  

This is fixed in 2.1.0 https://github.com/carltongibson/django-filter/blob/2.1.0/django_filters/utils.py#L320 so we could upgrade to this version but I wasn't sure if that should be done as part of this pull request.  If we do want to do this as part of this PR let me know.

