### PR TITLE
Feature/910 related zaaktype select

### DIFF
--- a/src/openzaak/components/catalogi/admin/zaaktypen.py
+++ b/src/openzaak/components/catalogi/admin/zaaktypen.py
@@ -32,7 +32,7 @@ from ..models import (
     ZaakTypenRelatie,
 )
 from .eigenschap import EigenschapAdmin
-from .forms import ZaakTypeForm
+from .forms import ZaakTypeForm, ZaakTypenRelatieAdminForm
 from .mixins import (
     CatalogusContextAdminMixin,
     ExportMixin,
@@ -52,6 +52,7 @@ logger = logging.getLogger(__name__)
 @admin.register(ZaakTypenRelatie)
 class ZaakTypenRelatieAdmin(ReadOnlyPublishedZaaktypeMixin, admin.ModelAdmin):
     model = ZaakTypenRelatie
+    form = ZaakTypenRelatieAdminForm
 
     # List
     list_display = ("gerelateerd_zaaktype", "zaaktype")

--- a/src/openzaak/components/catalogi/tests/admin/test_zaaktypenrelatie_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_zaaktypenrelatie_admin.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2021 Dimpact
+from django.conf import settings
+from django.contrib.sites.models import Site
+from django.test import override_settings
+from django.urls import reverse
+
+from django_webtest import WebTest
+from vng_api_common.tests import reverse as _reverse
+
+from openzaak.accounts.tests.factories import SuperUserFactory
+from openzaak.components.catalogi.models import ZaakTypenRelatie
+from openzaak.utils.tests import ClearCachesMixin
+
+from ...constants import AardRelatieChoices
+from ..factories import ZaakTypeFactory, ZaakTypenRelatieFactory
+
+
+@override_settings(ALLOWED_HOSTS=["testserver", "example.com"])
+class ZaakTypenRelatieAdminTests(ClearCachesMixin, WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = SuperUserFactory.create()
+        site = Site.objects.get_current()
+        site.domain = "example.com"
+        site.save()
+
+    def setUp(self):
+        super().setUp()
+
+        self.app.set_user(self.user)
+
+    def test_zaaktypenrelatie_create_with_gerelateerd_zaaktype_internal(self):
+        zaaktype1, zaaktype2 = ZaakTypeFactory.create_batch(2)
+
+        protocol = "https" if settings.IS_HTTPS else "http"
+        domain = Site.objects.get_current().domain
+        zaaktype_url = f"{protocol}://{domain}{_reverse(zaaktype1)}"
+
+        url = reverse("admin:catalogi_zaaktypenrelatie_add")
+
+        response = self.app.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        related_zaaktype = response.html.find(
+            "div", {"class": "field-gerelateerd_zaaktype"}
+        )
+
+        inputs = related_zaaktype.find_all("input")
+
+        self.assertEqual(len(inputs), 2)
+
+        form = response.form
+
+        form["gerelateerd_zaaktype_0"] = zaaktype1.pk
+        form["aard_relatie"] = AardRelatieChoices.vervolg
+        form["zaaktype"] = zaaktype2.pk
+
+        response = form.submit()
+
+        self.assertEqual(response.status_code, 302)
+
+        self.assertEqual(ZaakTypenRelatie.objects.count(), 1)
+
+        relatie = ZaakTypenRelatie.objects.get()
+
+        self.assertEqual(relatie.gerelateerd_zaaktype, zaaktype_url)
+        self.assertEqual(relatie.aard_relatie, AardRelatieChoices.vervolg)
+        self.assertEqual(relatie.zaaktype, zaaktype2)
+
+    def test_zaaktypenrelatie_create_with_gerelateerd_zaaktype_external(self):
+        zaaktype1, zaaktype2 = ZaakTypeFactory.create_batch(2)
+
+        protocol = "https" if settings.IS_HTTPS else "http"
+        domain = Site.objects.get_current().domain
+        zaaktype_url = f"{protocol}://{domain}{_reverse(zaaktype1)}"
+
+        url = reverse("admin:catalogi_zaaktypenrelatie_add")
+
+        response = self.app.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        related_zaaktype = response.html.find(
+            "div", {"class": "field-gerelateerd_zaaktype"}
+        )
+
+        inputs = related_zaaktype.find_all("input")
+
+        self.assertEqual(len(inputs), 2)
+
+        form = response.form
+
+        form["gerelateerd_zaaktype_1"] = zaaktype_url
+        form["aard_relatie"] = AardRelatieChoices.vervolg
+        form["zaaktype"] = zaaktype2.pk
+
+        response = form.submit()
+
+        self.assertEqual(response.status_code, 302)
+
+        self.assertEqual(ZaakTypenRelatie.objects.count(), 1)
+
+        relatie = ZaakTypenRelatie.objects.get()
+
+        self.assertEqual(relatie.gerelateerd_zaaktype, zaaktype_url)
+        self.assertEqual(relatie.aard_relatie, AardRelatieChoices.vervolg)
+        self.assertEqual(relatie.zaaktype, zaaktype2)
+
+    def test_zaaktypenrelatie_create_with_gerelateerd_zaaktype_both_internal_and_external_error(
+        self,
+    ):
+        zaaktype1, zaaktype2 = ZaakTypeFactory.create_batch(2)
+
+        protocol = "https" if settings.IS_HTTPS else "http"
+        domain = Site.objects.get_current().domain
+        zaaktype_url = f"{protocol}://{domain}{_reverse(zaaktype1)}"
+
+        url = reverse("admin:catalogi_zaaktypenrelatie_add")
+
+        response = self.app.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        related_zaaktype = response.html.find(
+            "div", {"class": "field-gerelateerd_zaaktype"}
+        )
+
+        inputs = related_zaaktype.find_all("input")
+
+        self.assertEqual(len(inputs), 2)
+
+        form = response.form
+
+        # Filling in both values
+        form["gerelateerd_zaaktype_0"] = zaaktype1.pk
+        form["gerelateerd_zaaktype_1"] = zaaktype_url
+        form["aard_relatie"] = AardRelatieChoices.vervolg
+        form["zaaktype"] = zaaktype2.pk
+
+        response = form.submit()
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(ZaakTypenRelatie.objects.count(), 0)
+
+        related_zaaktype = response.html.find(
+            "div", {"class": "field-gerelateerd_zaaktype"}
+        )
+        self.assertIsNotNone(related_zaaktype.find("ul", {"class": "errorlist"}))
+
+    def test_zaaktypenrelatie_detail_concept(self):
+        zaaktype1, zaaktype2 = ZaakTypeFactory.create_batch(2)
+
+        protocol = "https" if settings.IS_HTTPS else "http"
+        domain = Site.objects.get_current().domain
+        zaaktype_url = f"{protocol}://{domain}{_reverse(zaaktype1)}"
+
+        relatie = ZaakTypenRelatieFactory.create(
+            gerelateerd_zaaktype=zaaktype_url, zaaktype=zaaktype2
+        )
+
+        url = reverse("admin:catalogi_zaaktypenrelatie_change", args=(relatie.pk,))
+
+        response = self.app.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        related_zaaktype = response.html.find(
+            "div", {"class": "field-gerelateerd_zaaktype"}
+        )
+        inputs = related_zaaktype.find_all("input")
+        self.assertEqual(len(inputs), 2)
+
+        form = response.form
+        self.assertEqual(form["gerelateerd_zaaktype_0"].value, str(zaaktype1.pk))
+
+        lookup = response.html.find("a", {"id": "lookup_id_gerelateerd_zaaktype_0"})
+        self.assertIsNotNone(lookup)
+
+        related_zaaktype_admin_link = related_zaaktype.find_all("a")[1]
+        self.assertEqual(
+            related_zaaktype_admin_link.attrs["href"],
+            reverse("admin:catalogi_zaaktype_change", args=(zaaktype1.pk,)),
+        )
+        self.assertEqual(related_zaaktype_admin_link.text, str(zaaktype1))
+
+    def test_zaaktypenrelatie_detail_not_concept(self):
+        zaaktype1, zaaktype2 = ZaakTypeFactory.create_batch(2, concept=False)
+
+        protocol = "https" if settings.IS_HTTPS else "http"
+        domain = Site.objects.get_current().domain
+        zaaktype_url = f"{protocol}://{domain}{_reverse(zaaktype1)}"
+
+        relatie = ZaakTypenRelatieFactory.create(
+            gerelateerd_zaaktype=zaaktype_url, zaaktype=zaaktype2
+        )
+
+        url = reverse("admin:catalogi_zaaktypenrelatie_change", args=(relatie.pk,))
+
+        response = self.app.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        related_zaaktype = response.html.find(
+            "div", {"class": "field-gerelateerd_zaaktype"}
+        )
+        related_zaaktype_url = related_zaaktype.find("a")
+
+        self.assertEqual(related_zaaktype_url.attrs["href"], zaaktype_url)
+        self.assertEqual(related_zaaktype_url.text, zaaktype_url)
+
+    def test_zaaktypenrelatie_detail_external(self):
+        zaaktype1, zaaktype2 = ZaakTypeFactory.create_batch(2)
+
+        relatie = ZaakTypenRelatieFactory.create(
+            gerelateerd_zaaktype="http://catalogi.com/zaaktypen/1", zaaktype=zaaktype2
+        )
+
+        url = reverse("admin:catalogi_zaaktypenrelatie_change", args=(relatie.pk,))
+
+        response = self.app.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        related_zaaktype = response.html.find(
+            "div", {"class": "field-gerelateerd_zaaktype"}
+        )
+        inputs = related_zaaktype.find_all("input")
+        self.assertEqual(len(inputs), 2)
+
+        form = response.form
+        self.assertEqual(form["gerelateerd_zaaktype_0"].value, "")
+        self.assertEqual(
+            form["gerelateerd_zaaktype_1"].value, "http://catalogi.com/zaaktypen/1"
+        )
+
+        lookup = response.html.find("a", {"id": "lookup_id_gerelateerd_zaaktype_0"})
+        self.assertIsNotNone(lookup)
+
+    def test_zaaktypenrelatie_detail_with_external_url_internal_uuid(self):
+        zaaktype1, zaaktype2 = ZaakTypeFactory.create_batch(2)
+
+        # External URL with the same UUID as an internal zaaktype
+        external_zaaktype_url = f"http://catalogi.com/zaaktypen/{zaaktype2.uuid}"
+
+        relatie = ZaakTypenRelatieFactory.create(
+            gerelateerd_zaaktype=external_zaaktype_url, zaaktype=zaaktype2
+        )
+
+        url = reverse("admin:catalogi_zaaktypenrelatie_change", args=(relatie.pk,))
+
+        response = self.app.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        related_zaaktype = response.html.find(
+            "div", {"class": "field-gerelateerd_zaaktype"}
+        )
+        inputs = related_zaaktype.find_all("input")
+        self.assertEqual(len(inputs), 2)
+
+        form = response.form
+        self.assertEqual(form["gerelateerd_zaaktype_0"].value, "")
+        self.assertEqual(form["gerelateerd_zaaktype_1"].value, external_zaaktype_url)
+
+        lookup = response.html.find("a", {"id": "lookup_id_gerelateerd_zaaktype_0"})
+        self.assertIsNotNone(lookup)

--- a/src/openzaak/templates/widgets/multiwidget.html
+++ b/src/openzaak/templates/widgets/multiwidget.html
@@ -3,7 +3,7 @@
 {% spaceless %}
 {% for subwidget in widget.subwidgets %}
     {% include subwidget.template_name with widget=subwidget %}
-    {% if forloop.counter != widget.subwidgets|length %}
+    {% if forloop.last %}
         <strong> of </strong>
     {% endif %}
 {% endfor %}

--- a/src/openzaak/templates/widgets/multiwidget.html
+++ b/src/openzaak/templates/widgets/multiwidget.html
@@ -1,0 +1,10 @@
+{% comment %} SPDX-License-Identifier: EUPL-1.2 {% endcomment %}
+{% comment %} Copyright (C) 2021 Dimpact {% endcomment %}
+{% spaceless %}
+{% for subwidget in widget.subwidgets %}
+    {% include subwidget.template_name with widget=subwidget %}
+    {% if forloop.counter != widget.subwidgets|length %}
+        <strong> of </strong>
+    {% endif %}
+{% endfor %}
+{% endspaceless %}


### PR DESCRIPTION
Fixes #910 

**Changes**

* Split the `ZaakTypenRelatie.gerelateerd_zaaktype` field into two: a selection from local Zaaktypen (like a regular foreign key) and a field in which a raw URL can be entered. After saving the form, the value is always saved as a URL, it's just a visual change in the admin
