### PR TITLE
Feature/oidc integration

### DIFF
--- a/docs/manual/index.rst
+++ b/docs/manual/index.rst
@@ -23,3 +23,4 @@ directly in the management interface.
    api-authorizations
    other_apis
    adfs
+   oidc

--- a/docs/manual/oidc.rst
+++ b/docs/manual/oidc.rst
@@ -1,0 +1,80 @@
+.. _manual_oidc:
+
+===========================
+OpenID Connect configureren
+===========================
+
+Open Zaak ondersteunt Single Sign On (SSO) via het OpenID Connect protocol (OIDC) voor de beheerinterface.
+
+Gebruikers kunnen op die manier inloggen op Open Zaak met hun account bij de OpenID Connect provider. In deze
+flow:
+
+1. Klikt een gebruiker op het inlogscherm op *Inloggen met OIDC*
+2. De gebruiker wordt naar de omgeving van de OpenID Connect provider geleid (bijv. Keycloak) waar ze inloggen met gebruikersnaam
+   en wachtwoord (en eventuele Multi Factor Authorization)
+3. De OIDC omgeving stuurt de gebruiker terug naar Open Zaak (waar de account aangemaakt
+   wordt indien die nog niet bestaat)
+4. Een beheerder in Open Zaak kent de juiste groepen toe aan deze gebruiker als deze
+   voor het eerst inlogt.
+
+.. note:: Standaard krijgen deze gebruikers **geen** toegang tot de beheerinterface. Deze
+   rechten moeten door een (andere) beheerder :ref:`ingesteld <manual_users>` worden. De
+   account is wel aangemaakt.
+
+.. _manual_oidc_appgroup:
+
+Configureren van OIDC zelf
+==========================
+
+Contacteer de IAM beheerders in je organisatie om een *Client* aan te
+maken in de omgeving van de OpenID Connect provider.
+
+Voor de **Redirect URI** vul je ``https://open-zaak.gemeente.nl/oidc/callback`` in,
+waarbij je ``open-zaak.gemeente.nl`` vervangt door het relevante domein.
+
+Aan het eind van dit proces moet je de volgende gegevens hebben (on premise):
+
+* Server adres, bijvoorbeeld ``login.gemeente.nl``
+* Client ID, bijvoorbeeld ``a7d14516-8b20-418f-b34e-25f53c930948``
+* Client secret, bijvoorbeeld ``97d663a9-3624-4930-90c7-2b90635bd990``
+
+Configureren van OIDC in Open Zaak
+==================================
+
+Zorg dat je de volgende :ref:`gegevens <manual_oidc_appgroup>` hebt:
+
+* Server adres
+* Client ID
+* Client secret
+
+Navigeer vervolgens in de admin naar **Configuratie** > **OpenID Connect configuration**.
+
+1. Vink *Enable* aan om OIDC in te schakelen.
+2. Vul bij **Server (on premise)** het server adres in, bijvoorbeeld
+   ``login.gemeente.nl``.
+3. Vul bij **OpenID Connect client ID** het Client ID in, bijvoorbeeld
+   ``a7d14516-8b20-418f-b34e-25f53c930948``.
+4. Vul bij **OpenID Connect secret** het Client secret in, bijvoobeeld
+   ``97d663a9-3624-4930-90c7-2b90635bd990``.
+5. Vul bij **OpenID sign algorithm** ``RS256`` in.
+6. Laat bij **OpenID Connect scopes** de standaardwaarden staan.
+
+Vervolgens moeten er een aantal endpoints van de OIDC provider ingesteld worden,
+deze zijn af te leiden uit het OIDC Discovery Endpoint
+(``https://login.gemeente.nl/auth/realms/{realm}/.well-known/openid-configuration``)
+
+7. Vul bij **JSON Web Key Set endpoint** het JWKS endpoint van de OpenID Connect provider in,
+   meestal is dit ``https://login.gemeente.nl/auth/realms/{realm}/protocol/openid-connect/certs``.
+8. Vul bij **Authorization endpoint** het authorization endpoint van de OpenID Connect provider in,
+   meestal is dit ``https://login.gemeente.nl/auth/realms/{realm}/protocol/openid-connect/auth``.
+9. Vul bij **Token endpoint** het token endpoint van de OpenID Connect provider in,
+   meestal is dit ``https://login.gemeente.nl/auth/realms/{realm}/protocol/openid-connect/token``.
+10. Vul bij **User endpoint** het user endpoint van de OpenID Connect provider in,
+    meestal is dit ``https://login.gemeente.nl/auth/realms/{realm}/protocol/openid-connect/userinfo``.
+11. Laat **Sign key** leeg.
+
+Klik tot slot rechtsonder op **Opslaan**.
+
+Je kan vervolgens het makkelijkst testen of alles werkt door in een incognitoscherm
+naar https://open-zaak.gemeente.nl/admin/ te navigeren en op *Inloggen met OIDC* te
+klikken.

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -22,6 +22,7 @@ django-markup
 django-redis
 django-privates
 django-relativedelta
+mozilla-django-oidc-db
 
 # Admin and UI libraries
 django-admin-index

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,11 @@ coreschema==0.0.4
     #   coreapi
     #   drf-yasg
 cryptography==3.4.4
-    # via django-auth-adfs
+    # via
+    #   django-auth-adfs
+    #   josepy
+    #   mozilla-django-oidc
+    #   pyopenssl
 dictdiffer==0.8.0
     # via -r requirements/base.in
 django-admin-index==1.2.2
@@ -36,7 +40,9 @@ django-auth-adfs==1.6.1
 django-axes==4.4.0
     # via -r requirements/base.in
 django-better-admin-arrayfield==1.4.2
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   mozilla-django-oidc-db
 django-choices==1.7.0
     # via
     #   -r requirements/base.in
@@ -80,6 +86,7 @@ django-solo==1.1.3
     # via
     #   django-auth-adfs-db
     #   drc-cmis
+    #   mozilla-django-oidc-db
     #   vng-api-common
     #   zgw-consumers
 django==2.2.24
@@ -104,6 +111,8 @@ django==2.2.24
     #   drc-cmis
     #   drf-nested-routers
     #   drf-yasg
+    #   mozilla-django-oidc
+    #   mozilla-django-oidc-db
     #   vng-api-common
     #   zgw-consumers
 djangorestframework-camel-case==1.2.0
@@ -155,16 +164,24 @@ itypes==1.1.0
     # via coreapi
 jinja2==2.11.3
     # via coreschema
+josepy==1.8.0
+    # via mozilla-django-oidc
 markdown==3.0.1
     # via -r requirements/base.in
 markupsafe==1.1.1
     # via jinja2
+mozilla-django-oidc-db==0.2.1
+    # via -r requirements/base.in
+mozilla-django-oidc==1.2.4
+    # via mozilla-django-oidc-db
 oyaml==1.0
     # via vng-api-common
 packaging==20.9
     # via drf-yasg
 psycopg2==2.8.4
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   mozilla-django-oidc-db
 pycparser==2.19
     # via cffi
 pyjwt==1.6.4
@@ -172,6 +189,8 @@ pyjwt==1.6.4
     #   django-auth-adfs
     #   gemma-zds-client
     #   vng-api-common
+pyopenssl==20.0.1
+    # via josepy
 pyparsing==2.4.7
     # via
     #   httplib2
@@ -203,6 +222,7 @@ requests==2.25.1
     #   coreapi
     #   django-auth-adfs
     #   gemma-zds-client
+    #   mozilla-django-oidc
     #   vng-api-common
     #   zgw-consumers
 ruamel.yaml.clib==0.2.2
@@ -219,6 +239,8 @@ six==1.11.0
     #   django-extra-views
     #   django-markup
     #   isodate
+    #   mozilla-django-oidc
+    #   pyopenssl
     #   python-dateutil
 sqlparse==0.3.0
     # via django

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -49,6 +49,9 @@ cryptography==3.4.4
     # via
     #   -r requirements/base.txt
     #   django-auth-adfs
+    #   josepy
+    #   mozilla-django-oidc
+    #   pyopenssl
 dictdiffer==0.8.0
     # via -r requirements/base.txt
 django-admin-index==1.2.2
@@ -66,7 +69,9 @@ django-auth-adfs==1.6.1
 django-axes==4.4.0
     # via -r requirements/base.txt
 django-better-admin-arrayfield==1.4.2
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   mozilla-django-oidc-db
 django-capture-on-commit-callbacks==1.3.0
     # via -r requirements/test-tools.in
 django-choices==1.7.0
@@ -119,6 +124,7 @@ django-solo==1.1.3
     #   -r requirements/base.txt
     #   django-auth-adfs-db
     #   drc-cmis
+    #   mozilla-django-oidc-db
     #   vng-api-common
     #   zgw-consumers
 django-webtest==1.9.7
@@ -146,6 +152,8 @@ django==2.2.24
     #   drc-cmis
     #   drf-nested-routers
     #   drf-yasg
+    #   mozilla-django-oidc
+    #   mozilla-django-oidc-db
     #   vng-api-common
     #   zgw-consumers
 djangorestframework-camel-case==1.2.0
@@ -227,6 +235,10 @@ jinja2==2.11.3
     # via
     #   -r requirements/base.txt
     #   coreschema
+josepy==1.8.0
+    # via
+    #   -r requirements/base.txt
+    #   mozilla-django-oidc
 markdown==3.0.1
     # via -r requirements/base.txt
 markupsafe==1.1.1
@@ -235,6 +247,12 @@ markupsafe==1.1.1
     #   jinja2
 mccabe==0.6.1
     # via flake8
+mozilla-django-oidc-db==0.2.1
+    # via -r requirements/base.txt
+mozilla-django-oidc==1.2.4
+    # via
+    #   -r requirements/base.txt
+    #   mozilla-django-oidc-db
 oyaml==1.0
     # via
     #   -r requirements/base.txt
@@ -246,7 +264,9 @@ packaging==20.9
 pathspec==0.8.0
     # via black
 psycopg2==2.8.4
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   mozilla-django-oidc-db
 pycodestyle==2.6.0
     # via flake8
 pycparser==2.19
@@ -261,6 +281,10 @@ pyjwt==1.6.4
     #   django-auth-adfs
     #   gemma-zds-client
     #   vng-api-common
+pyopenssl==20.0.1
+    # via
+    #   -r requirements/base.txt
+    #   josepy
 pyparsing==2.4.7
     # via
     #   -r requirements/base.txt
@@ -303,6 +327,7 @@ requests==2.25.1
     #   coreapi
     #   django-auth-adfs
     #   gemma-zds-client
+    #   mozilla-django-oidc
     #   requests-mock
     #   vng-api-common
     #   zgw-consumers
@@ -327,6 +352,8 @@ six==1.11.0
     #   faker
     #   freezegun
     #   isodate
+    #   mozilla-django-oidc
+    #   pyopenssl
     #   python-dateutil
     #   requests-mock
     #   webtest

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -73,6 +73,9 @@ cryptography==3.4.4
     #   -r requirements/ci.txt
     #   ansible
     #   django-auth-adfs
+    #   josepy
+    #   mozilla-django-oidc
+    #   pyopenssl
 dictdiffer==0.8.0
     # via -r requirements/ci.txt
 django-admin-index==1.2.2
@@ -90,7 +93,9 @@ django-auth-adfs==1.6.1
 django-axes==4.4.0
     # via -r requirements/ci.txt
 django-better-admin-arrayfield==1.4.2
-    # via -r requirements/ci.txt
+    # via
+    #   -r requirements/ci.txt
+    #   mozilla-django-oidc-db
 django-capture-on-commit-callbacks==1.3.0
     # via -r requirements/ci.txt
 django-choices==1.7.0
@@ -149,6 +154,7 @@ django-solo==1.1.3
     #   -r requirements/ci.txt
     #   django-auth-adfs-db
     #   drc-cmis
+    #   mozilla-django-oidc-db
     #   vng-api-common
     #   zgw-consumers
 django-webtest==1.9.7
@@ -178,6 +184,8 @@ django==2.2.24
     #   drc-cmis
     #   drf-nested-routers
     #   drf-yasg
+    #   mozilla-django-oidc
+    #   mozilla-django-oidc-db
     #   vng-api-common
     #   zgw-consumers
 djangorestframework-camel-case==1.2.0
@@ -283,6 +291,10 @@ jinja2==2.11.3
     #   django-silk
     #   openshift
     #   sphinx
+josepy==1.8.0
+    # via
+    #   -r requirements/ci.txt
+    #   mozilla-django-oidc
 jsonschema==3.2.0
     # via kubernetes-validate
 kubernetes-validate==1.18.0
@@ -301,6 +313,12 @@ mccabe==0.6.1
     # via
     #   -r requirements/ci.txt
     #   flake8
+mozilla-django-oidc-db==0.2.1
+    # via -r requirements/ci.txt
+mozilla-django-oidc==1.2.4
+    # via
+    #   -r requirements/ci.txt
+    #   mozilla-django-oidc-db
 oauthlib==3.1.0
     # via requests-oauthlib
 openshift==0.11.2
@@ -325,7 +343,9 @@ pep517==0.10.0
 pip-tools==6.0.1
     # via -r requirements/dev.in
 psycopg2==2.8.4
-    # via -r requirements/ci.txt
+    # via
+    #   -r requirements/ci.txt
+    #   mozilla-django-oidc-db
 pyasn1-modules==0.2.8
     # via google-auth
 pyasn1==0.4.8
@@ -356,6 +376,10 @@ pyjwt==1.6.4
     #   django-auth-adfs
     #   gemma-zds-client
     #   vng-api-common
+pyopenssl==20.0.1
+    # via
+    #   -r requirements/ci.txt
+    #   josepy
 pyparsing==2.4.7
     # via
     #   -r requirements/ci.txt
@@ -418,6 +442,7 @@ requests==2.25.1
     #   django-silk
     #   gemma-zds-client
     #   kubernetes
+    #   mozilla-django-oidc
     #   requests-mock
     #   requests-oauthlib
     #   sphinx
@@ -451,7 +476,9 @@ six==1.11.0
     #   isodate
     #   jsonschema
     #   kubernetes
+    #   mozilla-django-oidc
     #   openshift
+    #   pyopenssl
     #   python-dateutil
     #   requests-mock
     #   websocket-client

--- a/src/openzaak/accounts/tests/test_oidc.py
+++ b/src/openzaak/accounts/tests/test_oidc.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2021 Dimpact
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from django_webtest import WebTest
+from mozilla_django_oidc_db.models import OpenIDConnectConfig
+
+
+class OIDCLoginButtonTestCase(WebTest):
+    def test_oidc_button_disabled(self):
+        config = OpenIDConnectConfig.get_solo()
+        config.enabled = False
+        config.save()
+
+        response = self.app.get(reverse("admin:login"))
+
+        oidc_login_link = response.html.find("a", string=_("Login with OIDC"))
+
+        # Verify that the login button is not visible
+        self.assertIsNone(oidc_login_link)
+
+    def test_oidc_button_enabled(self):
+        config = OpenIDConnectConfig.get_solo()
+        config.enabled = True
+        config.oidc_op_token_endpoint = "https://some.endpoint.nl/"
+        config.oidc_op_user_endpoint = "https://some.endpoint.nl/"
+        config.oidc_rp_client_id = "id"
+        config.oidc_rp_client_secret = "secret"
+        config.save()
+
+        response = self.app.get(reverse("admin:login"))
+
+        oidc_login_link = response.html.find("a", string=_("Login with OIDC"))
+
+        # Verify that the login button is visible
+        self.assertIsNotNone(oidc_login_link)
+        self.assertEqual(
+            oidc_login_link.attrs["href"], reverse("oidc_authentication_init")
+        )

--- a/src/openzaak/accounts/tests/test_oidc.py
+++ b/src/openzaak/accounts/tests/test_oidc.py
@@ -15,7 +15,9 @@ class OIDCLoginButtonTestCase(WebTest):
 
         response = self.app.get(reverse("admin:login"))
 
-        oidc_login_link = response.html.find("a", string=_("Login with OIDC"))
+        oidc_login_link = response.html.find(
+            "a", string=_("Login with organization account")
+        )
 
         # Verify that the login button is not visible
         self.assertIsNone(oidc_login_link)
@@ -31,7 +33,9 @@ class OIDCLoginButtonTestCase(WebTest):
 
         response = self.app.get(reverse("admin:login"))
 
-        oidc_login_link = response.html.find("a", string=_("Login with OIDC"))
+        oidc_login_link = response.html.find(
+            "a", string=_("Login with organization account")
+        )
 
         # Verify that the login button is visible
         self.assertIsNotNone(oidc_login_link)

--- a/src/openzaak/conf/ci.py
+++ b/src/openzaak/conf/ci.py
@@ -16,6 +16,7 @@ CACHES = {
     "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
     # See: https://github.com/jazzband/django-axes/blob/master/docs/configuration.rst#cache-problems
     "axes": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
+    "oidc": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
 }
 
 LOGGING = LOGGING_SETTINGS  # Minimally required logging is nice

--- a/src/openzaak/conf/dev.py
+++ b/src/openzaak/conf/dev.py
@@ -69,6 +69,7 @@ DEBUG_TOOLBAR_CONFIG = {"INTERCEPT_REDIRECTS": False}
 CACHES = {
     "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
     "axes": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
+    "oidc": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
 }
 
 REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] += (

--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -89,6 +89,14 @@ CACHES = {
             "IGNORE_EXCEPTIONS": True,
         },
     },
+    "oidc": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": f"redis://{config('CACHE_DEFAULT', 'localhost:6379/0')}",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "IGNORE_EXCEPTIONS": True,
+        },
+    },
 }
 
 #
@@ -133,6 +141,8 @@ INSTALLED_APPS = [
     "django_loose_fk",
     "zgw_consumers",
     "drc_cmis",
+    "mozilla_django_oidc",
+    "mozilla_django_oidc_db",
     # Project applications.
     "openzaak",
     "openzaak.accounts",
@@ -157,6 +167,7 @@ MIDDLEWARE = [
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "openzaak.components.autorisaties.middleware.AuthMiddleware",
+    "mozilla_django_oidc_db.middleware.SessionRefresh",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "openzaak.utils.middleware.APIVersionHeaderMiddleware",
@@ -311,6 +322,10 @@ LOGGING = {
             "level": "INFO",
             "propagate": True,
         },
+        "mozilla_django_oidc": {
+            "handlers": ["project"] if not LOG_STDOUT else ["console"],
+            "level": "DEBUG",
+        },
         "openzaak.utils.middleware": {
             "handlers": ["requests"] if not LOG_STDOUT else ["console"],
             "level": "DEBUG",
@@ -357,6 +372,7 @@ AUTHENTICATION_BACKENDS = [
     "openzaak.accounts.backends.UserModelEmailBackend",
     "django.contrib.auth.backends.ModelBackend",
     "django_auth_adfs_db.backends.AdfsAuthCodeBackend",
+    "mozilla_django_oidc_db.backends.OIDCAuthenticationBackend",
 ]
 
 SESSION_COOKIE_NAME = "openzaak_sessionid"
@@ -364,6 +380,7 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 
 LOGIN_URL = reverse_lazy("admin:login")
 LOGIN_REDIRECT_URL = reverse_lazy("admin:index")
+LOGOUT_REDIRECT_URL = reverse_lazy("admin:index")
 
 #
 # SECURITY settings
@@ -541,6 +558,14 @@ if SENTRY_DSN:
 #
 ADMIN_INDEX_SHOW_REMAINING_APPS_TO_SUPERUSERS = False
 ADMIN_INDEX_AUTO_CREATE_APP_GROUP = False
+
+#
+# Mozilla Django OIDC DB settings
+#
+OIDC_AUTHENTICATE_CLASS = "mozilla_django_oidc_db.views.OIDCAuthenticationRequestView"
+MOZILLA_DJANGO_OIDC_DB_CACHE = "oidc"
+MOZILLA_DJANGO_OIDC_DB_CACHE_TIMEOUT = 1
+
 
 #
 # OpenZaak configuration

--- a/src/openzaak/fixtures/default_admin_index.json
+++ b/src/openzaak/fixtures/default_admin_index.json
@@ -63,6 +63,10 @@
                 "adfsconfig"
             ],
             [
+                "mozilla_django_oidc_db",
+                "openidconnectconfig"
+            ],
+            [
                 "notifications",
                 "notificationsconfig"
             ],

--- a/src/openzaak/templates/admin/login.html
+++ b/src/openzaak/templates/admin/login.html
@@ -17,7 +17,7 @@
 {% get_solo 'mozilla_django_oidc_db.OpenIDConnectConfig' as oidc_config %}
 {% if oidc_config.enabled %}
 <div class="submit-row">
-    <a href="{% url 'oidc_authentication_init' %}">{% trans "Login with OIDC" %}</a>
+    <a href="{% url 'oidc_authentication_init' %}">{% trans "Login with organization account" %}</a>
 </div>
 {% endif %}
 

--- a/src/openzaak/templates/admin/login.html
+++ b/src/openzaak/templates/admin/login.html
@@ -13,4 +13,12 @@
     <a href="{% url 'django_auth_adfs:login' %}">{% trans "Login with ADFS" %}</a>
 </div>
 {% endif %}
+
+{% get_solo 'mozilla_django_oidc_db.OpenIDConnectConfig' as oidc_config %}
+{% if oidc_config.enabled %}
+<div class="submit-row">
+    <a href="{% url 'oidc_authentication_init' %}">{% trans "Login with OIDC" %}</a>
+</div>
+{% endif %}
+
 {% endblock %}

--- a/src/openzaak/urls.py
+++ b/src/openzaak/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     path("ref/", include("vng_api_common.notifications.urls")),
     # auth backends
     path("adfs/", include("django_auth_adfs.urls")),
+    path("oidc/", include("mozilla_django_oidc.urls")),
 ]
 
 # NOTE: The staticfiles_urlpatterns also discovers static files (ie. no need to run collectstatic). Both the static


### PR DESCRIPTION
fixes: https://github.com/open-zaak/open-zaak/issues/1002

For Den Haag, to see if we can use Keycloak (or other OpenID connect providers for that matter) for authentication

Uses a package I built on top of https://github.com/mozilla/mozilla-django-oidc (basically the same idea as https://github.com/isprojects/django-auth-adfs-db, though it also changes the default behaviour of the backend)

See https://github.com/maykinmedia/mozilla-django-oidc-db for the changes I made to ``mozilla-django-oidc``

TODO:
- [x] Change user creation (use info from identity provider to fill `first_name`, etc.)
- [x] It appears that users are identified by email (which is against the OIDC spec https://openid.net/specs/openid-connect-core-1_0.html#ClaimStability), so maybe the user creation/filtering should be changed -> changed to use `sub` (subject) as unique ID
- [x] Use django-solo for configuration
- [x] Add solo model to admin index fixture
- [x] Add documentation on configuration
- [x] Add tests