### PR TITLE
Issue/890 alphanumeric validation

### DIFF
--- a/src/openzaak/components/besluiten/api/serializers.py
+++ b/src/openzaak/components/besluiten/api/serializers.py
@@ -12,7 +12,11 @@ from rest_framework import serializers
 from rest_framework.reverse import reverse
 from vng_api_common.serializers import add_choice_values_help_text
 from vng_api_common.utils import get_help_text
-from vng_api_common.validators import IsImmutableValidator, validate_rsin
+from vng_api_common.validators import (
+    AlphanumericExcludingDiacritic,
+    IsImmutableValidator,
+    validate_rsin,
+)
 
 from openzaak.components.documenten.api.fields import EnkelvoudigInformatieObjectField
 from openzaak.components.zaken.api.utils import (
@@ -78,7 +82,9 @@ class BesluitSerializer(ConvertNoneMixin, serializers.HyperlinkedModelSerializer
                 "allow_null": False,
                 "allow_blank": True,
             },
-            "identificatie": {"validators": [IsImmutableValidator()]},
+            "identificatie": {
+                "validators": [IsImmutableValidator(), AlphanumericExcludingDiacritic()]
+            },
             "verantwoordelijke_organisatie": {
                 "validators": [IsImmutableValidator(), validate_rsin]
             },

--- a/src/openzaak/components/catalogi/tests/test_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/test_zaaktype.py
@@ -325,6 +325,47 @@ class ZaakTypeAPITests(TypeCheckMixin, APITestCase):
 
         self.assertNotEqual(zaaktype1.identificatie, zaaktype2.identificatie)
 
+    def test_create_zaaktype_identificatie_not_alphanumeric(self):
+        ZaakTypeFactory.create(catalogus=self.catalogus)
+
+        zaaktype_list_url = get_operation_url("zaaktype_list")
+        data = {
+            "doel": "some test",
+            "identificatie": "foo 1 2",
+            "aanleiding": "some test",
+            "indicatieInternOfExtern": InternExtern.extern,
+            "handelingInitiator": "indienen",
+            "onderwerp": "Klacht",
+            "handelingBehandelaar": "uitvoeren",
+            "doorlooptijd": "P30D",
+            "opschortingEnAanhoudingMogelijk": False,
+            "verlengingMogelijk": True,
+            "verlengingstermijn": "P30D",
+            "publicatieIndicatie": True,
+            "verantwoordingsrelatie": [],
+            "productenOfDiensten": ["https://example.com/product/123"],
+            "vertrouwelijkheidaanduiding": VertrouwelijkheidsAanduiding.openbaar,
+            "omschrijving": "some test",
+            "gerelateerdeZaaktypen": [
+                {
+                    "zaaktype": "http://example.com/zaaktype/1",
+                    "aard_relatie": AardRelatieChoices.bijdrage,
+                    "toelichting": "test relations",
+                }
+            ],
+            "referentieproces": {"naam": "ReferentieProces 0", "link": ""},
+            "catalogus": f"http://testserver{self.catalogus_detail_url}",
+            "besluittypen": [],
+            "beginGeldigheid": "2018-01-01",
+            "versiedatum": "2018-01-01",
+        }
+        response = self.client.post(zaaktype_list_url, data)
+
+        self.assertEqual(response.status_code, 400)
+
+        error = get_validation_errors(response, "identificatie")
+        self.assertEqual(error["code"], "invalid")
+
     def test_create_zaaktype_fail_besluittype_non_concept(self):
         besluittype = BesluitTypeFactory.create(concept=False, catalogus=self.catalogus)
         besluittype_url = get_operation_url("besluittype_read", uuid=besluittype.uuid)

--- a/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject.py
+++ b/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject.py
@@ -183,6 +183,33 @@ class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APITestCase):
             response.data["invalid_params"][0]["code"], "identificatie-niet-uniek"
         )
 
+    def test_create_eio_identificatie_not_alphanumeric(self):
+        informatieobjecttype = InformatieObjectTypeFactory.create(concept=False)
+        informatieobjecttype_url = reverse(informatieobjecttype)
+        content = {
+            "identificatie": "foo 1 2",
+            "bronorganisatie": "159351741",
+            "creatiedatum": "2018-06-27",
+            "titel": "detailed summary",
+            "auteur": "test_auteur",
+            "formaat": "txt",
+            "taal": "eng",
+            "bestandsnaam": "dummy.txt",
+            "inhoud": b64encode(b"some file content").decode("utf-8"),
+            "link": "http://een.link",
+            "beschrijving": "test_beschrijving",
+            "informatieobjecttype": f"http://testserver{informatieobjecttype_url}",
+            "vertrouwelijkheidaanduiding": "openbaar",
+        }
+
+        # Send to the API
+        response = self.client.post(self.list_url, content)
+
+        self.assertEqual(response.status_code, 400)
+
+        error = get_validation_errors(response, "identificatie")
+        self.assertEqual(error["code"], "invalid")
+
     def test_create_fail_informatieobjecttype_max_length(self):
         informatieobjecttype = InformatieObjectTypeFactory.create()
         informatieobjecttype_url = reverse(informatieobjecttype)

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -28,6 +28,7 @@ from vng_api_common.serializers import (
 )
 from vng_api_common.utils import get_help_text
 from vng_api_common.validators import (
+    AlphanumericExcludingDiacritic,
     IsImmutableValidator,
     ResourceValidator,
     UntilNowValidator,
@@ -261,7 +262,9 @@ class ZaakSerializer(
             "zaakgeometrie": {
                 "help_text": "Punt, lijn of (multi-)vlak geometrie-informatie, in GeoJSON."
             },
-            "identificatie": {"validators": [IsImmutableValidator()]},
+            "identificatie": {
+                "validators": [IsImmutableValidator(), AlphanumericExcludingDiacritic()]
+            },
             "einddatum": {"read_only": True, "allow_null": True},
             "communicatiekanaal": {
                 "validators": [


### PR DESCRIPTION
Fixes #890 

**Changes**

* Add the `AlphanumericExcludingDiacritic` validator to the Besluit and Zaak resources, so that this validation is also applied via the API

