### PR TITLE
:memo: Fix deprecated NLX url in kubernetes docs

### DIFF
--- a/docs/installation/deployment/kubernetes.rst
+++ b/docs/installation/deployment/kubernetes.rst
@@ -364,7 +364,7 @@ override.
 Configuring NLX
 ^^^^^^^^^^^^^^^
 
-If you want to use NLX, you need to create NLX certificate. See https://docs.nlx.io/try-nlx/retrieve-a-demo-certificate.
+If you want to use NLX, you need to create NLX certificate. See https://docs.nlx.io/try-nlx/docker/retrieve-a-demo-certificate.
 The key and certificate need to be set in ``vars/nlx.yml``:
 
 * ``nlx_inway_key``: private key


### PR DESCRIPTION
Fixes failing CI build

Changes:

* Fix incorrect URL in kubernetes docs