### PR TITLE
Configure Notificaties API service in setup_configuration script

### DIFF
--- a/src/openzaak/management/commands/setup_configuration.py
+++ b/src/openzaak/management/commands/setup_configuration.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
-import string
 import random
+import string
 from argparse import RawTextHelpFormatter
 
 from django.contrib.sites.models import Site
@@ -16,9 +16,8 @@ from vng_api_common.notifications.constants import (
     SCOPE_NOTIFICATIES_PUBLICEREN_LABEL,
 )
 from vng_api_common.notifications.models import NotificationsConfig
-
-from zgw_consumers.models import Service
 from zgw_consumers.constants import AuthTypes
+from zgw_consumers.models import Service
 
 from openzaak.components.autorisaties.api.scopes import SCOPE_AUTORISATIES_LEZEN
 
@@ -87,15 +86,17 @@ class Command(BaseCommand):
             # Step 2
             # This service should be created in migration
             #   0002_move_config_to_service_model
-            service = Service.objects.get(label='Notificaties API')
+            service = Service.objects.get(label="Notificaties API")
             service.api_root = notifications_api_root
             service.auth_type = AuthTypes.zgw
-            random_client_id = f'open-zaak-{"".join(random.choices(string.ascii_letters, k=10))}'
+            random_client_id = (
+                f'open-zaak-{"".join(random.choices(string.ascii_letters, k=10))}'
+            )
             random_secret = "".join(random.choices(string.ascii_letters, k=10))
             service.client_id = random_client_id
             service.secret = random_secret
-            service.user_id = 'open-zaak'
-            service.user_representation = 'Open Zaak'
+            service.user_id = "open-zaak"
+            service.user_representation = "Open Zaak"
             service.save()
 
             # Step 3
@@ -145,8 +146,10 @@ class Command(BaseCommand):
                 )
             )
 
-            self.stdout.write(f"Notificaties API Service configured with client_id {random_client_id} "
-                              f"and secret {random_secret}.  Use this to configure your Open Notifications instance.")
+            self.stdout.write(
+                f"Notificaties API Service configured with client_id {random_client_id} "
+                f"and secret {random_secret}.  Use this to configure your Open Notifications instance."
+            )
         except Exception as e:
             raise CommandError(
                 f"Something went wrong while setting up initial configuration: {e}"


### PR DESCRIPTION
**Changes**

This configures the script to update the Notificaties API Service so it's setup correctly by the script.  It updates the `auth_type` of the service because the check the endpoint `view-config` does assumes a certain `auth_type`  and creates a `client_id` and `secret` that can then be used to configure your Open Notificaties instance.

The client_id and secret will be written to the console when running the script. Eg.

```bash
Initial configuration for Open Zaak was setup successfully
Notificaties API Service configured with client_id open-zaak-1O4OzrcxfrFk and secret cnlFSqx5B9vI.  Use this to configure your Open Notifications instance.
```

I tested this by going to the `view-config` endpoint on my localhost.

Screenshot

<img width="1904" alt="Screenshot 2021-03-12 at 09 20 26" src="https://user-images.githubusercontent.com/60747362/110913455-7840da00-8315-11eb-8e15-5b3523a9d499.png">
