### PR TITLE
:wrench: Set the uWSGI timeout to 5 minutes.

### DIFF
--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -62,4 +62,5 @@ exec uwsgi \
     --enable-threads \
     --processes $uwsgi_processes \
     --threads $uwsgi_threads \
-    --buffer-size=65535
+    --buffer-size=65535 \
+    --http-timeout=300


### PR DESCRIPTION
Fixes timeout settings not matching Nginx timeout.

**Changes**

Increases the (undocumented) default timeout of uWSGI from 60s to 300s. This is in line with the Nginx timeout which is also set to 300s.

