### PR TITLE
Tests: running offline, first pass

### DIFF
--- a/src/openzaak/components/besluiten/tests/test_besluitinformatieobjecten.py
+++ b/src/openzaak/components/besluiten/tests/test_besluitinformatieobjecten.py
@@ -296,10 +296,12 @@ class ExternalDocumentsAPITests(JWTAuthMixin, APITestCase):
         error = get_validation_errors(response, "informatieobject")
         self.assertEqual(error["code"], "bad-url")
 
-    def test_create_bio_fail_not_json(self):
+    @requests_mock.Mocker()
+    def test_create_bio_fail_not_json(self, m):
         besluit = BesluitFactory.create(besluittype__concept=False)
         besluit_url = f"http://openzaak.nl{reverse(besluit)}"
         data = {"besluit": besluit_url, "informatieobject": "http://example.com"}
+        m.get("http://example.com", status_code=200, text="<html></html>")
 
         response = self.client.post(self.list_url, data, HTTP_HOST="openzaak.nl")
 

--- a/src/openzaak/components/catalogi/tests/test_notifications_send.py
+++ b/src/openzaak/components/catalogi/tests/test_notifications_send.py
@@ -2,14 +2,17 @@
 # Copyright (C) 2020 Dimpact
 from django.test import override_settings
 
+import requests_mock
 from django_capture_on_commit_callbacks import capture_on_commit_callbacks
 from django_db_logger.models import StatusLog
 from freezegun import freeze_time
 from rest_framework import status
 from vng_api_common.constants import VertrouwelijkheidsAanduiding
+from vng_api_common.notifications.models import NotificationsConfig
 from vng_api_common.tests import reverse
 
 from openzaak.notifications.models import FailedNotification
+from openzaak.notifications.tests import mock_oas_get
 from openzaak.notifications.tests.mixins import NotificationServiceMixin
 from openzaak.notifications.tests.utils import LOGGING_SETTINGS
 
@@ -19,13 +22,18 @@ from .factories import BesluitTypeFactory, InformatieObjectTypeFactory, ZaakType
 from .utils import get_operation_url
 
 
+@requests_mock.Mocker()
 @override_settings(NOTIFICATIONS_DISABLED=False, LOGGING=LOGGING_SETTINGS)
 @freeze_time("2019-01-01T12:00:00Z")
 class FailedNotificationTests(NotificationServiceMixin, APITestCase):
     heeft_alle_autorisaties = True
     maxDiff = None
 
-    def test_besluittype_create_fail_send_notification_create_db_entry(self):
+    def test_besluittype_create_fail_send_notification_create_db_entry(self, m):
+        mock_oas_get(m)
+        m.post(
+            f"{NotificationsConfig.get_solo().api_root}notificaties", status_code=403
+        )
         url = get_operation_url("besluittype_create")
 
         data = {
@@ -69,7 +77,11 @@ class FailedNotificationTests(NotificationServiceMixin, APITestCase):
         self.assertEqual(failed.statuslog_ptr, logged_warning)
         self.assertEqual(failed.message, message)
 
-    def test_besluittype_delete_fail_send_notification_create_db_entry(self):
+    def test_besluittype_delete_fail_send_notification_create_db_entry(self, m):
+        mock_oas_get(m)
+        m.post(
+            f"{NotificationsConfig.get_solo().api_root}notificaties", status_code=403
+        )
         besluittype = BesluitTypeFactory.create()
         url = reverse(besluittype)
 
@@ -97,7 +109,13 @@ class FailedNotificationTests(NotificationServiceMixin, APITestCase):
         self.assertEqual(failed.statuslog_ptr, logged_warning)
         self.assertEqual(failed.message, message)
 
-    def test_informatieobjecttype_create_fail_send_notification_create_db_entry(self):
+    def test_informatieobjecttype_create_fail_send_notification_create_db_entry(
+        self, m
+    ):
+        mock_oas_get(m)
+        m.post(
+            f"{NotificationsConfig.get_solo().api_root}notificaties", status_code=403
+        )
         url = get_operation_url("informatieobjecttype_create")
 
         data = {
@@ -133,7 +151,13 @@ class FailedNotificationTests(NotificationServiceMixin, APITestCase):
         self.assertEqual(failed.statuslog_ptr, logged_warning)
         self.assertEqual(failed.message, message)
 
-    def test_informatieobjecttype_delete_fail_send_notification_create_db_entry(self):
+    def test_informatieobjecttype_delete_fail_send_notification_create_db_entry(
+        self, m
+    ):
+        mock_oas_get(m)
+        m.post(
+            f"{NotificationsConfig.get_solo().api_root}notificaties", status_code=403
+        )
         iotype = InformatieObjectTypeFactory.create()
         url = reverse(iotype)
 
@@ -161,7 +185,11 @@ class FailedNotificationTests(NotificationServiceMixin, APITestCase):
         self.assertEqual(failed.statuslog_ptr, logged_warning)
         self.assertEqual(failed.message, message)
 
-    def test_zaaktype_create_fail_send_notification_create_db_entry(self):
+    def test_zaaktype_create_fail_send_notification_create_db_entry(self, m):
+        mock_oas_get(m)
+        m.post(
+            f"{NotificationsConfig.get_solo().api_root}notificaties", status_code=403
+        )
         url = get_operation_url("zaaktype_create")
 
         data = {
@@ -221,7 +249,11 @@ class FailedNotificationTests(NotificationServiceMixin, APITestCase):
         self.assertEqual(failed.statuslog_ptr, logged_warning)
         self.assertEqual(failed.message, message)
 
-    def test_zaaktype_delete_fail_send_notification_create_db_entry(self):
+    def test_zaaktype_delete_fail_send_notification_create_db_entry(self, m):
+        mock_oas_get(m)
+        m.post(
+            f"{NotificationsConfig.get_solo().api_root}notificaties", status_code=403
+        )
         zaaktype = ZaakTypeFactory.create()
         url = reverse(zaaktype)
 

--- a/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject.py
+++ b/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject.py
@@ -842,24 +842,27 @@ class InformatieobjectCreateExternalURLsTests(JWTAuthMixin, APITestCase):
 
     @override_settings(ALLOWED_HOSTS=["testserver"])
     def test_create_external_informatieobjecttype_fail_not_json_url(self):
-        response = self.client.post(
-            self.list_url,
-            {
-                "identificatie": "12345",
-                "bronorganisatie": "159351741",
-                "creatiedatum": "2018-06-27",
-                "titel": "detailed summary",
-                "auteur": "test_auteur",
-                "formaat": "txt",
-                "taal": "eng",
-                "bestandsnaam": "dummy.txt",
-                "inhoud": b64encode(b"some file content").decode("utf-8"),
-                "link": "http://een.link",
-                "beschrijving": "test_beschrijving",
-                "informatieobjecttype": "http://example.com",
-                "vertrouwelijkheidaanduiding": "openbaar",
-            },
-        )
+        with requests_mock.Mocker() as m:
+            m.get("http://example.com", status_code=200, text="<html></html>")
+
+            response = self.client.post(
+                self.list_url,
+                {
+                    "identificatie": "12345",
+                    "bronorganisatie": "159351741",
+                    "creatiedatum": "2018-06-27",
+                    "titel": "detailed summary",
+                    "auteur": "test_auteur",
+                    "formaat": "txt",
+                    "taal": "eng",
+                    "bestandsnaam": "dummy.txt",
+                    "inhoud": b64encode(b"some file content").decode("utf-8"),
+                    "link": "http://een.link",
+                    "beschrijving": "test_beschrijving",
+                    "informatieobjecttype": "http://example.com",
+                    "vertrouwelijkheidaanduiding": "openbaar",
+                },
+            )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 

--- a/src/openzaak/components/documenten/tests/test_validation.py
+++ b/src/openzaak/components/documenten/tests/test_validation.py
@@ -65,9 +65,12 @@ class EnkelvoudigInformatieObjectTests(JWTAuthMixin, APITestCase):
         m.get("https://example.com", text="<html><head></head><body></body></html>")
         url = reverse("enkelvoudiginformatieobject-list")
 
-        response = self.client.post(
-            url, {"informatieobjecttype": "https://example.com"}
-        )
+        with requests_mock.Mocker() as m:
+            m.get("https://example.com", status_code=200, text="<html></html>")
+
+            response = self.client.post(
+                url, {"informatieobjecttype": "https://example.com"}
+            )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         error = get_validation_errors(response, "informatieobjecttype")

--- a/src/openzaak/components/zaken/tests/test_relevantezaakrelatie.py
+++ b/src/openzaak/components/zaken/tests/test_relevantezaakrelatie.py
@@ -89,25 +89,28 @@ class ExternalRelevanteZakenTestsTestCase(JWTAuthMixin, APITestCase):
         zaaktype = ZaakTypeFactory.create(concept=False)
         zaaktype_url = f"http://testserver.com{reverse(zaaktype)}"
 
-        response = self.client.post(
-            self.list_url,
-            {
-                "zaaktype": zaaktype_url,
-                "bronorganisatie": "517439943",
-                "verantwoordelijkeOrganisatie": "517439943",
-                "registratiedatum": "2018-12-24",
-                "startdatum": "2018-12-24",
-                "vertrouwelijkheidaanduiding": VertrouwelijkheidsAanduiding.openbaar,
-                "relevanteAndereZaken": [
-                    {
-                        "url": " http://example.com",
-                        "aardRelatie": AardZaakRelatie.vervolg,
-                    }
-                ],
-            },
-            **ZAAK_WRITE_KWARGS,
-            HTTP_HOST="testserver.com",
-        )
+        with requests_mock.Mocker() as m:
+            m.get("http://example.com", status_code=200, text="<html></html>")
+
+            response = self.client.post(
+                self.list_url,
+                {
+                    "zaaktype": zaaktype_url,
+                    "bronorganisatie": "517439943",
+                    "verantwoordelijkeOrganisatie": "517439943",
+                    "registratiedatum": "2018-12-24",
+                    "startdatum": "2018-12-24",
+                    "vertrouwelijkheidaanduiding": VertrouwelijkheidsAanduiding.openbaar,
+                    "relevanteAndereZaken": [
+                        {
+                            "url": " http://example.com",
+                            "aardRelatie": AardZaakRelatie.vervolg,
+                        }
+                    ],
+                },
+                **ZAAK_WRITE_KWARGS,
+                HTTP_HOST="testserver.com",
+            )
 
         self.assertEqual(
             response.status_code, status.HTTP_400_BAD_REQUEST, response.data

--- a/src/openzaak/components/zaken/tests/test_resultaten.py
+++ b/src/openzaak/components/zaken/tests/test_resultaten.py
@@ -68,14 +68,17 @@ class ResultaatCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         zaak = ZaakFactory()
         zaak_url = reverse(zaak)
 
-        response = self.client.post(
-            self.list_url,
-            {
-                "zaak": f"http://testserver{zaak_url}",
-                "resultaattype": "http://example.com",
-                "toelichting": "some desc",
-            },
-        )
+        with requests_mock.Mocker() as m:
+            m.get("http://example.com", status_code=200, text="<html></html>")
+
+            response = self.client.post(
+                self.list_url,
+                {
+                    "zaak": f"http://testserver{zaak_url}",
+                    "resultaattype": "http://example.com",
+                    "toelichting": "some desc",
+                },
+            )
 
         error = get_validation_errors(response, "resultaattype")
         self.assertEqual(error["code"], "invalid-resource")

--- a/src/openzaak/components/zaken/tests/test_rol.py
+++ b/src/openzaak/components/zaken/tests/test_rol.py
@@ -533,16 +533,19 @@ class RolCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         zaak = ZaakFactory.create()
         zaak_url = reverse(zaak)
 
-        response = self.client.post(
-            self.list_url,
-            {
-                "zaak": f"http://testserver{zaak_url}",
-                "betrokkene": BETROKKENE,
-                "betrokkene_type": RolTypes.natuurlijk_persoon,
-                "roltype": "http://example.com",
-                "roltoelichting": "awerw",
-            },
-        )
+        with requests_mock.Mocker() as m:
+            m.get("http://example.com", status_code=200, text="<html></html>")
+
+            response = self.client.post(
+                self.list_url,
+                {
+                    "zaak": f"http://testserver{zaak_url}",
+                    "betrokkene": BETROKKENE,
+                    "betrokkene_type": RolTypes.natuurlijk_persoon,
+                    "roltype": "http://example.com",
+                    "roltoelichting": "awerw",
+                },
+            )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 

--- a/src/openzaak/components/zaken/tests/test_statussen.py
+++ b/src/openzaak/components/zaken/tests/test_statussen.py
@@ -155,14 +155,17 @@ class StatusCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         zaak = ZaakFactory.create()
         zaak_url = f"http://testserver{reverse(zaak)}"
 
-        response = self.client.post(
-            self.list_url,
-            {
-                "zaak": zaak_url,
-                "statustype": "http://example.com",
-                "datumStatusGezet": "2018-10-18T20:00:00Z",
-            },
-        )
+        with requests_mock.Mocker() as m:
+            m.get("http://example.com", status_code=200, text="<html></html>")
+
+            response = self.client.post(
+                self.list_url,
+                {
+                    "zaak": zaak_url,
+                    "statustype": "http://example.com",
+                    "datumStatusGezet": "2018-10-18T20:00:00Z",
+                },
+            )
 
         self.assertEqual(
             response.status_code, status.HTTP_400_BAD_REQUEST, response.data

--- a/src/openzaak/components/zaken/tests/test_validation.py
+++ b/src/openzaak/components/zaken/tests/test_validation.py
@@ -93,17 +93,20 @@ class ZaakValidationTests(JWTAuthMixin, APITestCase):
     def test_validate_zaaktype_invalid_resource(self):
         url = reverse("zaak-list")
 
-        response = self.client.post(
-            url,
-            {
-                "zaaktype": "https://example.com",
-                "bronorganisatie": "517439943",
-                "verantwoordelijkeOrganisatie": "517439943",
-                "registratiedatum": "2018-06-11",
-                "startdatum": "2018-06-11",
-            },
-            **ZAAK_WRITE_KWARGS,
-        )
+        with requests_mock.Mocker() as m:
+            m.get("https://example.com", status_code=200, text="<html></html>")
+
+            response = self.client.post(
+                url,
+                {
+                    "zaaktype": "https://example.com",
+                    "bronorganisatie": "517439943",
+                    "verantwoordelijkeOrganisatie": "517439943",
+                    "registratiedatum": "2018-06-11",
+                    "startdatum": "2018-06-11",
+                },
+                **ZAAK_WRITE_KWARGS,
+            )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -753,14 +756,17 @@ class StatusValidationTests(JWTAuthMixin, APITestCase):
         zaak_url = reverse(zaak)
         list_url = reverse("status-list")
 
-        response = self.client.post(
-            list_url,
-            {
-                "zaak": zaak_url,
-                "statustype": "https://example.com",
-                "datumStatusGezet": isodatetime(2018, 10, 1, 10, 00, 00),
-            },
-        )
+        with requests_mock.Mocker() as m:
+            m.get("https://example.com", status_code=200, text="<html></html>")
+
+            response = self.client.post(
+                list_url,
+                {
+                    "zaak": zaak_url,
+                    "statustype": "https://example.com",
+                    "datumStatusGezet": isodatetime(2018, 10, 1, 10, 00, 00),
+                },
+            )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -920,9 +926,12 @@ class ResultaatValidationTests(JWTAuthMixin, APITestCase):
         zaak_url = reverse("zaak-detail", kwargs={"uuid": zaak.uuid})
         list_url = reverse("resultaat-list")
 
-        response = self.client.post(
-            list_url, {"zaak": zaak_url, "resultaattype": "https://example.com"}
-        )
+        with requests_mock.Mocker() as m:
+            m.get("https://example.com", status_code=200, text="<html></html>")
+
+            response = self.client.post(
+                list_url, {"zaak": zaak_url, "resultaattype": "https://example.com"}
+            )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -1033,10 +1042,17 @@ class ZaakEigenschapValidationTests(JWTAuthMixin, APITestCase):
 
         list_url = reverse("zaakeigenschap-list", kwargs={"zaak_uuid": zaak.uuid})
 
-        response = self.client.post(
-            list_url,
-            {"zaak": zaak_url, "eigenschap": "http://example.com", "waarde": "test"},
-        )
+        with requests_mock.Mocker() as m:
+            m.get("http://example.com", status_code=200, text="<html></html>")
+
+            response = self.client.post(
+                list_url,
+                {
+                    "zaak": zaak_url,
+                    "eigenschap": "http://example.com",
+                    "waarde": "test",
+                },
+            )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 

--- a/src/openzaak/components/zaken/tests/test_zaakeigenschap.py
+++ b/src/openzaak/components/zaken/tests/test_zaakeigenschap.py
@@ -151,24 +151,27 @@ class ZaakEigenschapCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         error = get_validation_errors(response, "eigenschap")
         self.assertEqual(error["code"], "bad-url")
 
-    def test_create_external_resultaattype_fail_not_json_url(self):
+    def test_create_external_eigenschap_fail_not_json_url(self):
         zaak = ZaakFactory()
         zaak_url = reverse(zaak)
         url = get_operation_url("zaakeigenschap_list", zaak_uuid=zaak.uuid)
 
-        response = self.client.post(
-            url,
-            {
-                "zaak": zaak_url,
-                "eigenschap": "http://example.com",
-                "waarde": "overlast_water",
-            },
-        )
+        with requests_mock.Mocker() as m:
+            m.get("http://example.com", status_code=200, text="<html></html>")
+
+            response = self.client.post(
+                url,
+                {
+                    "zaak": zaak_url,
+                    "eigenschap": "http://example.com",
+                    "waarde": "overlast_water",
+                },
+            )
 
         error = get_validation_errors(response, "eigenschap")
         self.assertEqual(error["code"], "invalid-resource")
 
-    def test_create_external_resultaattype_fail_invalid_schema(self):
+    def test_create_external_eigenschap_fail_invalid_schema(self):
         catalogus = "https://externe.catalogus.nl/api/v1/catalogussen/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
         zaaktype = "https://externe.catalogus.nl/api/v1/zaaktypen/b71f72ef-198d-44d8-af64-ae1932df830a"
         eigenschap = "https://externe.catalogus.nl/api/v1/eigenschappen/7a3e4a22-d789-4381-939b-401dbce29426"
@@ -195,7 +198,7 @@ class ZaakEigenschapCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         error = get_validation_errors(response, "eigenschap")
         self.assertEqual(error["code"], "invalid-resource")
 
-    def test_create_external_resultaattype_fail_zaaktype_mismatch(self):
+    def test_create_external_eigenschap_fail_zaaktype_mismatch(self):
         catalogus = "https://externe.catalogus.nl/api/v1/catalogussen/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
         zaaktype1 = "https://externe.catalogus.nl/api/v1/zaaktypen/b71f72ef-198d-44d8-af64-ae1932df830a"
         zaaktype2 = "https://externe.catalogus.nl/api/v1/zaaktypen/b923543f-97aa-4a55-8c20-889b5906cf75"

--- a/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten.py
+++ b/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten.py
@@ -518,6 +518,7 @@ class ExternalDocumentsAPITests(JWTAuthMixin, APITestCase):
         error = get_validation_errors(response, "informatieobject")
         self.assertEqual(error["code"], "bad-url")
 
+    @override_settings(ALLOWED_HOSTS=["testserver", "openzaak.nl"])
     def test_create_zio_fail_not_json(self):
         zaak = ZaakFactory.create(zaaktype__concept=False)
         zaak_url = f"http://openzaak.nl{reverse(zaak)}"

--- a/src/openzaak/components/zaken/tests/test_zaken.py
+++ b/src/openzaak/components/zaken/tests/test_zaken.py
@@ -666,17 +666,19 @@ class ZaakCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         self.assertEqual(error["code"], "bad-url")
 
     def test_create_external_zaaktype_fail_not_json_url(self):
-        response = self.client.post(
-            self.list_url,
-            {
-                "zaaktype": "http://example.com",
-                "bronorganisatie": "517439943",
-                "verantwoordelijkeOrganisatie": "517439943",
-                "registratiedatum": "2018-12-24",
-                "startdatum": "2018-12-24",
-            },
-            **ZAAK_WRITE_KWARGS,
-        )
+        with requests_mock.Mocker() as m:
+            m.get("http://example.com", status_code=200, text="<html></html>")
+            response = self.client.post(
+                self.list_url,
+                {
+                    "zaaktype": "http://example.com",
+                    "bronorganisatie": "517439943",
+                    "verantwoordelijkeOrganisatie": "517439943",
+                    "registratiedatum": "2018-12-24",
+                    "startdatum": "2018-12-24",
+                },
+                **ZAAK_WRITE_KWARGS,
+            )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
This should remove real HTTP calls from the test suite and eventually make
it possible to run the tests offline.

* removes real calls to example.com
* remove real calls to notifications API