### PR TITLE
:sparkles: [#1046] Zaken list extra ordering options

### DIFF
--- a/src/openzaak/components/zaken/api/filters.py
+++ b/src/openzaak/components/zaken/api/filters.py
@@ -3,6 +3,7 @@
 from urllib.parse import urlparse
 
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 
 from django_filters import filters
 from django_loose_fk.filters import FkOrUrlFieldFilter
@@ -10,6 +11,7 @@ from django_loose_fk.utils import get_resource_for_path
 from vng_api_common.filtersets import FilterSet
 from vng_api_common.utils import get_help_text
 
+from openzaak.utils.apidoc import mark_oas_difference
 from openzaak.utils.filters import MaximaleVertrouwelijkheidaanduidingFilter
 
 from ..models import (
@@ -43,6 +45,12 @@ class ZaakFilter(FilterSet):
     rol__betrokkene_identificatie__organisatorische_eenheid__identificatie = filters.CharFilter(
         field_name="rol__organisatorischeeenheid__identificatie",
         help_text=get_help_text("zaken.OrganisatorischeEenheid", "identificatie"),
+    )
+    ordering = filters.OrderingFilter(
+        fields=("startdatum", "einddatum", "publicatiedatum", "archiefactiedatum",),
+        help_text=_(
+            mark_oas_difference("Het veld waarop de resultaten geordend worden.")
+        ),
     )
 
     class Meta:

--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -11,7 +11,6 @@ from django_loose_fk.virtual_models import ProxyMixin
 from rest_framework import mixins, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied, ValidationError
-from rest_framework.filters import OrderingFilter
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.reverse import reverse
 from rest_framework.settings import api_settings
@@ -35,6 +34,7 @@ from zgw_consumers.models import Service
 
 from openzaak.utils.api import delete_remote_oio
 from openzaak.utils.data_filtering import ListFilterByAuthorizationsMixin
+from openzaak.utils.filters import OrderingFilter
 
 from ..models import (
     KlantContact,
@@ -224,7 +224,12 @@ class ZaakViewSet(
     search_input_serializer_class = ZaakZoekSerializer
     filter_backends = (Backend, OrderingFilter)
     filterset_class = ZaakFilter
-    ordering_fields = ("startdatum",)
+    ordering_fields = (
+        "startdatum",
+        "einddatum",
+        "publicatiedatum",
+        "archiefactiedatum",
+    )
     lookup_field = "uuid"
     pagination_class = PageNumberPagination
 

--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -34,7 +34,6 @@ from zgw_consumers.models import Service
 
 from openzaak.utils.api import delete_remote_oio
 from openzaak.utils.data_filtering import ListFilterByAuthorizationsMixin
-from openzaak.utils.filters import OrderingFilter
 
 from ..models import (
     KlantContact,
@@ -222,14 +221,8 @@ class ZaakViewSet(
     )
     serializer_class = ZaakSerializer
     search_input_serializer_class = ZaakZoekSerializer
-    filter_backends = (Backend, OrderingFilter)
+    filter_backends = (Backend,)
     filterset_class = ZaakFilter
-    ordering_fields = (
-        "startdatum",
-        "einddatum",
-        "publicatiedatum",
-        "archiefactiedatum",
-    )
     lookup_field = "uuid"
     pagination_class = PageNumberPagination
 

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -1919,6 +1919,11 @@ paths:
         required: false
         schema:
           type: string
+          enum:
+          - startdatum
+          - einddatum
+          - publicatiedatum
+          - archiefactiedatum
       - name: page
         in: query
         description: Een pagina binnen de gepagineerde set resultaten.

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -1915,7 +1915,7 @@ paths:
           type: string
       - name: ordering
         in: query
-        description: Which field to use when ordering the results.
+        description: '***AFWIJKING:** Which field to use when ordering the results.'
         required: false
         schema:
           type: string
@@ -5835,7 +5835,7 @@ components:
           minLength: 1
         ordering:
           title: Ordering
-          description: Which field to use when ordering the results.
+          description: '***AFWIJKING:** Which field to use when ordering the results.'
           type: string
           minLength: 1
     Wijzigingen:

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -1915,15 +1915,19 @@ paths:
           type: string
       - name: ordering
         in: query
-        description: '***AFWIJKING:** Which field to use when ordering the results.'
+        description: '***AFWIJKING:** Het veld waarop de resultaten geordend worden.'
         required: false
         schema:
           type: string
           enum:
           - startdatum
+          - -startdatum
           - einddatum
+          - -einddatum
           - publicatiedatum
+          - -publicatiedatum
           - archiefactiedatum
+          - -archiefactiedatum
       - name: page
         in: query
         description: Een pagina binnen de gepagineerde set resultaten.
@@ -5835,9 +5839,37 @@ components:
           minLength: 1
         ordering:
           title: Ordering
-          description: '***AFWIJKING:** Which field to use when ordering the results.'
+          description: '***AFWIJKING:** Het veld waarop de resultaten geordend worden.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `startdatum` - Startdatum
+
+            * `-startdatum` - Startdatum (descending)
+
+            * `einddatum` - Einddatum
+
+            * `-einddatum` - Einddatum (descending)
+
+            * `publicatiedatum` - Publicatiedatum
+
+            * `-publicatiedatum` - Publicatiedatum (descending)
+
+            * `archiefactiedatum` - Archiefactiedatum
+
+            * `-archiefactiedatum` - Archiefactiedatum (descending)'
           type: string
-          minLength: 1
+          enum:
+          - startdatum
+          - -startdatum
+          - einddatum
+          - -einddatum
+          - publicatiedatum
+          - -publicatiedatum
+          - archiefactiedatum
+          - -archiefactiedatum
     Wijzigingen:
       type: object
       properties:

--- a/src/openzaak/components/zaken/swagger2.0.json
+++ b/src/openzaak/components/zaken/swagger2.0.json
@@ -2595,14 +2595,18 @@
                     {
                         "name": "ordering",
                         "in": "query",
-                        "description": "***AFWIJKING:** Which field to use when ordering the results.",
+                        "description": "***AFWIJKING:** Het veld waarop de resultaten geordend worden.",
                         "required": false,
                         "type": "string",
                         "enum": [
                             "startdatum",
+                            "-startdatum",
                             "einddatum",
+                            "-einddatum",
                             "publicatiedatum",
-                            "archiefactiedatum"
+                            "-publicatiedatum",
+                            "archiefactiedatum",
+                            "-archiefactiedatum"
                         ]
                     },
                     {
@@ -7118,9 +7122,18 @@
                 },
                 "ordering": {
                     "title": "Ordering",
-                    "description": "***AFWIJKING:** Which field to use when ordering the results.",
+                    "description": "***AFWIJKING:** Het veld waarop de resultaten geordend worden.\n\nUitleg bij mogelijke waarden:\n\n* `startdatum` - Startdatum\n* `-startdatum` - Startdatum (descending)\n* `einddatum` - Einddatum\n* `-einddatum` - Einddatum (descending)\n* `publicatiedatum` - Publicatiedatum\n* `-publicatiedatum` - Publicatiedatum (descending)\n* `archiefactiedatum` - Archiefactiedatum\n* `-archiefactiedatum` - Archiefactiedatum (descending)",
                     "type": "string",
-                    "minLength": 1
+                    "enum": [
+                        "startdatum",
+                        "-startdatum",
+                        "einddatum",
+                        "-einddatum",
+                        "publicatiedatum",
+                        "-publicatiedatum",
+                        "archiefactiedatum",
+                        "-archiefactiedatum"
+                    ]
                 }
             }
         },

--- a/src/openzaak/components/zaken/swagger2.0.json
+++ b/src/openzaak/components/zaken/swagger2.0.json
@@ -2595,7 +2595,7 @@
                     {
                         "name": "ordering",
                         "in": "query",
-                        "description": "Which field to use when ordering the results.",
+                        "description": "***AFWIJKING:** Which field to use when ordering the results.",
                         "required": false,
                         "type": "string",
                         "enum": [
@@ -7118,7 +7118,7 @@
                 },
                 "ordering": {
                     "title": "Ordering",
-                    "description": "Which field to use when ordering the results.",
+                    "description": "***AFWIJKING:** Which field to use when ordering the results.",
                     "type": "string",
                     "minLength": 1
                 }

--- a/src/openzaak/components/zaken/swagger2.0.json
+++ b/src/openzaak/components/zaken/swagger2.0.json
@@ -2597,7 +2597,13 @@
                         "in": "query",
                         "description": "Which field to use when ordering the results.",
                         "required": false,
-                        "type": "string"
+                        "type": "string",
+                        "enum": [
+                            "startdatum",
+                            "einddatum",
+                            "publicatiedatum",
+                            "archiefactiedatum"
+                        ]
                     },
                     {
                         "name": "page",

--- a/src/openzaak/components/zaken/tests/test_zaken.py
+++ b/src/openzaak/components/zaken/tests/test_zaken.py
@@ -493,7 +493,33 @@ class ZakenTests(JWTAuthMixin, APITestCase):
         self.assertEqual(response_gte.data["results"][0]["startdatum"], "2019-03-01")
         self.assertEqual(response_lte.data["results"][0]["startdatum"], "2019-01-01")
 
-    def test_sort_datum(self):
+    def test_sort_datum_ascending(self):
+        sorting_params = [
+            "startdatum",
+            "einddatum",
+            "publicatiedatum",
+            "archiefactiedatum",
+        ]
+
+        for param in sorting_params:
+            with self.subTest(param=param):
+                Zaak.objects.all().delete()
+                ZaakFactory.create(**{param: "2019-01-01"}, zaaktype=self.zaaktype)
+                ZaakFactory.create(**{param: "2019-03-01"}, zaaktype=self.zaaktype)
+                ZaakFactory.create(**{param: "2019-02-01"}, zaaktype=self.zaaktype)
+                url = reverse("zaak-list")
+
+                response = self.client.get(url, {"ordering": param}, **ZAAK_READ_KWARGS)
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.data["results"]
+
+                self.assertEqual(data[0][param], "2019-01-01")
+                self.assertEqual(data[1][param], "2019-02-01")
+                self.assertEqual(data[2][param], "2019-03-01")
+
+    def test_sort_datum_descending(self):
         sorting_params = [
             "startdatum",
             "einddatum",

--- a/src/openzaak/utils/apidoc.py
+++ b/src/openzaak/utils/apidoc.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: EUPL-1.2
-# Copyright (C) 2019 - 2020 Dimpact
+# Copyright (C) 2019 - 2021 Dimpact
 DOC_AUTH_JWT = """
 ### Autorisatie
 
@@ -35,3 +35,19 @@ UNIX-timestamp die aangeeft op welk moment het token gegenereerd is.
 vrije velden met als enige beperking dat de lengte maximaal de lengte van
 de overeenkomstige velden in de audit trail resources is (zie rest API spec).
 """
+
+
+DOC_OAS_DIFFERENCES = """
+### API specificatie afwijkingen
+
+Afwijkingen in de API specificatie ten opzichte van de referentie API specificatie
+zijn aangemerkt met ***AFWIJKING:**
+"""
+
+
+def mark_oas_difference(help_text):
+    """
+    Indicate in help_text that the feature is a deviation from the reference
+    API specification
+    """
+    return f"***AFWIJKING:** {help_text}"

--- a/src/openzaak/utils/filters.py
+++ b/src/openzaak/utils/filters.py
@@ -1,13 +1,8 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
-from django.utils.encoding import force_str
 
 from django_filters import filters
-from rest_framework import filters as drf_filters
-from rest_framework.compat import coreapi, coreschema
 from vng_api_common.constants import VertrouwelijkheidsAanduiding
-
-from openzaak.utils.apidoc import mark_oas_difference
 
 
 class MaximaleVertrouwelijkheidaanduidingFilter(filters.ChoiceFilter):
@@ -29,31 +24,3 @@ class MaximaleVertrouwelijkheidaanduidingFilter(filters.ChoiceFilter):
         qs = qs.annotate(**{self.field_name: order_expression})
         numeric_value = VertrouwelijkheidsAanduiding.get_choice(value).order
         return super().filter(qs, numeric_value)
-
-
-class OrderingFilter(drf_filters.OrderingFilter):
-    def get_schema_fields(self, view):
-        """
-        Display as enum in schema, to show which fields can be used
-        for ordering
-        """
-        assert (
-            coreapi is not None
-        ), "coreapi must be installed to use `get_schema_fields()`"
-        assert (
-            coreschema is not None
-        ), "coreschema must be installed to use `get_schema_fields()`"
-        return [
-            coreapi.Field(
-                name=self.ordering_param,
-                required=False,
-                location="query",
-                schema=coreschema.Enum(
-                    title=force_str(self.ordering_title),
-                    description=force_str(
-                        mark_oas_difference(self.ordering_description)
-                    ),
-                    enum=view.ordering_fields,
-                ),
-            )
-        ]

--- a/src/openzaak/utils/filters.py
+++ b/src/openzaak/utils/filters.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
+from django.utils.encoding import force_str
+
 from django_filters import filters
+from rest_framework import filters as drf_filters
+from rest_framework.compat import coreapi, coreschema
 from vng_api_common.constants import VertrouwelijkheidsAanduiding
 
 
@@ -23,3 +27,29 @@ class MaximaleVertrouwelijkheidaanduidingFilter(filters.ChoiceFilter):
         qs = qs.annotate(**{self.field_name: order_expression})
         numeric_value = VertrouwelijkheidsAanduiding.get_choice(value).order
         return super().filter(qs, numeric_value)
+
+
+class OrderingFilter(drf_filters.OrderingFilter):
+    def get_schema_fields(self, view):
+        """
+        Display as enum in schema, to show which fields can be used
+        for ordering
+        """
+        assert (
+            coreapi is not None
+        ), "coreapi must be installed to use `get_schema_fields()`"
+        assert (
+            coreschema is not None
+        ), "coreschema must be installed to use `get_schema_fields()`"
+        return [
+            coreapi.Field(
+                name=self.ordering_param,
+                required=False,
+                location="query",
+                schema=coreschema.Enum(
+                    title=force_str(self.ordering_title),
+                    description=force_str(self.ordering_description),
+                    enum=view.ordering_fields,
+                ),
+            )
+        ]

--- a/src/openzaak/utils/filters.py
+++ b/src/openzaak/utils/filters.py
@@ -7,6 +7,8 @@ from rest_framework import filters as drf_filters
 from rest_framework.compat import coreapi, coreschema
 from vng_api_common.constants import VertrouwelijkheidsAanduiding
 
+from openzaak.utils.apidoc import mark_oas_difference
+
 
 class MaximaleVertrouwelijkheidaanduidingFilter(filters.ChoiceFilter):
     def __init__(self, *args, **kwargs):
@@ -48,7 +50,9 @@ class OrderingFilter(drf_filters.OrderingFilter):
                 location="query",
                 schema=coreschema.Enum(
                     title=force_str(self.ordering_title),
-                    description=force_str(self.ordering_description),
+                    description=force_str(
+                        mark_oas_difference(self.ordering_description)
+                    ),
                     enum=view.ordering_fields,
                 ),
             )


### PR DESCRIPTION
Fixes #1046

PR in reference implementation has been merged: https://github.com/VNG-Realisatie/zaken-api/pull/206

**Changes**
* Add extra options for Zaken list ordering: einddatum, publicatiedatum, archiefactiedatum
* Explicitly document these options in the Zaken OAS
