### PR TITLE
Removing disabled newrelic APM monitoring

### DIFF
--- a/src/openzaak/wsgi.py
+++ b/src/openzaak/wsgi.py
@@ -14,23 +14,5 @@ from django.core.wsgi import get_wsgi_application
 
 from openzaak.setup import setup_env
 
-
-def init_newrelic():
-    if os.environ.get("PROJECT_ROOT"):
-        try:
-            import newrelic.agent
-
-            newrelic.agent.initialize(
-                os.path.join(os.environ.get("PROJECT_ROOT"), "newrelic.ini"),
-                "production",
-            )
-        except Exception as e:
-            print("Could not initialize New Relic APM, ignoring:")
-            print(e)
-
-
-# Enable New Relic on production
-# init_newrelic()
-
 setup_env()
 application = get_wsgi_application()

--- a/src/openzaak/wsgi.py
+++ b/src/openzaak/wsgi.py
@@ -8,8 +8,6 @@ It exposes the WSGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/2.0/howto/deployment/wsgi/
 """
-import os
-
 from django.core.wsgi import get_wsgi_application
 
 from openzaak.setup import setup_env


### PR DESCRIPTION
**Changes**

In the past we were using New Relic actively and had this commented out in the wsgi.py file to easily enable APM monitoring.

However this was long ago and we now internally use self-hosted elastic-apm for most production systems. Enabling this for open-zaak could be interesting, but as I'm cleaning up newrelic from older projects I've done this too for open-zaak.

