### PR TITLE
Fix exporting published zaaktypen

### DIFF
--- a/src/openzaak/components/catalogi/admin/forms.py
+++ b/src/openzaak/components/catalogi/admin/forms.py
@@ -60,7 +60,7 @@ class ZaakTypeForm(forms.ModelForm):
             "initial-trefwoorden",
             "selectielijst_procestype_jaar",
         ]:
-            if self.data[field] != str(
+            if field in self.data and self.data[field] != str(
                 getattr(self.instance, field.replace("initial-", ""))
             ):
                 return True

--- a/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
@@ -764,6 +764,27 @@ class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
         import_button = response.html.find("input", {"name": "_import_zaaktype"})
         self.assertIsNone(import_button)
 
+    def test_export_published_zaaktype(self):
+        """
+        Regression test for #964 - export published zaaktype.
+        """
+        catalogus = CatalogusFactory.create(rsin="000000000", domein="TEST")
+        zaaktype = ZaakTypeFactory.create(
+            catalogus=catalogus,
+            vertrouwelijkheidaanduiding="openbaar",
+            zaaktype_omschrijving="bla",
+            concept=False,
+        )
+
+        url = reverse("admin:catalogi_zaaktype_change", args=(zaaktype.pk,))
+
+        response = self.app.get(url)
+        form = response.forms["zaaktype_form"]
+
+        response = form.submit("_export")
+
+        self.assertEqual(response.status_code, 200)
+
 
 @override_settings(CUSTOM_CLIENT_FETCHER=None)
 class ZaakTypeAdminImportExportTransactionTests(MockSelectielijst, TransactionWebTest):


### PR DESCRIPTION
Fixes #964

**Changes**

Only compare fields that are submitted in the POST request - published zaaktypen are read-only so the fields are absent.

