### PR TITLE
Issue/891 nameless catalogus

### DIFF
--- a/src/openzaak/components/catalogi/admin/catalogus.py
+++ b/src/openzaak/components/catalogi/admin/catalogus.py
@@ -67,7 +67,7 @@ class CatalogusAdmin(
     change_form_template = "admin/catalogi/change_form_catalogus.html"
 
     # List
-    list_display = ("_admin_name", "domein", "rsin")
+    list_display = ("get_admin_name", "domein", "rsin")
     list_filter = ("domein", "rsin")
     ordering = ("domein", "rsin")
     search_fields = (
@@ -97,6 +97,11 @@ class CatalogusAdmin(
 
     # For import/export mixins
     resource_name = "catalogus"
+
+    def get_admin_name(self, obj):
+        return obj._admin_name or "(onbekend)"
+
+    get_admin_name.short_description = _("Naam")
 
     def get_related_objects(self, obj):
         resources = {}

--- a/src/openzaak/components/catalogi/tests/admin/test_catalogus.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_catalogus.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2021 Dimpact
+from django.urls import reverse
+
+from django_webtest import WebTest
+
+from openzaak.accounts.tests.factories import SuperUserFactory
+
+from ..factories import CatalogusFactory
+
+
+class CatalogusAdminTests(WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = SuperUserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+
+        self.app.set_user(self.user)
+
+    def test_catalogus_list_name(self):
+        CatalogusFactory.create(_admin_name="test")
+
+        response = self.app.get(reverse("admin:catalogi_catalogus_changelist"))
+
+        admin_name = response.html.find("th", {"class": "field-get_admin_name"})
+        self.assertEqual(admin_name.text, "test")
+
+    def test_catalogus_list_placeholder_name(self):
+        CatalogusFactory.create(_admin_name="")
+
+        response = self.app.get(reverse("admin:catalogi_catalogus_changelist"))
+
+        admin_name = response.html.find("th", {"class": "field-get_admin_name"})
+        self.assertEqual(admin_name.text, "(onbekend)")


### PR DESCRIPTION
Fixes #891 

**Changes**
- Display placeholder `(onbekend)` in catalogi list in admin if a Catalogus does not have a name (yet)

