### PR TITLE
Support X-Forwarded-Host header

### DIFF
--- a/docs/installation/config/env_config.md
+++ b/docs/installation/config/env_config.md
@@ -56,6 +56,11 @@ on Docker, since `localhost` is contained within the container:
 
 * `DB_PORT`: port number of the database, defaults to `5432`.
 
+* `USE_X_FORWARDED_HOST`: whether to grab the domain/host from the `X-Forwarded-Host`
+  header or not. This header is typically set by reverse proxies (such as nginx,
+  traefik, Apache...). Default `False` - this is a header that can be spoofed and you
+  need to ensure you control it before enabling this.
+
 * `CACHE_DEFAULT`: redis cache address for the default cache. Defaults to
   `localhost:6379/0`.
 

--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -40,6 +40,7 @@ DEBUG = config("DEBUG", default=False)
 
 # = domains we're running on
 ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="", split=True)
+USE_X_FORWARDED_HOST = config("USE_X_FORWARDED_HOST", default=False)
 
 IS_HTTPS = config("IS_HTTPS", default=not DEBUG)
 

--- a/src/openzaak/tests/test_x_forwarded_host.py
+++ b/src/openzaak/tests/test_x_forwarded_host.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2021 Dimpact
+from django.test import RequestFactory, SimpleTestCase, override_settings, tag
+
+
+@tag("x-forwarded-for")
+class XForwardedHostTests(SimpleTestCase):
+    """
+    Test the opt-in behaviour of the X-Forwarded-For header.
+    """
+
+    factory = RequestFactory()
+
+    def test_default_disabled(self):
+        request = self.factory.get("/", HTTP_X_FORWARDED_HOST="evil.com",)
+
+        self.assertEqual(
+            request.get_host(), "testserver",
+        )
+
+    @override_settings(
+        USE_X_FORWARDED_HOST=True, ALLOWED_HOSTS=["upstream.proxy"],
+    )
+    def test_enabled(self):
+        request = self.factory.get("/", HTTP_X_FORWARDED_HOST="upstream.proxy",)
+
+        self.assertEqual(
+            request.get_host(), "upstream.proxy",
+        )


### PR DESCRIPTION
Fixes #916

**Changes**

* Added opt-in to get the request host from the `X-Forwarded-Host` header

