### PR TITLE
Fix crash on null user id in JWT

### DIFF
--- a/src/openzaak/tests/test_jwt_auth.py
+++ b/src/openzaak/tests/test_jwt_auth.py
@@ -8,7 +8,9 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 from vng_api_common.tests import reverse
 
+from openzaak.components.autorisaties.middleware import JWTAuth
 from openzaak.components.zaken.tests.factories import ZaakFactory
+from openzaak.components.zaken.tests.utils import ZAAK_WRITE_KWARGS
 from openzaak.utils.tests import JWTAuthMixin, generate_jwt_auth
 
 
@@ -94,3 +96,30 @@ class JWTLeewayTests(JWTAuthMixin, APITestCase):
         response = self.client.get(zaak_url)
 
         self.assertNotEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class JWTRegressionTests(JWTAuthMixin, APITestCase):
+    heeft_alle_autorisaties = True
+
+    def test_null_user_id(self):
+        """
+        Assert that ``user_id: null`` claim does not crash Open Zaak.
+
+        Regression test for https://github.com/open-zaak/open-zaak/issues/936
+        """
+        token = generate_jwt_auth(
+            self.client_id,
+            self.secret,
+            user_id=None,
+            user_representation=self.user_representation,
+            nbf=int(timezone.now().timestamp()),
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=token)
+        zaak = ZaakFactory.create()
+        endpoint = reverse(zaak)
+        payload = JWTAuth(token.split(" ")[1]).payload
+        assert payload["user_id"] is None
+
+        response = self.client.patch(endpoint, data={}, **ZAAK_WRITE_KWARGS)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
Fixes #936

**Changes**

* Added regression test
* Fix applied in vng-api-common: https://github.com/VNG-Realisatie/vng-api-common/commit/9495766b3355603688cdb05378d8fd36afe743af
* Bumped to newer vng-api-common

