### PR TITLE
:sparkles: [#1046] Zaken list extra ordering options

### DIFF
--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -11,7 +11,6 @@ from django_loose_fk.virtual_models import ProxyMixin
 from rest_framework import mixins, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied, ValidationError
-from rest_framework.filters import OrderingFilter
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.reverse import reverse
 from rest_framework.settings import api_settings
@@ -35,6 +34,7 @@ from zgw_consumers.models import Service
 
 from openzaak.utils.api import delete_remote_oio
 from openzaak.utils.data_filtering import ListFilterByAuthorizationsMixin
+from openzaak.utils.filters import OrderingFilter
 
 from ..models import (
     KlantContact,
@@ -224,7 +224,12 @@ class ZaakViewSet(
     search_input_serializer_class = ZaakZoekSerializer
     filter_backends = (Backend, OrderingFilter)
     filterset_class = ZaakFilter
-    ordering_fields = ("startdatum",)
+    ordering_fields = (
+        "startdatum",
+        "einddatum",
+        "publicatiedatum",
+        "archiefactiedatum",
+    )
     lookup_field = "uuid"
     pagination_class = PageNumberPagination
 

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -1919,6 +1919,11 @@ paths:
         required: false
         schema:
           type: string
+          enum:
+          - startdatum
+          - einddatum
+          - publicatiedatum
+          - archiefactiedatum
       - name: page
         in: query
         description: Een pagina binnen de gepagineerde set resultaten.

--- a/src/openzaak/components/zaken/swagger2.0.json
+++ b/src/openzaak/components/zaken/swagger2.0.json
@@ -2597,7 +2597,13 @@
                         "in": "query",
                         "description": "Which field to use when ordering the results.",
                         "required": false,
-                        "type": "string"
+                        "type": "string",
+                        "enum": [
+                            "startdatum",
+                            "einddatum",
+                            "publicatiedatum",
+                            "archiefactiedatum"
+                        ]
                     },
                     {
                         "name": "page",

--- a/src/openzaak/utils/filters.py
+++ b/src/openzaak/utils/filters.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
+from django.utils.encoding import force_str
+
 from django_filters import filters
+from rest_framework import filters as drf_filters
+from rest_framework.compat import coreapi, coreschema
 from vng_api_common.constants import VertrouwelijkheidsAanduiding
 
 
@@ -23,3 +27,29 @@ class MaximaleVertrouwelijkheidaanduidingFilter(filters.ChoiceFilter):
         qs = qs.annotate(**{self.field_name: order_expression})
         numeric_value = VertrouwelijkheidsAanduiding.get_choice(value).order
         return super().filter(qs, numeric_value)
+
+
+class OrderingFilter(drf_filters.OrderingFilter):
+    def get_schema_fields(self, view):
+        """
+        Display as enum in schema, to show which fields can be used
+        for ordering
+        """
+        assert (
+            coreapi is not None
+        ), "coreapi must be installed to use `get_schema_fields()`"
+        assert (
+            coreschema is not None
+        ), "coreschema must be installed to use `get_schema_fields()`"
+        return [
+            coreapi.Field(
+                name=self.ordering_param,
+                required=False,
+                location="query",
+                schema=coreschema.Enum(
+                    title=force_str(self.ordering_title),
+                    description=force_str(self.ordering_description),
+                    enum=view.ordering_fields,
+                ),
+            )
+        ]


### PR DESCRIPTION
Fixes #1046

Requires https://github.com/VNG-Realisatie/vng-api-common/pull/182/ to be merged and vng-api-common to be upgraded

**Changes**
* Add extra options for Zaken list ordering: einddatum, publicatiedatum, archiefactiedatum
* Explicitly document these options in the Zaken OAS
