### PR TITLE
Validate unique constraint zaakstatus

### DIFF
--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -386,6 +386,9 @@ class StatusSerializer(serializers.HyperlinkedModelSerializer):
             "statustoelichting",
         )
         validators = [
+            UniqueTogetherValidator(
+                queryset=Status.objects.all(), fields=("zaak", "datum_status_gezet"),
+            ),
             CorrectZaaktypeValidator("statustype"),
             EndStatusIOsUnlockedValidator(),
             EndStatusIOsIndicatieGebruiksrechtValidator(),


### PR DESCRIPTION
Fixes #960

**Changes**

* Added `UniqueTogetherValidator` to catch unique constraint violations before they hit the DB

