### PR TITLE
Allow all characters in (Besluit|Zaak).identificatie (admin)

### DIFF
--- a/src/openzaak/components/besluiten/models.py
+++ b/src/openzaak/components/besluiten/models.py
@@ -11,10 +11,7 @@ from django_loose_fk.fields import FkOrURLField
 from vng_api_common.fields import RSINField
 from vng_api_common.models import APIMixin
 from vng_api_common.utils import generate_unique_identification
-from vng_api_common.validators import (
-    UntilTodayValidator,
-    alphanumeric_excluding_diacritic,
-)
+from vng_api_common.validators import UntilTodayValidator
 
 from openzaak.components.documenten.loaders import EIOLoader
 from openzaak.loaders import AuthorizedRequestsLoader
@@ -36,7 +33,6 @@ class Besluit(AuditTrailMixin, APIMixin, models.Model):
         "identificatie",
         max_length=50,
         blank=True,
-        validators=[alphanumeric_excluding_diacritic],
         help_text="Identificatie van het besluit binnen de organisatie die "
         "het besluit heeft vastgesteld. Indien deze niet opgegeven is, "
         "dan wordt die gegenereerd.",

--- a/src/openzaak/components/besluiten/tests/admin/test_besluit_admin.py
+++ b/src/openzaak/components/besluiten/tests/admin/test_besluit_admin.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2020 Dimpact
+from django.urls import reverse
+
+from django_webtest import WebTest
+
+from openzaak.accounts.tests.factories import SuperUserFactory
+
+from ..factories import BesluitFactory
+
+
+class BesluitAdminTests(WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = SuperUserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+
+        self.app.set_user(self.user)
+
+    def test_non_alphanumeric_identificatie_validation(self):
+        """
+        Edit a zaak with an identificatie allowed by the API.
+
+        This should not trigger validation errors.
+        """
+        besluit = BesluitFactory.create(identificatie="ZK bläh")
+        url = reverse("admin:besluiten_besluit_change", args=(besluit.pk,))
+        response = self.app.get(url)
+        self.assertEqual(response.form["identificatie"].value, "ZK bläh")
+
+        submit_response = response.form.submit()
+
+        self.assertEqual(submit_response.status_code, 302)

--- a/src/openzaak/components/zaken/models/zaken.py
+++ b/src/openzaak/components/zaken/models/zaken.py
@@ -26,7 +26,6 @@ from vng_api_common.descriptors import GegevensGroepType
 from vng_api_common.fields import RSINField, VertrouwelijkheidsAanduidingField
 from vng_api_common.models import APIMixin
 from vng_api_common.utils import generate_unique_identification
-from vng_api_common.validators import alphanumeric_excluding_diacritic
 
 from openzaak.client import fetch_object
 from openzaak.components.documenten.loaders import EIOLoader
@@ -97,7 +96,6 @@ class Zaak(AuditTrailMixin, APIMixin, models.Model):
         blank=True,
         help_text="De unieke identificatie van de ZAAK binnen de organisatie "
         "die verantwoordelijk is voor de behandeling van de ZAAK.",
-        validators=[alphanumeric_excluding_diacritic],
         db_index=True,
     )
     bronorganisatie = RSINField(


### PR DESCRIPTION
Fixes #890

**Changes**

* Added API tests to make the behaviour explicit
* Added admin regression tests
* Removed alphanumeric validators from `Zaak.identificatie` and `Besluit.identificatie`

Replaces #944