### PR TITLE
Bug/notification version

### DIFF
--- a/src/openzaak/components/catalogi/tests/admin/test_notifications.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_notifications.py
@@ -19,13 +19,13 @@ from openzaak.selectielijst.tests.mixins import ReferentieLijstServiceMixin
 from openzaak.tests.utils import mock_nrc_oas_get
 from openzaak.utils.tests import ClearCachesMixin
 
+from ...models import ZaakType
 from ..factories import (
     BesluitTypeFactory,
     CatalogusFactory,
     InformatieObjectTypeFactory,
     ZaakTypeFactory,
 )
-from ...models import ZaakType
 
 
 @override_settings(NOTIFICATIONS_DISABLED=False)
@@ -351,5 +351,5 @@ class NotificationAdminTests(
         last_request_data = last_request.json()
         self.assertEqual(
             f"http://testserver{zaaktype_new.get_absolute_api_url()}",
-            last_request_data['resourceUrl']
+            last_request_data["resourceUrl"],
         )

--- a/src/openzaak/utils/models.py
+++ b/src/openzaak/utils/models.py
@@ -1,11 +1,13 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2019 - 2020 Dimpact
 import copy
 
 
 def clone_object(instance):
-    cloned = copy.copy(instance) # don't alter original instance
+    cloned = copy.deepcopy(instance)  # don't alter original instance
     cloned.pk = None
     try:
-        delattr(cloned, '_prefetched_objects_cache')
+        delattr(cloned, "_prefetched_objects_cache")
     except AttributeError:
         pass
     return cloned


### PR DESCRIPTION
Fixes #1026

**Changes**

Fix notification version bug by ensuring NewVersionMixin triggers before NotificationsMixin and storing the new version as an attribute. Added a `clone_object` util function to prevent modifying the original object within the mixin.