### PR TITLE
Bump django-auth-adfs(-db) to latest versions

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,9 +29,9 @@ django-admin-index==1.2.2
     # via -r requirements/base.in
 django-appconf==1.0.2
     # via django-axes
-django-auth-adfs-db==0.2.0
+django-auth-adfs-db==0.3.0
     # via -r requirements/base.in
-django-auth-adfs==1.3.1
+django-auth-adfs==1.6.1
     # via django-auth-adfs-db
 django-axes==4.4.0
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -57,9 +57,9 @@ django-appconf==1.0.2
     # via
     #   -r requirements/base.txt
     #   django-axes
-django-auth-adfs-db==0.2.0
+django-auth-adfs-db==0.3.0
     # via -r requirements/base.txt
-django-auth-adfs==1.3.1
+django-auth-adfs==1.6.1
     # via
     #   -r requirements/base.txt
     #   django-auth-adfs-db

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -81,9 +81,9 @@ django-appconf==1.0.2
     # via
     #   -r requirements/ci.txt
     #   django-axes
-django-auth-adfs-db==0.2.0
+django-auth-adfs-db==0.3.0
     # via -r requirements/ci.txt
-django-auth-adfs==1.3.1
+django-auth-adfs==1.6.1
     # via
     #   -r requirements/ci.txt
     #   django-auth-adfs-db


### PR DESCRIPTION
This includes updated support for Azure AD.

**Changes**

* Updated django-auth-adfs from 1.3.x to 1.6.x
* Updated django-auth-adfs-db from 0.2.0 to 0.3.0

