### PR TITLE
Fix alignment with DRC reference implementation (1.0.x)

### DIFF
--- a/src/openzaak/components/documenten/api/validators.py
+++ b/src/openzaak/components/documenten/api/validators.py
@@ -89,7 +89,7 @@ class RemoteRelationValidator:
 
     def __call__(self, oio: ObjectInformatieObject):
         # external object
-        if isinstance(oio.object, ProxyMixin):
+        if isinstance(oio.object, ProxyMixin) and not settings.CMIS_ENABLED:
             invalid = self._check_remote(oio)
         else:
             invalid = self._check_local(oio)
@@ -112,16 +112,13 @@ class RemoteRelationValidator:
     def _check_remote(self, oio: ObjectInformatieObject) -> bool:
         object_url = oio.object._loose_fk_data["url"]
 
-        if settings.CMIS_ENABLED:
-            document_url = oio.get_informatieobject_url()
-        else:
-            default_version = settings.REST_FRAMEWORK["DEFAULT_VERSION"]
-            document_url = build_absolute_url(
-                oio.informatieobject.latest_version.get_absolute_api_url(
-                    version=default_version
-                ),
-                request=self.request,
-            )
+        default_version = settings.REST_FRAMEWORK["DEFAULT_VERSION"]
+        document_url = build_absolute_url(
+            oio.informatieobject.latest_version.get_absolute_api_url(
+                version=default_version
+            ),
+            request=self.request,
+        )
 
         # obtain a client for the remote API. this should exist, otherwise loose-fk
         # would not have been able to load this resource :-)

--- a/src/openzaak/components/documenten/api/validators.py
+++ b/src/openzaak/components/documenten/api/validators.py
@@ -112,13 +112,16 @@ class RemoteRelationValidator:
     def _check_remote(self, oio: ObjectInformatieObject) -> bool:
         object_url = oio.object._loose_fk_data["url"]
 
-        default_version = settings.REST_FRAMEWORK["DEFAULT_VERSION"]
-        document_url = build_absolute_url(
-            oio.informatieobject.latest_version.get_absolute_api_url(
-                version=default_version
-            ),
-            request=self.request,
-        )
+        if settings.CMIS_ENABLED:
+            document_url = oio.get_informatieobject_url()
+        else:
+            default_version = settings.REST_FRAMEWORK["DEFAULT_VERSION"]
+            document_url = build_absolute_url(
+                oio.informatieobject.latest_version.get_absolute_api_url(
+                    version=default_version
+                ),
+                request=self.request,
+            )
 
         # obtain a client for the remote API. this should exist, otherwise loose-fk
         # would not have been able to load this resource :-)

--- a/src/openzaak/components/documenten/api/validators.py
+++ b/src/openzaak/components/documenten/api/validators.py
@@ -89,7 +89,7 @@ class RemoteRelationValidator:
 
     def __call__(self, oio: ObjectInformatieObject):
         # external object
-        if isinstance(oio.object, ProxyMixin) and not settings.CMIS_ENABLED:
+        if isinstance(oio.object, ProxyMixin):
             invalid = self._check_remote(oio)
         else:
             invalid = self._check_local(oio)
@@ -112,13 +112,16 @@ class RemoteRelationValidator:
     def _check_remote(self, oio: ObjectInformatieObject) -> bool:
         object_url = oio.object._loose_fk_data["url"]
 
-        default_version = settings.REST_FRAMEWORK["DEFAULT_VERSION"]
-        document_url = build_absolute_url(
-            oio.informatieobject.latest_version.get_absolute_api_url(
-                version=default_version
-            ),
-            request=self.request,
-        )
+        if settings.CMIS_ENABLED:
+            document_url = oio.get_informatieobject_url()
+        else:
+            default_version = settings.REST_FRAMEWORK["DEFAULT_VERSION"]
+            document_url = build_absolute_url(
+                oio.informatieobject.latest_version.get_absolute_api_url(
+                    version=default_version
+                ),
+                request=self.request,
+            )
 
         # obtain a client for the remote API. this should exist, otherwise loose-fk
         # would not have been able to load this resource :-)

--- a/src/openzaak/components/documenten/api/validators.py
+++ b/src/openzaak/components/documenten/api/validators.py
@@ -1,17 +1,22 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
+import logging
 from collections import OrderedDict
 
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
+from django_loose_fk.virtual_models import ProxyMixin
 from rest_framework import serializers
+from vng_api_common.constants import ObjectTypes
 from vng_api_common.validators import (
     UniekeIdentificatieValidator as _UniekeIdentificatieValidator,
 )
 
 from ..models import ObjectInformatieObject
 from ..validators import validate_status
+
+logger = logging.getLogger(__name__)
 
 
 class StatusValidator:
@@ -66,3 +71,27 @@ class UniekeIdentificatieValidator(_UniekeIdentificatieValidator):
 
     def __init__(self):
         super().__init__("bronorganisatie", "identificatie")
+
+
+class RemoteRelationValidator:
+    message = _(
+        "The canonical remote relation still exists, this relation cannot be deleted."
+    )
+    code = "remote-relation-exists"
+
+    def __call__(self, oio: ObjectInformatieObject):
+        # external object
+        if isinstance(oio.object, ProxyMixin):
+            # TODO: validate that the source relation has been destroyed
+            return
+
+        method_map = {
+            ObjectTypes.zaak: "does_zaakinformatieobject_exist",
+            ObjectTypes.besluit: "does_besluitinformatieobject_exist",
+        }
+        check_method = getattr(oio, method_map[oio.object_type])
+        if check_method():
+            logger.info(
+                "Relation between %s and informatieobject still exists", oio.object_type
+            )
+            raise serializers.ValidationError(self.message, self.code)

--- a/src/openzaak/components/documenten/api/viewsets.py
+++ b/src/openzaak/components/documenten/api/viewsets.py
@@ -532,7 +532,7 @@ class ObjectInformatieObjectViewSet(
         The actual relation information must be updated in the signals,
         so this is just a check.
         """
-        validator = RemoteRelationValidator()
+        validator = RemoteRelationValidator(request=self.request)
         try:
             validator(instance)
         except ValidationError as exc:

--- a/src/openzaak/components/documenten/tests/factories.py
+++ b/src/openzaak/components/documenten/tests/factories.py
@@ -11,7 +11,6 @@ Factory models for the documenten application.
     creation.
 """
 import datetime
-import uuid
 
 from django.test import RequestFactory
 from django.utils import timezone
@@ -37,7 +36,7 @@ class EnkelvoudigInformatieObjectFactory(factory.django.DjangoModelFactory):
     canonical = factory.SubFactory(
         EnkelvoudigInformatieObjectCanonicalFactory, latest_version=None
     )
-    identificatie = factory.fuzzy.FuzzyAttribute(uuid.uuid4)
+    identificatie = factory.Sequence(lambda n: f"document-{n}")
     bronorganisatie = factory.Faker("ssn", locale="nl_NL")
     creatiedatum = datetime.date(2018, 6, 27)
     titel = "some titel"

--- a/src/openzaak/components/documenten/tests/test_objectinformatieobject.py
+++ b/src/openzaak/components/documenten/tests/test_objectinformatieobject.py
@@ -556,7 +556,7 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         self.assertEqual(response.data[0]["object"], besluit2)
 
     @requests_mock.Mocker()
-    def test_destroy_external_zaak(self, m):
+    def test_destroy_oio_with_external_zaak(self, m):
         zaak = "https://extern.zrc.nl/api/v1/zaken/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
         zaaktype = "https://externe.catalogus.nl/api/v1/zaaktypen/b71f72ef-198d-44d8-af64-ae1932df830a"
         eio = EnkelvoudigInformatieObjectFactory.create()
@@ -579,7 +579,7 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         self.assertEqual(ObjectInformatieObject.objects.count(), 0)
 
     @requests_mock.Mocker()
-    def test_destroy_external_besluit(self, m):
+    def test_destroy_oio_with_external_besluit(self, m):
         besluit = "https://extern.brc.nl/api/v1/besluiten/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
         besluittype = "https://externe.catalogus.nl/api/v1/besluittypen/b71f72ef-198d-44d8-af64-ae1932df830a"
         eio = EnkelvoudigInformatieObjectFactory.create()

--- a/src/openzaak/components/documenten/tests/test_objectinformatieobject.py
+++ b/src/openzaak/components/documenten/tests/test_objectinformatieobject.py
@@ -568,7 +568,6 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(ObjectInformatieObject.objects.count(), 0)
 
-    @tag("test-this")
     @requests_mock.Mocker()
     @override_settings(ALLOWED_HOSTS=["openzaak.nl"])
     def test_destroy_oio_remote_still_present(self, m):

--- a/src/openzaak/components/documenten/tests/test_objectinformatieobject.py
+++ b/src/openzaak/components/documenten/tests/test_objectinformatieobject.py
@@ -269,6 +269,16 @@ class ObjectInformatieObjectDestroyTests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
 
     def test_destroy_oio_remote_gone(self):
+        """
+        Assert that the OIO is deleted when the primary relation side is deleted.
+
+        When the ZIO or BIO is deleted, Open Zaak must make the call to delete the OIO.
+        We verify this by deleting the ZIO and observing that the end result is the
+        same - the OIO no longer exists in the API. This deviates from the reference
+        implementation, since they are two different systems making the calls, but
+        here Open Zaak has full control about the database and doesn't even have to
+        make the DELETE call, so it's fine this 404's.
+        """
         eio = EnkelvoudigInformatieObjectFactory.create()
 
         # relate the two
@@ -294,7 +304,7 @@ class ObjectInformatieObjectDestroyTests(JWTAuthMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         error = get_validation_errors(response, "nonFieldErrors")
-        self.assertEqual(error["code"], "inconsistent-relation")
+        self.assertEqual(error["code"], "remote-relation-exists")
 
 
 @tag("external-urls")

--- a/src/openzaak/components/documenten/tests/test_objectinformatieobject_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_objectinformatieobject_cmis.py
@@ -715,7 +715,7 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["object"], besluit2)
 
-    def test_destroy_external_zaak(self):
+    def test_destroy_oio_with_external_zaak(self):
         self.adapter.get(self.zaak, json=get_zaak_response(self.zaak, self.zaaktype))
         self.adapter.get(
             self.zaaktype, json=get_zaak_response(self.catalogus, self.zaaktype)
@@ -738,7 +738,7 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(ObjectInformatieObject.objects.count(), 0)
 
-    def test_destroy_external_besluit(self):
+    def test_destroy_oio_with_external_besluit(self):
         self.adapter.get(
             self.besluit,
             json=get_besluit_response(self.besluit, self.besluittype, self.zaak),

--- a/src/openzaak/components/documenten/tests/test_objectinformatieobject_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_objectinformatieobject_cmis.py
@@ -25,7 +25,10 @@ from openzaak.components.zaken.tests.factories import (
     ZaakFactory,
     ZaakInformatieObjectFactory,
 )
-from openzaak.components.zaken.tests.utils import get_zaak_response
+from openzaak.components.zaken.tests.utils import (
+    get_zaak_response,
+    get_zaaktype_response,
+)
 from openzaak.tests.utils import mock_service_oas_get
 from openzaak.utils.tests import APICMISTestCase
 
@@ -356,11 +359,11 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
     heeft_alle_autorisaties = True
     list_url = reverse_lazy(ObjectInformatieObject)
 
-    besluit = "https://externe.catalogus.nl/api/v1/besluiten/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
-    besluittype = "https://externe.catalogus.nl/api/v1/besluittypen/b71f72ef-198d-44d8-af64-ae1932df830a"
-    zaak = (
-        "https://externe.catalogus.nl/api/v1/zaken/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
+    besluit = (
+        "https://extern.brc.nl/api/v1/besluiten/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
     )
+    besluittype = "https://externe.catalogus.nl/api/v1/besluittypen/b71f72ef-198d-44d8-af64-ae1932df830a"
+    zaak = "https://extern.zrc.nl/api/v1/zaken/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
     zaaktype = "https://externe.catalogus.nl/api/v1/zaaktypen/b71f72ef-198d-44d8-af64-ae1932df830a"
     catalogus = "https://externe.catalogus.nl/api/v1/catalogussen/5c4c492b-3548-4258-b17f-0e2e31dcfe25"
 
@@ -375,6 +378,23 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
             auth_type=AuthTypes.no_auth,
         )
 
+        cls.zrc_service = Service.objects.create(
+            label="Remote Zaken API",
+            api_type=APITypes.zrc,
+            api_root="https://extern.zrc.nl/api/v1/",
+            auth_type=AuthTypes.zgw,
+            client_id="test",
+            secret="test",
+        )
+        cls.brc_service = Service.objects.create(
+            label="Remote Besluiten API",
+            api_type=APITypes.brc,
+            api_root="https://extern.brc.nl/api/v1/",
+            auth_type=AuthTypes.zgw,
+            client_id="test",
+            secret="test",
+        )
+
         config = CMISConfig.objects.get()
 
         if settings.CMIS_URL_MAPPING_ENABLED:
@@ -383,12 +403,31 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
                 short_pattern="https://xcat.nl",
                 config=config,
             )
+            UrlMapping.objects.create(
+                long_pattern="https://extern.zrc.nl",
+                short_pattern="https://xzrc.nl",
+                config=config,
+            )
+            UrlMapping.objects.create(
+                long_pattern="https://extern.brc.nl",
+                short_pattern="https://xbrc.nl",
+                config=config,
+            )
 
-    def test_create_external_zaak(self):
+    def setUp(self):
+        super().setUp()
+
         mock_service_oas_get(
-            self.adapter, APITypes.zrc, "https://externe.catalogus.nl/api/v1/"
+            self.adapter, APITypes.zrc, "https://extern.zrc.nl/api/v1/"
+        )
+        mock_service_oas_get(
+            self.adapter, APITypes.ztc, "https://externe.catalogus.nl/api/v1/"
+        )
+        mock_service_oas_get(
+            self.adapter, APITypes.brc, "https://extern.brc.nl/api/v1/"
         )
 
+    def test_create_external_zaak(self):
         self.adapter.get(self.zaak, json=get_zaak_response(self.zaak, self.zaaktype))
         self.adapter.get(
             self.zaaktype, json=get_zaak_response(self.catalogus, self.zaaktype)
@@ -412,10 +451,6 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(oio.object, self.zaak)
 
     def test_create_external_besluit(self):
-        mock_service_oas_get(
-            self.adapter, APITypes.zrc, "https://externe.catalogus.nl/api/v1/"
-        )
-
         self.adapter.get(
             self.besluit,
             json=get_besluit_response(self.besluit, self.besluittype, self.zaak),
@@ -447,7 +482,7 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(oio.object, self.besluit)
 
     def test_create_external_zaak_fail_invalid_schema(self):
-        zaak = "https://externe.catalogus.nl/api/v1/zaken/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
+        zaak = "https://extern.zrc.nl/api/v1/zaken/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
         zaaktype = "https://externe.catalogus.nl/api/v1/zaaktypen/b71f72ef-198d-44d8-af64-ae1932df830a"
 
         eio = EnkelvoudigInformatieObjectFactory.create()
@@ -479,7 +514,7 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(error["code"], "invalid-resource")
 
     def test_create_external_besluit_fail_invalid_schema(self):
-        besluit = "https://externe.catalogus.nl/api/v1/besluiten/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
+        besluit = "https://extern.brc.nl/api/v1/besluiten/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
         besluittype = "https://externe.catalogus.nl/api/v1/besluittypen/b71f72ef-198d-44d8-af64-ae1932df830a"
 
         eio = EnkelvoudigInformatieObjectFactory.create()
@@ -510,10 +545,6 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(error["code"], "invalid-resource")
 
     def test_create_fail_not_unique(self):
-        mock_service_oas_get(
-            self.adapter, APITypes.zrc, "https://externe.catalogus.nl/api/v1/"
-        )
-
         self.adapter.get(
             self.besluit,
             json=get_besluit_response(self.besluit, self.besluittype, self.zaak),
@@ -546,10 +577,6 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(error["code"], "unique")
 
     def test_read_external_zaak(self):
-        mock_service_oas_get(
-            self.adapter, APITypes.zrc, "https://externe.catalogus.nl/api/v1/"
-        )
-
         self.adapter.get(self.zaak, json=get_zaak_response(self.zaak, self.zaaktype))
         self.adapter.get(
             self.zaaktype, json=get_zaak_response(self.catalogus, self.zaaktype)
@@ -574,10 +601,6 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(data["informatieobject"], f"http://testserver{reverse(eio)}")
 
     def test_read_external_besluit(self):
-        mock_service_oas_get(
-            self.adapter, APITypes.zrc, "https://externe.catalogus.nl/api/v1/"
-        )
-
         self.adapter.get(
             self.besluit,
             json=get_besluit_response(self.besluit, self.besluittype, self.zaak),
@@ -609,12 +632,12 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
     def test_list_filter_by_external_zaak(self):
         eio = EnkelvoudigInformatieObjectFactory.create()
 
-        mock_service_oas_get(
-            self.adapter, APITypes.zrc, "https://externe.catalogus.nl/api/v1/"
+        zaak1 = (
+            "https://extern.zrc.nl/api/v1/zaken/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
         )
-
-        zaak1 = "https://externe.catalogus.nl/api/v1/zaken/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
-        zaak2 = "https://externe.catalogus.nl/api/v1/zaken/b923543f-97aa-4a55-8c20-889b5906cf75"
+        zaak2 = (
+            "https://extern.zrc.nl/api/v1/zaken/b923543f-97aa-4a55-8c20-889b5906cf75"
+        )
         zaaktype1 = "https://externe.catalogus.nl/api/v1/zaaktypen/b71f72ef-198d-44d8-af64-ae1932df830a"
         zaaktype2 = "https://externe.catalogus.nl/api/v1/zaaktypen/5c4c492b-3548-4258-b17f-0e2e31dcfe25"
         catalogus1 = "https://externe.catalogus.nl/api/v1/catalogussen/5c4c492b-3548-4258-b17f-0e2e31dcfe25"
@@ -646,19 +669,19 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
 
     def test_list_filter_by_external_besluit(self):
         eio = EnkelvoudigInformatieObjectFactory.create()
-        mock_service_oas_get(
-            self.adapter, APITypes.zrc, "https://externe.catalogus.nl/api/v1/"
-        )
-
         # Needed for the CMIS adapter
-        zaak1 = "https://externe.catalogus.nl/api/v1/zaken/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
-        zaak2 = "https://externe.catalogus.nl/api/v1/zaken/b923543f-97aa-4a55-8c20-889b5906cf75"
+        zaak1 = (
+            "https://extern.zrc.nl/api/v1/zaken/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
+        )
+        zaak2 = (
+            "https://extern.zrc.nl/api/v1/zaken/b923543f-97aa-4a55-8c20-889b5906cf75"
+        )
         zaaktype1 = "https://externe.catalogus.nl/api/v1/zaaktypen/b71f72ef-198d-44d8-af64-ae1932df830a"
         zaaktype2 = "https://externe.catalogus.nl/api/v1/zaaktypen/5c4c492b-3548-4258-b17f-0e2e31dcfe25"
         catalogus1 = "https://externe.catalogus.nl/api/v1/catalogussen/5c4c492b-3548-4258-b17f-0e2e31dcfe25"
         catalogus2 = "https://externe.catalogus.nl/api/v1/catalogussen/a8e03e86-152d-4e8c-83fc-047645cfc585"
-        besluit1 = "https://externe.catalogus.nl/api/v1/besluiten/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
-        besluit2 = "https://externe.catalogus.nl/api/v1/besluiten/b923543f-97aa-4a55-8c20-889b5906cf75"
+        besluit1 = "https://extern.brc.nl/api/v1/besluiten/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
+        besluit2 = "https://extern.brc.nl/api/v1/besluiten/b923543f-97aa-4a55-8c20-889b5906cf75"
         besluittype1 = "https://externe.catalogus.nl/api/v1/besluittypen/b71f72ef-198d-44d8-af64-ae1932df830a"
         besluittype2 = "https://externe.catalogus.nl/api/v1/besluittypen/3665b9be-6ac5-4075-8736-d79598e5325c"
 
@@ -693,24 +716,22 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(response.data[0]["object"], besluit2)
 
     def test_destroy_external_zaak(self):
-        mock_service_oas_get(
-            self.adapter, APITypes.zrc, "https://externe.catalogus.nl/api/v1/"
-        )
-
         self.adapter.get(self.zaak, json=get_zaak_response(self.zaak, self.zaaktype))
         self.adapter.get(
             self.zaaktype, json=get_zaak_response(self.catalogus, self.zaaktype)
         )
 
         eio = EnkelvoudigInformatieObjectFactory.create()
+        eio_url = f"http://testserver{reverse(eio)}"
         oio = ObjectInformatieObject.objects.create(
-            informatieobject=f"http://testserver{reverse(eio)}",
-            zaak=self.zaak,
-            object_type="zaak",
+            informatieobject=eio_url, zaak=self.zaak, object_type="zaak",
         )
         url = reverse(oio)
 
-        self.adapter.get(self.zaak, json=get_zaak_response(self.zaak, self.zaaktype))
+        self.adapter.get(
+            f"https://extern.zrc.nl/api/v1/zaakinformatieobjecten?zaak={self.zaak}&informatieobject={eio_url}",
+            json=[],
+        )
 
         response = self.client.delete(url)
 
@@ -718,10 +739,6 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(ObjectInformatieObject.objects.count(), 0)
 
     def test_destroy_external_besluit(self):
-        mock_service_oas_get(
-            self.adapter, APITypes.zrc, "https://externe.catalogus.nl/api/v1/"
-        )
-
         self.adapter.get(
             self.besluit,
             json=get_besluit_response(self.besluit, self.besluittype, self.zaak),
@@ -731,20 +748,23 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
             self.zaaktype, json=get_zaak_response(self.catalogus, self.zaaktype)
         )
 
-        eio = EnkelvoudigInformatieObjectFactory.create()
+        self.adapter.get(
+            self.besluit, json=get_besluit_response(self.besluit, self.besluittype),
+        )
 
+        eio = EnkelvoudigInformatieObjectFactory.create()
+        eio_url = f"http://testserver{reverse(eio)}"
         oio = ObjectInformatieObject.objects.create(
             informatieobject=f"http://testserver{reverse(eio)}",
             besluit=self.besluit,
             object_type="besluit",
         )
-
         url = reverse(oio)
 
-        self.adapter.register_uri(
-            "GET",
-            self.besluit,
-            json=get_besluit_response(self.besluit, self.besluittype),
+        self.adapter.get(
+            "https://extern.brc.nl/api/v1/besluitinformatieobjecten"
+            f"?besluit={self.besluit}&informatieobject={eio_url}",
+            json=[],
         )
 
         response = self.client.delete(url)
@@ -752,28 +772,14 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(ObjectInformatieObject.objects.count(), 0)
 
-    @override_settings(ALLOWED_HOSTS=["openzaak.nl"])
-    def test_destroy_oio_remote_still_present(self, m):
-        service = Service.objects.create(
-            label="Remote Zaken API",
-            api_type=APITypes.zrc,
-            api_root="https://extern.zrc.nl/api/v1/",
-            auth_type=AuthTypes.zgw,
-            client_id="test",
-            secret="test",
-        )
+    def test_destroy_oio_remote_still_present(self):
         zaak = "https://extern.zrc.nl/api/v1/zaken/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
         zaaktype = "https://extern.zrc.nl/api/v1/zaaktypen/b71f72ef-198d-44d8-af64-ae1932df830a"
         eio = EnkelvoudigInformatieObjectFactory.create()
-        eio_url = f"http://openzaak.nl{reverse(eio)}"
-        oio = ObjectInformatieObject.objects.create(
-            informatieobject=eio_url, zaak=zaak, object_type="zaak",
-        )
-        url = reverse(oio)
-
+        eio_url = f"http://testserver{reverse(eio)}"
         # set up mocks
-        mock_service_oas_get(self.adapter, "zrc", url=service.api_root)
         self.adapter.get(zaak, json=get_zaak_response(zaak, zaaktype))
+        self.adapter.get(zaaktype, json=get_zaaktype_response(self.catalogus, zaaktype))
         self.adapter.get(
             f"https://extern.zrc.nl/api/v1/zaakinformatieobjecten?zaak={zaak}&informatieobject={eio_url}",
             json=[
@@ -785,8 +791,12 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
                 }
             ],
         )
+        oio = ObjectInformatieObject.objects.create(
+            informatieobject=eio_url, zaak=zaak, object_type="zaak",
+        )
+        url = reverse(oio)
 
-        response = self.client.delete(url, HTTP_HOST="openzaak.nl")
+        response = self.client.delete(url)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         error = get_validation_errors(response, "nonFieldErrors")


### PR DESCRIPTION
These came up during testing by Contezza, many thanks for that!

**Changes**

* the `RemoveRelationValidator` now emits the correct error code `remote-relation-exists` instead of `inconsistent-relation`
* the `RemoveRelationValidator` now validates external URLs as well instead of letting those through (when deleting ObjectInformatieObject)

