### PR TITLE
Fixes #860 -- remove autorisatie-inlines for applicaties

### DIFF
--- a/src/openzaak/components/autorisaties/tests/admin/test_autorisaties_admin.py
+++ b/src/openzaak/components/autorisaties/tests/admin/test_autorisaties_admin.py
@@ -116,53 +116,6 @@ class ApplicatieInlinesAdminTests(WebTest):
             applicatie=self.applicatie, **{field: url, **kwargs},
         )
 
-    def test_inline_zaaktype_autorisaties(self):
-        zt = ZaakTypeFactory.create()
-        self._add_autorisatie(
-            zt,
-            component=ComponentTypes.zrc,
-            scopes=["zaken.lezen"],
-            max_vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.geheim,
-        )
-
-        response = self.app.get(self.url)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, str(zt))
-        self.assertContains(
-            response,
-            VertrouwelijkheidsAanduiding.labels[VertrouwelijkheidsAanduiding.geheim],
-        )
-
-    def test_inline_informatieobjecttype_autorisaties(self):
-        iot = InformatieObjectTypeFactory.create()
-        self._add_autorisatie(
-            iot,
-            component=ComponentTypes.drc,
-            scopes=["documenten.lezen"],
-            max_vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.geheim,
-        )
-
-        response = self.app.get(self.url)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, str(iot))
-        self.assertContains(
-            response,
-            VertrouwelijkheidsAanduiding.labels[VertrouwelijkheidsAanduiding.geheim],
-        )
-
-    def test_inline_besluittype_autorisaties(self):
-        bt = BesluitTypeFactory.create()
-        self._add_autorisatie(
-            bt, component=ComponentTypes.brc, scopes=["besluiten.lezen"]
-        )
-
-        response = self.app.get(self.url)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, str(bt))
-
 
 @tag("admin-autorisaties")
 class ManageAutorisatiesAdmin(NotificationServiceMixin, TransactionTestCase):

--- a/src/openzaak/components/autorisaties/tests/test_autorisatiespec.py
+++ b/src/openzaak/components/autorisaties/tests/test_autorisatiespec.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from vng_api_common.authorizations.models import Autorisatie
 from vng_api_common.constants import ComponentTypes, VertrouwelijkheidsAanduiding
@@ -11,6 +11,9 @@ from openzaak.utils import build_absolute_url
 from .factories import ApplicatieFactory, AutorisatieFactory, AutorisatieSpecFactory
 
 
+@override_settings(
+    ALLOWED_HOSTS=["example.com", "testserver"]
+)  # default value Site.objects.get_current()
 class DeleteAutorisatieTest(TestCase):
     def test_autorisaties_are_deleted(self):
         applicatie = ApplicatieFactory.create()

--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -398,11 +398,6 @@ X_FRAME_OPTIONS = "DENY"
 SILENCED_SYSTEM_CHECKS = ["rest_framework.W001"]
 
 #
-# Increase number of parameters for GET/POST requests
-#
-DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
-
-#
 # Custom settings
 #
 PROJECT_NAME = "Open Zaak"


### PR DESCRIPTION
Fixes #860

The 'manage authorizations' view presents a condensed, aggregated view
of the different authorizations for a given API application.

The regular admin interface displayed all authorizations as inline with
the application, but because of the amount of possible combinations
(different zaaktypen, documenttypen, besluittypen... and permissions),
this inline can quite easily exceed 10.000 records.

Once that number is exceeded, Django blocks the request because
`DATA_UPLOAD_MAX_NUMBER_FIELDS` is exceeded. Removing the inlines
fixes this.

**Changes**

* `Applicatie.autorisaties` inline removed with relevant tests
* `DATA_UPLOAD_MAX_NUMBER_FIELDS` reset to original value of 1000 (setting removed, using the Django default again)

