### PR TITLE
Improving test isolation

### DIFF
--- a/src/openzaak/components/besluiten/tests/test_besluit_create.py
+++ b/src/openzaak/components/besluiten/tests/test_besluit_create.py
@@ -23,6 +23,7 @@ from .factories import BesluitFactory, BesluitInformatieObjectFactory
 from .utils import get_besluittype_response, get_operation_url
 
 
+@override_settings(ALLOWED_HOSTS=["testserver", "openzaak.nl"])
 class BesluitCreateTests(TypeCheckMixin, JWTAuthMixin, APITestCase):
 
     heeft_alle_autorisaties = True

--- a/src/openzaak/components/besluiten/tests/test_besluitinformatieobjecten.py
+++ b/src/openzaak/components/besluiten/tests/test_besluitinformatieobjecten.py
@@ -33,6 +33,7 @@ from .factories import BesluitFactory, BesluitInformatieObjectFactory
 from .utils import get_besluittype_response
 
 
+@override_settings(ALLOWED_HOSTS=["testserver", "openzaak.nl"])
 class BesluitInformatieObjectAPITests(JWTAuthMixin, APITestCase):
 
     list_url = reverse_lazy("besluitinformatieobject-list", kwargs={"version": "1"})
@@ -585,7 +586,7 @@ class ExternalInformatieObjectAPITests(JWTAuthMixin, APITestCase):
 
 
 @tag("external-urls")
-@override_settings(ALLOWED_HOSTS=["openzaak.nl"])
+@override_settings(ALLOWED_HOSTS=["testserver", "openzaak.nl"])
 class ExternalDocumentDestroyTests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
 

--- a/src/openzaak/components/besluiten/tests/test_filters.py
+++ b/src/openzaak/components/besluiten/tests/test_filters.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
-from django.test import tag
+from django.test import override_settings, tag
 
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -18,6 +18,7 @@ from .utils import get_operation_url
 
 
 @tag("external-urls")
+@override_settings(ALLOWED_HOSTS=["testserver", "openzaak.nl"])
 class ListFilterLocalFKTests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
 

--- a/src/openzaak/components/documenten/tests/test_objectinformatieobject.py
+++ b/src/openzaak/components/documenten/tests/test_objectinformatieobject.py
@@ -34,6 +34,7 @@ from .factories import EnkelvoudigInformatieObjectFactory
 
 
 @tag("oio")
+@override_settings(ALLOWED_HOSTS=["testserver", "openzaak.nl"])
 class ObjectInformatieObjectTests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
     list_url = reverse_lazy("objectinformatieobject-list")
@@ -313,7 +314,7 @@ class ObjectInformatieObjectDestroyTests(JWTAuthMixin, APITestCase):
 
 
 @tag("external-urls")
-@override_settings(ALLOWED_HOSTS=["testserver"])
+@override_settings(ALLOWED_HOSTS=["testserver", "openzaak.nl"])
 class OIOCreateExternalURLsTests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
     list_url = reverse_lazy(ObjectInformatieObject)

--- a/src/openzaak/components/zaken/tests/test_create_melding_rol.py
+++ b/src/openzaak/components/zaken/tests/test_create_melding_rol.py
@@ -36,7 +36,10 @@ BEHANDELAAR = "https://example.com/orc/api/v1/brp/organisatorische-eenheden/d6cb
 VERANTWOORDELIJKE_ORGANISATIE = "517439943"
 
 
-@override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
+@override_settings(
+    LINK_FETCHER="vng_api_common.mocks.link_fetcher_200",
+    ALLOWED_HOSTS=["testserver", "openzaak.nl"],
+)
 class US169TestCase(JWTAuthMixin, APITestCase):
 
     heeft_alle_autorisaties = True

--- a/src/openzaak/components/zaken/tests/test_statussen.py
+++ b/src/openzaak/components/zaken/tests/test_statussen.py
@@ -19,6 +19,7 @@ from .utils import (
 )
 
 
+@override_settings(ALLOWED_HOSTS=["testserver", "openzaak.nl"])
 class StatusTests(JWTAuthMixin, APITestCase):
 
     heeft_alle_autorisaties = True

--- a/src/openzaak/components/zaken/tests/test_zaak_zoek.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_zoek.py
@@ -7,6 +7,7 @@ gemeente zodat ik weet wat er speelt of dat een melding al gedaan is.
 ref: https://github.com/VNG-Realisatie/gemma-zaken/issues/42
 """
 from django.contrib.gis.geos import Point
+from django.test import override_settings
 
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -20,6 +21,7 @@ from .factories import ZaakFactory
 from .utils import ZAAK_WRITE_KWARGS, get_operation_url
 
 
+@override_settings(ALLOWED_HOSTS=["testserver", "openzaak.nl"])
 class US42TestCase(JWTAuthMixin, TypeCheckMixin, APITestCase):
 
     heeft_alle_autorisaties = True

--- a/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten.py
+++ b/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten.py
@@ -41,6 +41,7 @@ from .factories import ZaakFactory, ZaakInformatieObjectFactory
 from .utils import get_zaaktype_response
 
 
+@override_settings(ALLOWED_HOSTS=["testserver", "openzaak.nl"])
 class ZaakInformatieObjectAPITests(JWTAuthMixin, APITestCase):
 
     list_url = reverse_lazy(ZaakInformatieObject)
@@ -421,6 +422,7 @@ class ZaakInformatieObjectAPITests(JWTAuthMixin, APITestCase):
         self.assertTrue(Zaak.objects.exists())
 
 
+@override_settings(ALLOWED_HOSTS=["testserver", "openzaak.nl"])
 @tag("external-urls")
 class ExternalDocumentsAPITests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
@@ -522,7 +524,9 @@ class ExternalDocumentsAPITests(JWTAuthMixin, APITestCase):
         list_url = reverse(ZaakInformatieObject)
         data = {"zaak": zaak_url, "informatieobject": "http://example.com"}
 
-        response = self.client.post(list_url, data, HTTP_HOST="openzaak.nl")
+        with requests_mock.Mocker() as m:
+            m.get("http://example.com", text="<html></html>")
+            response = self.client.post(list_url, data, HTTP_HOST="openzaak.nl")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -674,7 +678,7 @@ class ExternalDocumentsAPITransactionTests(JWTAuthMixin, APITransactionTestCase)
 
 
 @tag("external-urls")
-@override_settings(ALLOWED_HOSTS=["openzaak.nl"])
+@override_settings(ALLOWED_HOSTS=["testserver", "openzaak.nl"])
 class ExternalInformatieObjectAPITests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
 
@@ -850,7 +854,7 @@ class ExternalInformatieObjectAPITests(JWTAuthMixin, APITestCase):
 
 
 @tag("external-urls")
-@override_settings(ALLOWED_HOSTS=["openzaak.nl"])
+@override_settings(ALLOWED_HOSTS=["testserver", "openzaak.nl"])
 class ExternalDocumentDestroyTests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
 

--- a/src/openzaak/components/zaken/tests/test_zaakobject_filter.py
+++ b/src/openzaak/components/zaken/tests/test_zaakobject_filter.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
+from django.test import override_settings
+
 from rest_framework import status
 from rest_framework.test import APITestCase
 from vng_api_common.constants import ZaakobjectTypes
@@ -10,6 +12,7 @@ from .factories import ZaakObjectFactory
 from .utils import get_operation_url
 
 
+@override_settings(ALLOWED_HOSTS=["testserver", "openzaak.nl"])
 class ZaakObjectFilterTestCase(JWTAuthMixin, APITestCase):
 
     heeft_alle_autorisaties = True


### PR DESCRIPTION
My `.env` locally often breaks tests when running tests locally, while they pass in CI -> test isolation/pinning is not good enough.