### PR TITLE
Issue #938 - Remove need for document services

### DIFF
--- a/docs/installation/config/cmis.rst
+++ b/docs/installation/config/cmis.rst
@@ -124,53 +124,6 @@ Using the CMIS adapter
 
 .. _`CMIS adapter library`: https://github.com/open-zaak/cmis-adapter
 
-When using the CMIS-adapter, sometimes a Zaak, a Zaaktype or a Besluit need to be retrieved from the APIs.
-This happens for example when a Zaak folder is created, since the description of the Zaak is used as part of the folder name.
-
-For this reason, the CMIS-adapter needs to be given access to the various APIs.
-These are the steps to configure it:
-
-1. Go to **API Autorisaties > Applicaties** and click on **Applicatie toevoegen**.
-
-2. Fill out the form:
-
-    a. **Client ID**: *For example:* ``cmis-adapter``
-
-    b. **Secret**: *Some random string, for example:* ``Tl8@04&O4gXTtB``. You will need this later on!
-
-3. Click **Opslaan en opnieuw bewerken**.
-
-4. Click **Beheer Autorisaties**.
-
-5. Under **Component** check ``Zaken API``, under **Selecteer scopes** check ``zaken.lezen``, under **Voor welke typen geldt dit?** check ``Alle huidige en toekomsitge ZAAKTYPEN`` and  under **Tot en met welke vertrouwelijkheidaanduiding?** check ``Zeer geheim``.
-
-6. Click on **Nog Autorisaties toevoegen** and under **Component** check ``Catalogi API`` and under **Selecteer scopes** check ``catalogi.lezen``.
-
-7. Click on **Nog Autorisaties toevoegen** and check under **Component** ``Besluiten API``, under **Selecteer scopes** check ``besluiten.lezen`` and under **Voor welke typen geldt dit?** check ``Alle huidige en toekomsitge BESLUITTYPEN``.
-
-8. Click on **Nog Autorisaties toevoegen** and under **Component** check ``Documenten API``,  under **Selecteer scopes** check ``documenten.lezen``,  under **Voor welke typen geldt dit?** check ``Alle huidige en toekomsitge INFORMATIEOBJECTTYPEN`` and under **Tot en met welke vertrouwelijkheidaanduiding?** check ``Zeer geheim``.
-
-9. Click on **Opslaan** to save.
-
-Then, the services need to be configured.
-First, configure the Zaken API as follows:
-
-1. Go to **API Autorisaties > Services** and click on **Service Toevoegen**.
-
-2. Fill out the form:
-
-    a. The **API type** should be ``ZRC (Zaken)``.
-
-    b. The **API root** could be ``http://example.com/zaken/api/v1/``.
-
-    c. The **client ID** and the **secret** should be those configured in the **API Autorisaties > Applicaties**. Following the previous example, they would be ``cmis-adapter`` and ``Tl8@04&O4gXTtB`` respectively.
-
-3. Click **Opslaan** to save.
-
-Repeat the procedure above for the Zaaktypen API, Besluiten API and Documenten API.
-Make sure to use the proper **Type** and **API root**. The credentials should all be the same.
-
-
 
 Additional notes on creating documents
 --------------------------------------

--- a/src/openzaak/components/besluiten/tests/models/test_bio_block_change_cmis.py
+++ b/src/openzaak/components/besluiten/tests/models/test_bio_block_change_cmis.py
@@ -8,7 +8,7 @@ from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
 from openzaak.utils.query import QueryBlocked
-from openzaak.utils.tests import APICMISTestCase, OioMixin, serialise_eio
+from openzaak.utils.tests import APICMISTestCase
 
 from ...models import BesluitInformatieObject
 from ..factories import BesluitFactory, BesluitInformatieObjectFactory
@@ -16,16 +16,12 @@ from ..factories import BesluitFactory, BesluitInformatieObjectFactory
 
 @tag("cmis")
 @override_settings(CMIS_ENABLED=True)
-class BlockChangeCMISTestCase(APICMISTestCase, OioMixin):
+class BlockChangeCMISTestCase(APICMISTestCase):
     def setUp(self) -> None:
         super().setUp()
         eio = EnkelvoudigInformatieObjectFactory.create(identificatie="12345")
         eio_url = eio.get_url()
-        self.adapter.get(eio_url, json=serialise_eio(eio, eio_url))
-        self.create_zaak_besluit_services()
-        self.bio = BesluitInformatieObjectFactory.create(
-            informatieobject=eio_url, besluit=self.create_besluit()
-        )
+        self.bio = BesluitInformatieObjectFactory.create(informatieobject=eio_url)
 
     def test_update(self):
         self.assertRaises(
@@ -51,7 +47,6 @@ class BlockChangeCMISTestCase(APICMISTestCase, OioMixin):
         besluit = BesluitFactory.create()
         eio = EnkelvoudigInformatieObjectFactory.create()
         eio_url = eio.get_url()
-        self.adapter.get(eio_url, json=serialise_eio(eio, eio_url))
         bio = BesluitInformatieObject(
             besluit=besluit, informatieobject=eio_url, uuid=uuid.uuid4()
         )

--- a/src/openzaak/components/besluiten/tests/models/test_unique_representation_cmis.py
+++ b/src/openzaak/components/besluiten/tests/models/test_unique_representation_cmis.py
@@ -5,22 +5,20 @@ from django.test import override_settings, tag
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.utils.tests import APICMISTestCase, OioMixin, serialise_eio
+from openzaak.utils.tests import APICMISTestCase
 
-from ...tests.factories import BesluitInformatieObjectFactory
+from ...tests.factories import BesluitFactory, BesluitInformatieObjectFactory
 
 
 @tag("cmis")
 @override_settings(CMIS_ENABLED=True)
-class UniqueRepresentationTestCMISCase(APICMISTestCase, OioMixin):
+class UniqueRepresentationTestCMISCase(APICMISTestCase):
     def test_besluitinformatieobject(self):
         eio = EnkelvoudigInformatieObjectFactory.create(identificatie="12345")
         eio_url = eio.get_url()
-        self.adapter.get(eio_url, json=serialise_eio(eio, eio_url))
-        self.create_zaak_besluit_services()
         bio = BesluitInformatieObjectFactory(
             informatieobject=eio_url,
-            besluit=self.create_besluit(
+            besluit=BesluitFactory.create(
                 **{"identificatie": "5d940d52-ff5e-4b18-a769-977af9130c04"}
             ),
         )

--- a/src/openzaak/components/besluiten/tests/test_besluit_delete_cmis.py
+++ b/src/openzaak/components/besluiten/tests/test_besluit_delete_cmis.py
@@ -4,17 +4,17 @@ from django.test import override_settings, tag
 
 from rest_framework import status
 
-from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin, OioMixin, serialise_eio
+from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin
 
 from ...documenten.tests.factories import EnkelvoudigInformatieObjectFactory
 from ..models import Besluit, BesluitInformatieObject
-from .factories import BesluitInformatieObjectFactory
+from .factories import BesluitFactory, BesluitInformatieObjectFactory
 from .utils import get_operation_url
 
 
 @tag("cmis")
 @override_settings(CMIS_ENABLED=True)
-class BesluitDeleteCMISTestCase(JWTAuthMixin, APICMISTestCase, OioMixin):
+class BesluitDeleteCMISTestCase(JWTAuthMixin, APICMISTestCase):
 
     heeft_alle_autorisaties = True
 
@@ -22,11 +22,10 @@ class BesluitDeleteCMISTestCase(JWTAuthMixin, APICMISTestCase, OioMixin):
         """
         Deleting a Besluit causes all related objects to be deleted as well.
         """
-        self.create_zaak_besluit_services()
-        besluit = self.create_besluit_without_zaak()
+        besluit = BesluitFactory.create()
         eio = EnkelvoudigInformatieObjectFactory.create()
         eio_url = eio.get_url()
-        self.adapter.get(eio_url, json=serialise_eio(eio, eio_url))
+
         BesluitInformatieObjectFactory.create(besluit=besluit, informatieobject=eio_url)
         besluit_delete_url = get_operation_url("besluit_delete", uuid=besluit.uuid)
 

--- a/src/openzaak/components/besluiten/tests/test_besluitinformatieobjecten_cmis.py
+++ b/src/openzaak/components/besluiten/tests/test_besluitinformatieobjecten_cmis.py
@@ -10,7 +10,7 @@ from vng_api_common.tests import get_validation_errors, reverse, reverse_lazy
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin, OioMixin, serialise_eio
+from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin
 
 from ..models import Besluit, BesluitInformatieObject
 from .factories import BesluitFactory, BesluitInformatieObjectFactory
@@ -18,7 +18,7 @@ from .factories import BesluitFactory, BesluitInformatieObjectFactory
 
 @tag("cmis")
 @override_settings(CMIS_ENABLED=True)
-class BesluitInformatieObjectCMISAPITests(JWTAuthMixin, APICMISTestCase, OioMixin):
+class BesluitInformatieObjectCMISAPITests(JWTAuthMixin, APICMISTestCase):
 
     list_url = reverse_lazy("besluitinformatieobject-list", kwargs={"version": "1"})
 
@@ -33,14 +33,12 @@ class BesluitInformatieObjectCMISAPITests(JWTAuthMixin, APICMISTestCase, OioMixi
         site.save()
 
     def test_create(self):
-        self.create_zaak_besluit_services()
-        besluit = self.create_besluit()
+        besluit = BesluitFactory.create()
 
         io = EnkelvoudigInformatieObjectFactory.create(
             informatieobjecttype__concept=False
         )
         io_url = f"http://testserver{reverse(io)}"
-        self.adapter.get(io_url, json=serialise_eio(io, io_url))
 
         besluit.besluittype.informatieobjecttypen.add(io.informatieobjecttype)
         besluit_url = make_absolute_uri(reverse(besluit))
@@ -72,12 +70,9 @@ class BesluitInformatieObjectCMISAPITests(JWTAuthMixin, APICMISTestCase, OioMixi
         """
         io = EnkelvoudigInformatieObjectFactory.create()
         io_url = f"http://testserver{reverse(io)}"
-        self.adapter.get(io_url, json=serialise_eio(io, io_url))
 
-        self.create_zaak_besluit_services()
-        besluit = self.create_besluit()
-        BesluitInformatieObjectFactory.create(informatieobject=io_url, besluit=besluit)
-        besluit_url = make_absolute_uri(reverse(besluit))
+        bio = BesluitInformatieObjectFactory.create(informatieobject=io_url)
+        besluit_url = make_absolute_uri(reverse(bio.besluit))
 
         content = {
             "informatieobject": io_url,
@@ -97,13 +92,8 @@ class BesluitInformatieObjectCMISAPITests(JWTAuthMixin, APICMISTestCase, OioMixi
     def test_read_besluit(self):
         io = EnkelvoudigInformatieObjectFactory.create()
         io_url = f"http://testserver{reverse(io)}"
-        self.adapter.get(io_url, json=serialise_eio(io, io_url))
 
-        self.create_zaak_besluit_services()
-        besluit = self.create_besluit()
-        bio = BesluitInformatieObjectFactory.create(
-            informatieobject=io_url, besluit=besluit
-        )
+        bio = BesluitInformatieObjectFactory.create(informatieobject=io_url)
         bio_detail_url = reverse(bio)
 
         response = self.client.get(bio_detail_url)
@@ -123,12 +113,8 @@ class BesluitInformatieObjectCMISAPITests(JWTAuthMixin, APICMISTestCase, OioMixi
     def test_filter_by_besluit(self):
         io = EnkelvoudigInformatieObjectFactory.create()
         io_url = io.get_url()
-        self.adapter.get(io_url, json=serialise_eio(io, io_url))
-        self.create_zaak_besluit_services()
-        besluit = self.create_besluit()
-        bio = BesluitInformatieObjectFactory.create(
-            informatieobject=io_url, besluit=besluit
-        )
+
+        bio = BesluitInformatieObjectFactory.create(informatieobject=io_url)
         besluit_url = reverse(bio.besluit)
         bio_list_url = reverse("besluitinformatieobject-list")
 
@@ -148,11 +134,8 @@ class BesluitInformatieObjectCMISAPITests(JWTAuthMixin, APICMISTestCase, OioMixi
     def test_filter_by_informatieobject(self):
         io = EnkelvoudigInformatieObjectFactory.create()
         io_url = f"http://example.com{reverse(io)}"
-        self.adapter.get(io_url, json=serialise_eio(io, io_url))
 
-        self.create_zaak_besluit_services()
-        besluit = self.create_besluit()
-        BesluitInformatieObjectFactory.create(informatieobject=io_url, besluit=besluit)
+        BesluitInformatieObjectFactory.create(informatieobject=io_url)
         bio_list_url = reverse("besluitinformatieobject-list")
 
         response = self.client.get(
@@ -166,12 +149,8 @@ class BesluitInformatieObjectCMISAPITests(JWTAuthMixin, APICMISTestCase, OioMixi
     def test_put_besluit_not_allowed(self):
         io = EnkelvoudigInformatieObjectFactory.create()
         io_url = io.get_url()
-        self.adapter.get(io_url, json=serialise_eio(io, io_url))
-        self.create_zaak_besluit_services()
-        besluit = self.create_besluit()
-        bio = BesluitInformatieObjectFactory.create(
-            informatieobject=io_url, besluit=besluit
-        )
+
+        bio = BesluitInformatieObjectFactory.create(informatieobject=io_url)
         bio_detail_url = reverse(bio)
         besluit = BesluitFactory.create()
         besluit_url = reverse(besluit)
@@ -193,12 +172,8 @@ class BesluitInformatieObjectCMISAPITests(JWTAuthMixin, APICMISTestCase, OioMixi
     def test_patch_besluit_not_allowed(self):
         io = EnkelvoudigInformatieObjectFactory.create()
         io_url = io.get_url()
-        self.adapter.get(io_url, json=serialise_eio(io, io_url))
-        self.create_zaak_besluit_services()
-        besluit = self.create_besluit()
-        bio = BesluitInformatieObjectFactory.create(
-            informatieobject=io_url, besluit=besluit
-        )
+
+        bio = BesluitInformatieObjectFactory.create(informatieobject=io_url)
         bio_detail_url = reverse(bio)
         besluit = BesluitFactory.create()
         besluit_url = reverse(besluit)
@@ -220,12 +195,8 @@ class BesluitInformatieObjectCMISAPITests(JWTAuthMixin, APICMISTestCase, OioMixi
     def test_delete(self):
         io = EnkelvoudigInformatieObjectFactory.create()
         io_url = io.get_url()
-        self.adapter.get(io_url, json=serialise_eio(io, io_url))
-        self.create_zaak_besluit_services()
-        besluit = self.create_besluit()
-        bio = BesluitInformatieObjectFactory.create(
-            informatieobject=io_url, besluit=besluit
-        )
+
+        bio = BesluitInformatieObjectFactory.create(informatieobject=io_url)
         bio_url = reverse(bio)
 
         response = self.client.delete(bio_url)
@@ -239,19 +210,11 @@ class BesluitInformatieObjectCMISAPITests(JWTAuthMixin, APICMISTestCase, OioMixi
         self.assertTrue(Besluit.objects.exists())
 
     def test_delete_document_unrelated_to_besluit(self):
-        self.create_zaak_besluit_services()
-
         # Create a document related to a besluit
         eio_related = EnkelvoudigInformatieObjectFactory.create()
         eio_related_url = eio_related.get_url()
-        self.adapter.get(
-            eio_related_url, json=serialise_eio(eio_related, eio_related_url)
-        )
 
-        besluit = self.create_besluit()
-        BesluitInformatieObjectFactory.create(
-            informatieobject=eio_related_url, besluit=besluit
-        )
+        BesluitInformatieObjectFactory.create(informatieobject=eio_related_url)
 
         # Create a document unrelated to a besluit
         eio_unrelated = EnkelvoudigInformatieObjectFactory.create()

--- a/src/openzaak/components/besluiten/tests/test_filters_cmis.py
+++ b/src/openzaak/components/besluiten/tests/test_filters_cmis.py
@@ -5,7 +5,7 @@ from django.test import override_settings, tag
 from rest_framework import status
 from vng_api_common.tests import get_validation_errors, reverse
 
-from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin, OioMixin, serialise_eio
+from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin
 
 from ...documenten.tests.factories import EnkelvoudigInformatieObjectFactory
 from ..models import BesluitInformatieObject
@@ -14,21 +14,14 @@ from .factories import BesluitInformatieObjectFactory
 
 @tag("cmis")
 @override_settings(CMIS_ENABLED=True)
-class BesluitInformatieObjectCMISAPIFilterTests(
-    JWTAuthMixin, APICMISTestCase, OioMixin
-):
+class BesluitInformatieObjectCMISAPIFilterTests(JWTAuthMixin, APICMISTestCase):
     heeft_alle_autorisaties = True
 
     def test_validate_unknown_query_params(self):
-        self.create_zaak_besluit_services()
         for counter in range(2):
             eio = EnkelvoudigInformatieObjectFactory.create()
             eio_url = eio.get_url()
-            self.adapter.get(eio_url, json=serialise_eio(eio, eio_url))
-            besluit = self.create_besluit()
-            BesluitInformatieObjectFactory.create(
-                informatieobject=eio_url, besluit=besluit
-            )
+            BesluitInformatieObjectFactory.create(informatieobject=eio_url)
         url = reverse(BesluitInformatieObject)
 
         response = self.client.get(url, {"someparam": "somevalue"})
@@ -41,10 +34,7 @@ class BesluitInformatieObjectCMISAPIFilterTests(
     def test_filter_by_valid_url_object_does_not_exist(self):
         eio = EnkelvoudigInformatieObjectFactory.create()
         eio_url = eio.get_url()
-        self.adapter.get(eio_url, json=serialise_eio(eio, eio_url))
-        self.create_zaak_besluit_services()
-        besluit = self.create_besluit()
-        BesluitInformatieObjectFactory.create(informatieobject=eio_url, besluit=besluit)
+        BesluitInformatieObjectFactory.create(informatieobject=eio_url)
         response = self.client.get(
             reverse(BesluitInformatieObject), {"besluit": "https://google.com"}
         )

--- a/src/openzaak/components/documenten/loaders.py
+++ b/src/openzaak/components/documenten/loaders.py
@@ -28,6 +28,9 @@ class EIOLoader(AuthorizedRequestsLoader):
         if model is InformatieObjectType:
             return self.resolve_io_type(url)
 
+        if self.is_local_url(url):
+            return self.load_local_object(url, model)
+
         data = self.fetch_object(url)
         model_instance = get_model_instance(model, data, loader=self)
         self.add_missing_props(model, model_instance, data)

--- a/src/openzaak/components/documenten/tests/models/test_unique_representation_cmis.py
+++ b/src/openzaak/components/documenten/tests/models/test_unique_representation_cmis.py
@@ -4,7 +4,8 @@ from django.test import override_settings, tag
 
 from vng_api_common.tests import reverse
 
-from openzaak.utils.tests import APICMISTestCase, OioMixin
+from openzaak.components.zaken.tests.factories import ZaakFactory
+from openzaak.utils.tests import APICMISTestCase
 
 from ...models import ObjectInformatieObject
 from ..factories import EnkelvoudigInformatieObjectFactory, GebruiksrechtenCMISFactory
@@ -12,7 +13,7 @@ from ..factories import EnkelvoudigInformatieObjectFactory, GebruiksrechtenCMISF
 
 @tag("cmis")
 @override_settings(CMIS_ENABLED=True, ALLOWED_HOSTS=["testserver", "example.com"])
-class UniqueRepresentationTestCase(APICMISTestCase, OioMixin):
+class UniqueRepresentationTestCase(APICMISTestCase):
     def test_eio(self):
         eio = EnkelvoudigInformatieObjectFactory(
             bronorganisatie=730924658,
@@ -41,8 +42,7 @@ class UniqueRepresentationTestCase(APICMISTestCase, OioMixin):
 
     @tag("oio")
     def test_oio(self):
-        self.create_zaak_besluit_services()
-        zaak = self.create_zaak(**{"identificatie": 12345})
+        zaak = ZaakFactory.create(**{"identificatie": 12345})
         eio = EnkelvoudigInformatieObjectFactory.create(
             bronorganisatie=730924658,
             identificatie="5d940d52-ff5e-4b18-a769-977af9130c04",

--- a/src/openzaak/components/documenten/tests/test_eio_delete_cascade_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_eio_delete_cascade_cmis.py
@@ -12,7 +12,7 @@ from vng_api_common.tests import get_validation_errors, reverse
 
 from openzaak.components.besluiten.tests.factories import BesluitInformatieObjectFactory
 from openzaak.components.zaken.tests.factories import ZaakInformatieObjectFactory
-from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin, OioMixin
+from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin
 
 from ..models import EnkelvoudigInformatieObject, Gebruiksrechten
 from .factories import EnkelvoudigInformatieObjectFactory, GebruiksrechtenCMISFactory
@@ -21,7 +21,7 @@ from .utils import get_operation_url
 
 @tag("cmis")
 @override_settings(CMIS_ENABLED=True)
-class US349TestCase(JWTAuthMixin, APICMISTestCase, OioMixin):
+class US349TestCase(JWTAuthMixin, APICMISTestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -42,7 +42,7 @@ class US349TestCase(JWTAuthMixin, APICMISTestCase, OioMixin):
         Deleting a EnkelvoudigInformatieObject causes all related objects to be deleted as well.
         """
         eio = EnkelvoudigInformatieObjectFactory.create()
-        eio_url = f"http://example.com{reverse(eio)}"
+        eio_url = f"http://testserver{reverse(eio)}"
         GebruiksrechtenCMISFactory(informatieobject=eio_url)
         eio_uuid = eio.uuid
 
@@ -64,9 +64,7 @@ class US349TestCase(JWTAuthMixin, APICMISTestCase, OioMixin):
         eio_uuid = eio.uuid
         eio_url = eio.get_url()
 
-        self.create_zaak_besluit_services()
-        besluit = self.create_besluit()
-        BesluitInformatieObjectFactory.create(informatieobject=eio_url, besluit=besluit)
+        BesluitInformatieObjectFactory.create(informatieobject=eio_url)
 
         informatieobject_delete_url = get_operation_url(
             "enkelvoudiginformatieobject_delete", uuid=eio_uuid,
@@ -87,9 +85,7 @@ class US349TestCase(JWTAuthMixin, APICMISTestCase, OioMixin):
         eio_uuid = eio.uuid
         eio_url = eio.get_url()
 
-        self.create_zaak_besluit_services()
-        zaak = self.create_zaak()
-        ZaakInformatieObjectFactory.create(informatieobject=eio_url, zaak=zaak)
+        ZaakInformatieObjectFactory.create(informatieobject=eio_url)
 
         informatieobject_delete_url = get_operation_url(
             "enkelvoudiginformatieobject_delete", uuid=eio_uuid,

--- a/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject_cmis.py
@@ -16,7 +16,7 @@ from vng_api_common.tests import get_validation_errors, reverse, reverse_lazy
 
 from openzaak.components.catalogi.tests.factories import InformatieObjectTypeFactory
 from openzaak.components.zaken.tests.factories import ZaakInformatieObjectFactory
-from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin, OioMixin
+from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin
 
 from ..models import EnkelvoudigInformatieObject, EnkelvoudigInformatieObjectCanonical
 from .factories import EnkelvoudigInformatieObjectFactory
@@ -30,7 +30,7 @@ from .utils import (
 @tag("cmis")
 @freeze_time("2018-06-27 12:12:12")
 @override_settings(CMIS_ENABLED=True)
-class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APICMISTestCase, OioMixin):
+class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APICMISTestCase):
 
     list_url = reverse_lazy(EnkelvoudigInformatieObject)
     heeft_alle_autorisaties = True
@@ -430,9 +430,7 @@ class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APICMISTestCase, OioMixi
         eio_path = reverse(eio)
         eio_url = eio.get_url()
 
-        self.create_zaak_besluit_services()
-        zaak = self.create_zaak()
-        ZaakInformatieObjectFactory.create(informatieobject=eio_url, zaak=zaak)
+        ZaakInformatieObjectFactory.create(informatieobject=eio_url)
 
         response = self.client.delete(eio_path)
 

--- a/src/openzaak/components/documenten/tests/test_gebruiksrechten_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_gebruiksrechten_cmis.py
@@ -52,7 +52,7 @@ class GebruiksrechtenTests(JWTAuthMixin, APICMISTestCase):
         anymore.
         """
         eio = EnkelvoudigInformatieObjectFactory.create()
-        eio_url = f"http://example.com{reverse(eio)}"
+        eio_url = f"http://testserver{reverse(eio)}"
         gebruiksrechten = GebruiksrechtenCMISFactory(informatieobject=eio_url)
 
         url = reverse(

--- a/src/openzaak/components/documenten/tests/test_utils_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_utils_cmis.py
@@ -7,14 +7,16 @@ from drc_cmis.utils.convert import make_absolute_uri
 from rest_framework.reverse import reverse_lazy
 from vng_api_common.tests import reverse
 
+from openzaak.components.besluiten.tests.factories import BesluitFactory
 from openzaak.components.documenten.query.cmis import get_zaak_and_zaaktype_data
 from openzaak.components.zaken.models import ZaakInformatieObject
-from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin, OioMixin
+from openzaak.components.zaken.tests.factories import ZaakFactory
+from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin
 
 
 @tag("cmis")
 @override_settings(CMIS_ENABLED=True)
-class CMISUtilsTests(JWTAuthMixin, APICMISTestCase, OioMixin):
+class CMISUtilsTests(JWTAuthMixin, APICMISTestCase):
 
     list_url = reverse_lazy(ZaakInformatieObject)
     heeft_alle_autorisaties = True
@@ -26,8 +28,7 @@ class CMISUtilsTests(JWTAuthMixin, APICMISTestCase, OioMixin):
         site.save()
 
     def test_get_zaak_and_zaaktype_data(self):
-        self.create_zaak_besluit_services()
-        zaak = self.create_zaak()
+        zaak = ZaakFactory.create()
         zaak_url = make_absolute_uri(reverse(zaak))
 
         zaak_data, zaaktype_data = get_zaak_and_zaaktype_data(zaak_url)
@@ -44,9 +45,9 @@ class CMISUtilsTests(JWTAuthMixin, APICMISTestCase, OioMixin):
                 self.assertIn(field, zaaktype_data)
 
     def test_get_zaak_and_zaaktype_data_related_to_besluit(self):
-        self.create_zaak_besluit_services()
-        besluit = self.create_besluit()
-        zaak_url = make_absolute_uri(reverse(besluit.zaak))
+        zaak = ZaakFactory.create()
+        BesluitFactory.create(zaak=zaak)
+        zaak_url = make_absolute_uri(reverse(zaak))
 
         zaak_data, zaaktype_data = get_zaak_and_zaaktype_data(zaak_url)
 

--- a/src/openzaak/components/zaken/models/zaken.py
+++ b/src/openzaak/components/zaken/models/zaken.py
@@ -858,10 +858,11 @@ class ZaakInformatieObject(models.Model):
     def unique_representation(self):
         zaak_repr = self.zaak.unique_representation()
 
-        if hasattr(self.informatieobject, "identificatie"):
-            doc_identificatie = self.informatieobject.identificatie
+        informatieobject = self.informatieobject
+        if hasattr(informatieobject, "identificatie"):
+            doc_identificatie = informatieobject.identificatie
         else:
-            doc_identificatie = self.informatieobject.latest_version.identificatie
+            doc_identificatie = informatieobject.latest_version.identificatie
 
         return f"({zaak_repr}) - {doc_identificatie}"
 

--- a/src/openzaak/components/zaken/tests/assertions.py
+++ b/src/openzaak/components/zaken/tests/assertions.py
@@ -26,7 +26,9 @@ class CRUDAssertions:
         with self.subTest(action="partial_update"):
             response = self.client.patch(url)
 
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.data)
+            self.assertEqual(
+                response.status_code, status.HTTP_403_FORBIDDEN, response.data
+            )
 
     def assertDestroyBlocked(self, url: str):
         with self.subTest(action="destroy"):
@@ -56,7 +58,7 @@ class CRUDAssertions:
         with self.subTest(action="partial_update"):
             response = self.client.patch(url)
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+            self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
 
     def assertDestroyAllowed(self, url: str):
         with self.subTest(action="destroy"):

--- a/src/openzaak/components/zaken/tests/models/test_unique_representation_cmis.py
+++ b/src/openzaak/components/zaken/tests/models/test_unique_representation_cmis.py
@@ -5,26 +5,23 @@ from django.test import override_settings, tag
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.utils.tests import APICMISTestCase, OioMixin, serialise_eio
+from openzaak.utils.tests import APICMISTestCase
 
 from ..factories import ZaakInformatieObjectFactory
 
 
 @tag("cmis")
 @override_settings(CMIS_ENABLED=True)
-class UniqueRepresentationCMISTestCase(APICMISTestCase, OioMixin):
+class UniqueRepresentationCMISTestCase(APICMISTestCase):
     def test_zaakinformatieobject(self):
         eio = EnkelvoudigInformatieObjectFactory.create(identificatie="12345")
         eio_url = eio.get_url()
-        self.adapter.get(eio_url, json=serialise_eio(eio, eio_url))
-        self.create_zaak_besluit_services()
-        zaak = self.create_zaak(
-            **{
-                "bronorganisatie": 730924658,
-                "identificatie": "5d940d52-ff5e-4b18-a769-977af9130c04",
-            }
+
+        zio = ZaakInformatieObjectFactory(
+            zaak__bronorganisatie=730924658,
+            zaak__identificatie="5d940d52-ff5e-4b18-a769-977af9130c04",
+            informatieobject=eio_url,
         )
-        zio = ZaakInformatieObjectFactory(zaak=zaak, informatieobject=eio_url,)
 
         self.assertEqual(
             zio.unique_representation(),

--- a/src/openzaak/components/zaken/tests/models/test_zio_block_change_cmis.py
+++ b/src/openzaak/components/zaken/tests/models/test_zio_block_change_cmis.py
@@ -6,7 +6,7 @@ from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
 from openzaak.utils.query import QueryBlocked
-from openzaak.utils.tests import APICMISTestCase, OioMixin, serialise_eio
+from openzaak.utils.tests import APICMISTestCase
 
 from ...models import ZaakInformatieObject
 from ..factories import ZaakInformatieObjectFactory
@@ -14,17 +14,13 @@ from ..factories import ZaakInformatieObjectFactory
 
 @tag("cmis")
 @override_settings(CMIS_ENABLED=True)
-class BlockChangeCMISTestCase(APICMISTestCase, OioMixin):
+class BlockChangeCMISTestCase(APICMISTestCase):
     def setUp(self) -> None:
         super().setUp()
+
         eio = EnkelvoudigInformatieObjectFactory.create()
         eio_url = eio.get_url()
-        self.adapter.get(eio_url, json=serialise_eio(eio, eio_url))
-        self.create_zaak_besluit_services()
-        zaak = self.create_zaak()
-        self.zio = ZaakInformatieObjectFactory.create(
-            informatieobject=eio_url, zaak=zaak
-        )
+        self.zio = ZaakInformatieObjectFactory.create(informatieobject=eio_url)
 
     def test_update(self):
         self.assertRaises(

--- a/src/openzaak/components/zaken/tests/test_cmis_url_mapping.py
+++ b/src/openzaak/components/zaken/tests/test_cmis_url_mapping.py
@@ -16,8 +16,11 @@ from openzaak.components.catalogi.tests.factories import (
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.components.zaken.tests.factories import ZaakInformatieObjectFactory
-from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin, OioMixin, serialise_eio
+from openzaak.components.zaken.tests.factories import (
+    ZaakFactory,
+    ZaakInformatieObjectFactory,
+)
+from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin
 
 
 @tag("cmis")
@@ -26,19 +29,17 @@ from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin, OioMixin, serial
     CMIS_ENABLED=True, CMIS_URL_MAPPING_ENABLED=True,
 )
 @skipIf(os.getenv("CMIS_BINDING") != "WEBSERVICE", "WEBSERVICE binding specific tests")
-class URLMappingZIOAPITests(JWTAuthMixin, APICMISTestCase, OioMixin):
+class URLMappingZIOAPITests(JWTAuthMixin, APICMISTestCase):
 
     heeft_alle_autorisaties = True
 
     def test_create_no_url_mapping(self):
-        self.create_zaak_besluit_services()
-        zaak = self.create_zaak()
+        zaak = ZaakFactory.create()
         zaak_url = reverse(zaak)
         io = EnkelvoudigInformatieObjectFactory.create(
             informatieobjecttype__concept=False
         )
         io_url = f"http://testserver{reverse(io)}"
-        self.adapter.get(io_url, json=serialise_eio(io, io_url))
 
         ZaakTypeInformatieObjectTypeFactory.create(
             informatieobjecttype=io.informatieobjecttype, zaaktype=zaak.zaaktype
@@ -74,10 +75,8 @@ class URLMappingZIOAPITests(JWTAuthMixin, APICMISTestCase, OioMixin):
     def test_delete_no_url_mapping(self):
         eio = EnkelvoudigInformatieObjectFactory.create()
         eio_url = eio.get_url()
-        self.adapter.get(eio_url, json=serialise_eio(eio, eio_url))
-        self.create_zaak_besluit_services()
-        zaak = self.create_zaak()
-        zio = ZaakInformatieObjectFactory.create(informatieobject=eio_url, zaak=zaak)
+
+        zio = ZaakInformatieObjectFactory.create(informatieobject=eio_url)
         zio_url = reverse(zio)
 
         # Remove all available mappings

--- a/src/openzaak/components/zaken/tests/test_filters_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_filters_cmis.py
@@ -5,7 +5,7 @@ from django.test import override_settings, tag
 from rest_framework import status
 from vng_api_common.tests import reverse
 
-from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin, OioMixin, serialise_eio
+from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin
 
 from ...documenten.tests.factories import EnkelvoudigInformatieObjectFactory
 from ..models import ZaakInformatieObject
@@ -14,17 +14,14 @@ from .factories import ZaakInformatieObjectFactory
 
 @tag("cmis")
 @override_settings(CMIS_ENABLED=True)
-class ZaakInformatieObjectFilterCMISTests(JWTAuthMixin, APICMISTestCase, OioMixin):
+class ZaakInformatieObjectFilterCMISTests(JWTAuthMixin, APICMISTestCase):
     heeft_alle_autorisaties = True
 
     def test_filter_by_valid_url_object_does_not_exist(self):
         eio = EnkelvoudigInformatieObjectFactory.create()
         eio_url = eio.get_url()
-        self.adapter.get(eio_url, json=serialise_eio(eio, eio_url))
-        self.create_zaak_besluit_services()
-        self.zio = ZaakInformatieObjectFactory.create(
-            informatieobject=eio_url, zaak=self.create_zaak()
-        )
+
+        self.zio = ZaakInformatieObjectFactory.create(informatieobject=eio_url)
         for query_param in ["zaak", "informatieobject"]:
             with self.subTest(query_param=query_param):
                 response = self.client.get(

--- a/src/openzaak/components/zaken/tests/test_zaak_archive_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_archive_cmis.py
@@ -14,9 +14,9 @@ from vng_api_common.tests import reverse
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin, OioMixin, serialise_eio
+from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin
 
-from .factories import ZaakInformatieObjectFactory
+from .factories import ZaakFactory, ZaakInformatieObjectFactory
 from .utils import ZAAK_WRITE_KWARGS, get_operation_url
 
 VERANTWOORDELIJKE_ORGANISATIE = "517439943"
@@ -24,19 +24,18 @@ VERANTWOORDELIJKE_ORGANISATIE = "517439943"
 
 @tag("cmis")
 @override_settings(CMIS_ENABLED=True)
-class US345CMISTestCase(JWTAuthMixin, APICMISTestCase, OioMixin):
+class US345CMISTestCase(JWTAuthMixin, APICMISTestCase):
 
     heeft_alle_autorisaties = True
 
     def test_can_set_archiefstatus_when_all_documents_are_gearchiveerd(self):
-        self.create_zaak_besluit_services()
-        zaak = self.create_zaak(
+        zaak = ZaakFactory.create(
             archiefnominatie=Archiefnominatie.vernietigen,
             archiefactiedatum=date.today(),
         )
         io = EnkelvoudigInformatieObjectFactory.create(status="gearchiveerd")
         io_url = f"http://testserver{reverse(io)}"
-        self.adapter.get(io_url, json=serialise_eio(io, io_url))
+
         ZaakInformatieObjectFactory.create(zaak=zaak, informatieobject=io_url)
         zaak_patch_url = get_operation_url("zaak_partial_update", uuid=zaak.uuid)
         data = {"archiefstatus": Archiefstatus.gearchiveerd}
@@ -46,14 +45,13 @@ class US345CMISTestCase(JWTAuthMixin, APICMISTestCase, OioMixin):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
 
     def test_cannot_set_archiefstatus_when_not_all_documents_are_gearchiveerd(self):
-        self.create_zaak_besluit_services()
-        zaak = self.create_zaak(
+        zaak = ZaakFactory.create(
             archiefnominatie=Archiefnominatie.vernietigen,
             archiefactiedatum=date.today(),
         )
         io = EnkelvoudigInformatieObjectFactory.create(status="in_bewerking")
         io_url = f"http://testserver{reverse(io)}"
-        self.adapter.get(io_url, json=serialise_eio(io, io_url))
+
         ZaakInformatieObjectFactory.create(zaak=zaak, informatieobject=io_url)
         zaak_patch_url = get_operation_url("zaak_partial_update", uuid=zaak.uuid)
         data = {"archiefstatus": Archiefstatus.gearchiveerd}

--- a/src/openzaak/components/zaken/tests/test_zaak_delete_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_delete_cmis.py
@@ -5,7 +5,7 @@ from django.test import override_settings, tag
 from rest_framework import status
 from vng_api_common.tests import reverse
 
-from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin, OioMixin, serialise_eio
+from openzaak.utils.tests import APICMISTestCase, JWTAuthMixin
 
 from ...documenten.tests.factories import EnkelvoudigInformatieObjectFactory
 from ..models import (
@@ -33,7 +33,7 @@ from .utils import ZAAK_WRITE_KWARGS, get_operation_url
 
 @tag("cmis")
 @override_settings(CMIS_ENABLED=True)
-class US349TestCase(JWTAuthMixin, APICMISTestCase, OioMixin):
+class US349TestCase(JWTAuthMixin, APICMISTestCase):
 
     heeft_alle_autorisaties = True
 
@@ -41,14 +41,12 @@ class US349TestCase(JWTAuthMixin, APICMISTestCase, OioMixin):
         """
         Deleting a zaak causes all related objects to be deleted as well.
         """
-        self.create_zaak_besluit_services()
-        zaak = self.create_zaak()
+        zaak = ZaakFactory.create()
 
         io = EnkelvoudigInformatieObjectFactory.create(
             informatieobjecttype__concept=False
         )
         io_url = f"http://testserver{reverse(io)}"
-        self.adapter.get(io_url, json=serialise_eio(io, io_url))
 
         ZaakFactory.create(hoofdzaak=zaak)
 

--- a/src/openzaak/utils/tests.py
+++ b/src/openzaak/utils/tests.py
@@ -18,15 +18,12 @@ from django.utils import timezone
 from djangorestframework_camel_case.util import camelize
 from drc_cmis.client_builder import get_cmis_client
 from drc_cmis.models import CMISConfig, UrlMapping
-from drc_cmis.utils.convert import make_absolute_uri
 from rest_framework.test import APITestCase
 from vng_api_common.authorizations.models import Applicatie, Autorisatie
 from vng_api_common.constants import ComponentTypes, VertrouwelijkheidsAanduiding
 from vng_api_common.models import JWTSecret
 from vng_api_common.tests import generate_jwt_auth, reverse
 from zds_client.tests.mocks import MockClient
-from zgw_consumers.constants import APITypes, AuthTypes
-from zgw_consumers.models import Service
 
 from openzaak.accounts.models import User
 
@@ -203,120 +200,14 @@ class CMISMixin:
         self.adapter.stop()
 
 
-class OioMixin:
-    base_zaak = None
-    base_zaaktype = None
-    base_besluit = None
-
-    def create_zaak_besluit_services(
-        self, base_besluit: str = None, base_zaak: str = None, base_zaaktype: str = None
-    ):
-        site = Site.objects.get_current()
-        self.base_besluit = base_besluit or f"http://{site.domain}/besluiten/api/v1/"
-        self.base_zaak = base_zaak or f"http://{site.domain}/zaken/api/v1/"
-        self.base_zaaktype = base_zaaktype or f"http://{site.domain}/catalogi/api/v1/"
-
-        Service.objects.create(
-            api_type=APITypes.zrc,
-            api_root=self.base_zaak,
-            label="external zaken",
-            auth_type=AuthTypes.no_auth,
-        )
-        Service.objects.create(
-            api_type=APITypes.ztc,
-            api_root=self.base_zaaktype,
-            label="external zaaktypen",
-            auth_type=AuthTypes.no_auth,
-        )
-        Service.objects.create(
-            api_type=APITypes.brc,
-            api_root=self.base_besluit,
-            label="external besluiten",
-            auth_type=AuthTypes.no_auth,
-        )
-
-    def create_besluit_without_zaak(self, **kwargs):
-        from openzaak.components.besluiten.tests.factories import BesluitFactory
-        from openzaak.tests.utils import mock_service_oas_get
-
-        besluit = BesluitFactory.create(**kwargs)
-        mock_service_oas_get(self.adapter, APITypes.brc, self.base_besluit)
-        besluit_url = make_absolute_uri(reverse(besluit))
-        self.adapter.get(
-            besluit_url,
-            json={
-                "url": besluit_url,
-                "verantwoordelijke_organisatie": "517439943",
-                "identificatie": "123123",
-                "besluittype": "http://testserver/besluittype/some-random-id",
-                "datum": "2018-09-06",
-                "toelichting": "Vergunning verleend.",
-                "ingangsdatum": "2018-10-01",
-                "vervaldatum": "2018-11-01",
-            },
-        )
-
-        return besluit
-
-    def create_besluit(self, **kwargs):
-        from openzaak.components.besluiten.tests.factories import BesluitFactory
-        from openzaak.tests.utils import mock_service_oas_get
-
-        zaak = self.create_zaak()
-        besluit = BesluitFactory.create(zaak=zaak, **kwargs)
-        mock_service_oas_get(self.adapter, APITypes.brc, self.base_besluit)
-        self.adapter.get(
-            make_absolute_uri(reverse(besluit)),
-            json={
-                "zaak": make_absolute_uri(reverse(zaak)),
-                "url": make_absolute_uri(reverse(besluit)),
-            },
-        )
-
-        return besluit
-
-    def create_zaak(self, **kwargs):
-        from openzaak.components.zaken.tests.factories import ZaakFactory
-        from openzaak.tests.utils import mock_service_oas_get
-
-        zaak = ZaakFactory.create(**kwargs)
-
-        mock_service_oas_get(self.adapter, APITypes.zrc, self.base_zaak)
-        mock_service_oas_get(self.adapter, APITypes.ztc, self.base_zaaktype)
-
-        if kwargs.get("zaaktype") is not None and isinstance(
-            kwargs.get("zaaktype"), str
-        ):
-            zaaktype_url = kwargs.get("zaaktype")
-            zaaktype_identificatie = zaaktype_url.split("/")[-1]
-        else:
-            zaaktype_url = make_absolute_uri(reverse(zaak.zaaktype))
-            zaaktype_identificatie = zaak.zaaktype.identificatie
-
-        self.adapter.get(
-            make_absolute_uri(reverse(zaak)),
-            json={
-                "url": make_absolute_uri(reverse(zaak)),
-                "identificatie": zaak.identificatie,
-                "zaaktype": zaaktype_url,
-            },
-        )
-
-        self.adapter.get(
-            zaaktype_url,
-            json={
-                "url": zaaktype_url,
-                "identificatie": zaaktype_identificatie,
-                "omschrijving": "Melding Openbare Ruimte",
-            },
-        )
-        return zaak
-
-
 class APICMISTestCase(MockSchemasMixin, CMISMixin, APITestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
+
+        site = Site.objects.get_current()
+        site.domain = "testserver"
+        site.save()
 
         binding = os.getenv("CMIS_BINDING")
         if binding == "WEBSERVICE":

--- a/src/openzaak/utils/validators.py
+++ b/src/openzaak/utils/validators.py
@@ -88,16 +88,15 @@ class LooseFkIsImmutableValidator(FKOrURLValidator):
 
             new_value = self.resolver.resolve(self.host, new_value)
 
-        if (
-            isinstance(current_value, ProxyMixin)
-            and isinstance(current_value, EnkelvoudigInformatieObject)
-            and isinstance(new_value, EnkelvoudigInformatieObject)
+        if isinstance(current_value, EnkelvoudigInformatieObject) and isinstance(
+            new_value, EnkelvoudigInformatieObject
         ):
-            current_value_url = current_value._initial_data["url"]
             if settings.CMIS_ENABLED:
                 new_value_url = new_value.get_url()
+                current_value_url = current_value.get_url()
             else:
                 new_value_url = new_value._initial_data["url"]
+                current_value_url = current_value._initial_data["url"]
 
             if new_value_url != current_value_url:
                 raise serializers.ValidationError(


### PR DESCRIPTION
Fixes #938 

**What's changed**

- When the EIO is needed (e.g. when creating a ZIO), it is retrieved locally instead of doing an API call.
- The `OioMixin`, which was used to set up services for Zaken, Catalogi en Besluiten API in the tests, was removed (it was forgotten in https://github.com/open-zaak/open-zaak/pull/901). The tests were accordingly updated.
- The documentation was also updated, so that it doesn't explain how to set up services.