### PR TITLE
:sparkles: [#1048] Add object filter to EnkelvoudigInformatieObject list

### DIFF
--- a/src/openzaak/components/documenten/api/filters.py
+++ b/src/openzaak/components/documenten/api/filters.py
@@ -6,10 +6,13 @@ import uuid
 from urllib.parse import urlparse
 
 from django.conf import settings
+from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
 
 from django_filters import rest_framework as filters
+from django_filters.constants import EMPTY_VALUES
 from django_loose_fk.filters import FkOrUrlFieldFilter
+from django_loose_fk.loaders import BaseLoader
 from vng_api_common.filters import URLModelChoiceFilter
 from vng_api_common.filtersets import FilterSet
 from vng_api_common.utils import get_help_text
@@ -24,10 +27,53 @@ from ..models import (
 logger = logging.getLogger(__name__)
 
 
+class ObjectFilter(filters.BaseCSVFilter):
+    """
+    Allow filtering of ENKELVOUDIGINFORMATIEOBJECTen by objects they are related
+    to (through the OBJECTINFORMATIEOBJECT resource)
+    """
+
+    def filter(self, qs, values):
+        if values in EMPTY_VALUES:
+            return qs
+
+        if self.distinct:
+            qs = qs.distinct()
+
+        loader = BaseLoader()
+        lookups = Q()
+        for value in values:
+            if loader.is_local_url(value):
+                parsed = urlparse(value)
+                uuid = parsed.path.split("/")[-1]
+                if uuid:
+                    lookups |= Q(_zaak__uuid=uuid) | Q(_besluit__uuid=uuid)
+            else:
+                lookups |= Q(_zaak_url=value) | Q(_besluit_url=value)
+
+        oios = ObjectInformatieObject.objects.filter(lookups)
+        qs = self.get_method(qs)(
+            canonical__id__in=list(oios.values_list("informatieobject__id", flat=True))
+        )
+        return qs
+
+
 class EnkelvoudigInformatieObjectListFilter(FilterSet):
+    object = ObjectFilter(
+        help_text=_(
+            "De URL van het gerelateerde object "
+            "(zoals vastgelegd in de OBJECTINFORMATIEOBJECT resource). "
+            "Meerdere waardes kunnen met komma's gescheiden worden."
+        )
+    )
+
     class Meta:
         model = EnkelvoudigInformatieObject
-        fields = ("identificatie", "bronorganisatie")
+        fields = (
+            "identificatie",
+            "bronorganisatie",
+            "object",
+        )
 
 
 class EnkelvoudigInformatieObjectDetailFilter(FilterSet):

--- a/src/openzaak/components/documenten/openapi.yaml
+++ b/src/openzaak/components/documenten/openapi.yaml
@@ -83,6 +83,13 @@ paths:
         required: false
         schema:
           type: string
+      - name: object
+        in: query
+        description: De URL van het gerelateerde object (zoals vastgelegd in de OBJECTINFORMATIEOBJECT
+          resource). Meerdere waardes kunnen met komma's gescheiden worden.
+        required: false
+        schema:
+          type: string
       - name: page
         in: query
         description: Een pagina binnen de gepagineerde set resultaten.

--- a/src/openzaak/components/documenten/swagger2.0.json
+++ b/src/openzaak/components/documenten/swagger2.0.json
@@ -55,6 +55,13 @@
                         "type": "string"
                     },
                     {
+                        "name": "object",
+                        "in": "query",
+                        "description": "De URL van het gerelateerde object (zoals vastgelegd in de OBJECTINFORMATIEOBJECT resource). Meerdere waardes kunnen met komma's gescheiden worden.",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
                         "name": "page",
                         "in": "query",
                         "description": "Een pagina binnen de gepagineerde set resultaten.",


### PR DESCRIPTION
Fixes #1048

**Changes**

* Add `ObjectFilter` that allows filtering EnkelvoudigInformatieObjecten with one or more `object` URLs, eliminating the need for multiple requests to retrieve all EIOs that are related to a Zaak for example
