### PR TITLE
Refactor/admin publishing versioning notifications

### DIFF
--- a/src/openzaak/components/catalogi/admin/besluittype.py
+++ b/src/openzaak/components/catalogi/admin/besluittype.py
@@ -10,9 +10,9 @@ from .forms import BesluitTypeAdminForm
 from .mixins import (
     CatalogusContextAdminMixin,
     GeldigheidAdminMixin,
-    NotificationMixin,
     PublishAdminMixin,
     ReadOnlyPublishedMixin,
+    SideEffectsMixin,
 )
 
 
@@ -23,7 +23,7 @@ class BesluitTypeAdmin(
     CatalogusContextAdminMixin,
     GeldigheidAdminMixin,
     PublishAdminMixin,
-    NotificationMixin,
+    SideEffectsMixin,
     admin.ModelAdmin,
 ):
     # List

--- a/src/openzaak/components/catalogi/admin/informatieobjecttype.py
+++ b/src/openzaak/components/catalogi/admin/informatieobjecttype.py
@@ -16,10 +16,10 @@ from .forms import ZaakTypeInformatieObjectTypeAdminForm
 from .mixins import (
     CatalogusContextAdminMixin,
     GeldigheidAdminMixin,
-    NotificationMixin,
     PublishAdminMixin,
     ReadOnlyPublishedMixin,
     ReadOnlyPublishedParentMixin,
+    SideEffectsMixin,
 )
 
 
@@ -74,7 +74,7 @@ class InformatieObjectTypeAdmin(
     CatalogusContextAdminMixin,
     GeldigheidAdminMixin,
     PublishAdminMixin,
-    NotificationMixin,
+    SideEffectsMixin,
     admin.ModelAdmin,
 ):
     list_display = (

--- a/src/openzaak/components/catalogi/admin/side_effects.py
+++ b/src/openzaak/components/catalogi/admin/side_effects.py
@@ -3,6 +3,8 @@
 import uuid
 from datetime import date
 
+from rest_framework.request import Request
+
 from openzaak.utils.models import clone_object
 
 from ..api.viewsets import (
@@ -92,23 +94,21 @@ class VersioningSideEffect(SideEffectBase):
 
 class NotificationSideEffect(SideEffectBase):
     def apply(self):
-        obj = self.new_version or self.original
-
-        viewset_cls = VIEWSET_FOR_MODEL[type(obj)]
+        viewset_cls = VIEWSET_FOR_MODEL[type(self.original)]
         viewset = viewset_cls()
 
         send_notification = False
-        if not obj.pk or "_addversion" in request.POST:
+        if not self.original.pk or "_addversion" in self.request.POST:
             send_notification = True
             viewset.action = "create"
-        elif form.has_changed() or "_publish" in request.POST:
+        elif self.form.has_changed() or "_publish" in self.request.POST:
             send_notification = True
             viewset.action = "update"
 
         if send_notification:
-            reference_object = getattr(self, "new_version_instance", obj)
+            reference_object = getattr(self, "new_version_instance", self.original)
 
-            context_request = Request(request)
+            context_request = Request(self.request)
             # set versioning to context_request
             (
                 context_request.version,

--- a/src/openzaak/components/catalogi/admin/side_effects.py
+++ b/src/openzaak/components/catalogi/admin/side_effects.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2021 Dimpact
+import uuid
+from datetime import date
+
+from openzaak.utils.models import clone_object
+
+from ..api.viewsets import (
+    BesluitTypeViewSet,
+    InformatieObjectTypeViewSet,
+    ZaakTypeViewSet,
+)
+from ..models import BesluitType, InformatieObjectType, ZaakType
+
+VIEWSET_FOR_MODEL = {
+    ZaakType: ZaakTypeViewSet,
+    InformatieObjectType: InformatieObjectTypeViewSet,
+    BesluitType: BesluitTypeViewSet,
+}
+
+
+class SideEffectBase:
+    def __init__(self, modeladmin, request, original, change, form):
+        self.modeladmin = modeladmin
+        self.request = request
+        self.original = original
+        self.change = change
+        self.form = form
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # if anything went wrong, don't apply the side effects
+        if exc_type is not None:
+            return
+
+        self.apply()
+
+
+class VersioningSideEffect(SideEffectBase):
+
+    new_version = None
+
+    def apply(self):
+        if "_addversion" not in self.request.POST:
+            return
+
+        self.new_version = self.create_new_version()
+
+    def create_new_version(self):
+        new_obj = clone_object(self.original)
+        version_date = date.today()
+
+        new_obj.pk = None
+        new_obj.uuid = uuid.uuid4()
+        new_obj.datum_begin_geldigheid = version_date
+        new_obj.versiedatum = version_date
+        new_obj.datum_einde_geldigheid = None
+        new_obj.concept = True
+        new_obj.save()
+
+        related_objects = [
+            f
+            for f in new_obj._meta.get_fields(include_hidden=True)
+            if (f.auto_created and not f.concrete)
+        ]
+
+        # related objects
+        for relation in related_objects:
+            if relation.name in self.modeladmin.exclude_copy_relation:
+                continue
+
+            # m2m relation included in the loop below as one_to_many
+            if relation.one_to_many or relation.one_to_one:
+                remote_model = relation.related_model
+                remote_field = relation.field.name
+
+                related_queryset = remote_model.objects.filter(
+                    **{remote_field: self.original.pk}
+                )
+                for related_obj in related_queryset:
+                    related_obj.pk = None
+                    setattr(related_obj, remote_field, new_obj)
+
+                    if hasattr(related_obj, "uuid"):
+                        related_obj.uuid = uuid.uuid4()
+                    related_obj.save()
+
+        return new_obj
+
+
+class NotificationSideEffect(SideEffectBase):
+    def apply(self):
+        obj = self.new_version or self.original
+
+        viewset_cls = VIEWSET_FOR_MODEL[type(obj)]
+        viewset = viewset_cls()
+
+        send_notification = False
+        if not obj.pk or "_addversion" in request.POST:
+            send_notification = True
+            viewset.action = "create"
+        elif form.has_changed() or "_publish" in request.POST:
+            send_notification = True
+            viewset.action = "update"
+
+        if send_notification:
+            reference_object = getattr(self, "new_version_instance", obj)
+
+            context_request = Request(request)
+            # set versioning to context_request
+            (
+                context_request.version,
+                context_request.versioning_scheme,
+            ) = viewset.determine_version(context_request)
+
+            data = viewset.serializer_class(
+                reference_object, context={"request": context_request}
+            ).data
+
+            viewset.notify(status_code=200, data=data, instance=reference_object)

--- a/src/openzaak/components/catalogi/admin/side_effects.py
+++ b/src/openzaak/components/catalogi/admin/side_effects.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2021 Dimpact
 import uuid
+from abc import ABC, abstractmethod
 from datetime import date
 
 from rest_framework.request import Request
@@ -21,7 +22,7 @@ VIEWSET_FOR_MODEL = {
 }
 
 
-class SideEffectBase:
+class SideEffectBase(ABC):
     def __init__(self, modeladmin, request, original, change, form):
         self.modeladmin = modeladmin
         self.request = request
@@ -39,6 +40,10 @@ class SideEffectBase:
 
         self.apply()
 
+    @abstractmethod
+    def apply(self):
+        pass
+
 
 class VersioningSideEffect(SideEffectBase):
 
@@ -54,7 +59,6 @@ class VersioningSideEffect(SideEffectBase):
         new_obj = clone_object(self.original)
         version_date = date.today()
 
-        new_obj.pk = None
         new_obj.uuid = uuid.uuid4()
         new_obj.datum_begin_geldigheid = version_date
         new_obj.versiedatum = version_date

--- a/src/openzaak/components/catalogi/admin/zaaktypen.py
+++ b/src/openzaak/components/catalogi/admin/zaaktypen.py
@@ -36,11 +36,11 @@ from .forms import ZaakTypeForm, ZaakTypenRelatieAdminForm
 from .mixins import (
     CatalogusContextAdminMixin,
     ExportMixin,
-    NewVersionMixin,
     NotificationMixin,
     PublishAdminMixin,
     ReadOnlyPublishedMixin,
     ReadOnlyPublishedZaaktypeMixin,
+    SideEffectsMixin,
 )
 from .resultaattype import ResultaatTypeAdmin
 from .roltype import RolTypeAdmin
@@ -104,7 +104,7 @@ class ZaakTypenRelatieInline(EditInlineAdminMixin, admin.TabularInline):
 @admin.register(ZaakType)
 class ZaakTypeAdmin(
     ReadOnlyPublishedMixin,
-    NewVersionMixin,
+    SideEffectsMixin,
     ListObjectActionsAdminMixin,
     UUIDAdminMixin,
     PublishAdminMixin,

--- a/src/openzaak/components/catalogi/admin/zaaktypen.py
+++ b/src/openzaak/components/catalogi/admin/zaaktypen.py
@@ -36,7 +36,6 @@ from .forms import ZaakTypeForm, ZaakTypenRelatieAdminForm
 from .mixins import (
     CatalogusContextAdminMixin,
     ExportMixin,
-    NotificationMixin,
     PublishAdminMixin,
     ReadOnlyPublishedMixin,
     ReadOnlyPublishedZaaktypeMixin,
@@ -111,7 +110,6 @@ class ZaakTypeAdmin(
     ExportMixin,
     DynamicArrayMixin,
     CatalogusContextAdminMixin,
-    NotificationMixin,
     admin.ModelAdmin,
 ):
     model = ZaakType

--- a/src/openzaak/components/catalogi/tests/admin/test_notifications.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_notifications.py
@@ -19,13 +19,13 @@ from openzaak.selectielijst.tests.mixins import ReferentieLijstServiceMixin
 from openzaak.tests.utils import mock_nrc_oas_get
 from openzaak.utils.tests import ClearCachesMixin
 
+from ...models import ZaakType
 from ..factories import (
     BesluitTypeFactory,
     CatalogusFactory,
     InformatieObjectTypeFactory,
     ZaakTypeFactory,
 )
-from ...models import ZaakType
 
 
 @override_settings(NOTIFICATIONS_DISABLED=False)
@@ -351,5 +351,5 @@ class NotificationAdminTests(
         last_request_data = last_request.json()
         self.assertEqual(
             f"http://testserver{zaaktype_new.get_absolute_api_url()}",
-            last_request_data['resourceUrl']
+            last_request_data["resourceUrl"],
         )

--- a/src/openzaak/utils/models.py
+++ b/src/openzaak/utils/models.py
@@ -1,0 +1,11 @@
+import copy
+
+
+def clone_object(instance):
+    cloned = copy.deepcopy(instance)  # don't alter original instance
+    cloned.pk = None
+    try:
+        delattr(cloned, "_prefetched_objects_cache")
+    except AttributeError:
+        pass
+    return cloned

--- a/src/openzaak/utils/models.py
+++ b/src/openzaak/utils/models.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2021 Dimpact
 import copy
 
 

--- a/src/openzaak/utils/models.py
+++ b/src/openzaak/utils/models.py
@@ -6,6 +6,7 @@ import copy
 def clone_object(instance):
     cloned = copy.deepcopy(instance)  # don't alter original instance
     cloned.pk = None
+    cloned._state.adding = True
     try:
         delattr(cloned, "_prefetched_objects_cache")
     except AttributeError:


### PR DESCRIPTION
Fixes #1026, replaces #1028

**Changes**

* @dariomory added a regression test for the bug
* Refactored Version and Notification admin mixins into a single SideEffectsMixin
* Refactored the body of the mixins two two side-effect implementations
* Organized both side effects so that no thread locals or magic/private attributes on the request object are needed

