### PR TITLE
:sparkles: [#1044] Zaken expand parameter

### DIFF
--- a/src/openzaak/components/zaken/api/filters.py
+++ b/src/openzaak/components/zaken/api/filters.py
@@ -11,6 +11,7 @@ from django_loose_fk.utils import get_resource_for_path
 from vng_api_common.filtersets import FilterSet
 from vng_api_common.utils import get_help_text
 
+from openzaak.utils.apidoc import mark_oas_difference
 from openzaak.utils.filters import (
     ExpandFilter,
     MaximaleVertrouwelijkheidaanduidingFilter,
@@ -51,7 +52,9 @@ class ZaakFilter(FilterSet):
     )
     expand = ExpandFilter(
         serializer_class=ZaakSerializer,
-        help_text=_("Haal details van inline resources direct op."),
+        help_text=_(
+            mark_oas_difference("Haal details van inline resources direct op.")
+        ),
     )
 
     class Meta:

--- a/src/openzaak/components/zaken/api/filters.py
+++ b/src/openzaak/components/zaken/api/filters.py
@@ -3,6 +3,7 @@
 from urllib.parse import urlparse
 
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 
 from django_filters import filters
 from django_loose_fk.filters import FkOrUrlFieldFilter
@@ -10,7 +11,10 @@ from django_loose_fk.utils import get_resource_for_path
 from vng_api_common.filtersets import FilterSet
 from vng_api_common.utils import get_help_text
 
-from openzaak.utils.filters import MaximaleVertrouwelijkheidaanduidingFilter
+from openzaak.utils.filters import (
+    ExpandFilter,
+    MaximaleVertrouwelijkheidaanduidingFilter,
+)
 
 from ..models import (
     KlantContact,
@@ -21,6 +25,7 @@ from ..models import (
     ZaakInformatieObject,
     ZaakObject,
 )
+from .serializers.zaken import ZaakSerializer
 
 
 class ZaakFilter(FilterSet):
@@ -43,6 +48,10 @@ class ZaakFilter(FilterSet):
     rol__betrokkene_identificatie__organisatorische_eenheid__identificatie = filters.CharFilter(
         field_name="rol__organisatorischeeenheid__identificatie",
         help_text=get_help_text("zaken.OrganisatorischeEenheid", "identificatie"),
+    )
+    expand = ExpandFilter(
+        serializer_class=ZaakSerializer,
+        help_text=_("Haal details van inline resources direct op."),
     )
 
     class Meta:

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -139,6 +139,13 @@ class ZaakSerializer(
         parent_lookup_kwargs={"zaak_uuid": "zaak__uuid"},
         source="zaakeigenschap_set",
     )
+    rollen = NestedHyperlinkedRelatedField(
+        many=True,
+        read_only=True,
+        lookup_field="uuid",
+        view_name="rol-detail",
+        source="rol_set",
+    )
     status = serializers.HyperlinkedRelatedField(
         source="current_status_uuid",
         read_only=True,
@@ -146,6 +153,20 @@ class ZaakSerializer(
         view_name="status-detail",
         lookup_url_kwarg="uuid",
         help_text=_("Indien geen status bekend is, dan is de waarde 'null'"),
+    )
+    zaakinformatieobjecten = NestedHyperlinkedRelatedField(
+        many=True,
+        read_only=True,
+        lookup_field="uuid",
+        view_name="zaakinformatieobject-detail",
+        source="zaakinformatieobject_set",
+    )
+    zaakobjecten = NestedHyperlinkedRelatedField(
+        many=True,
+        read_only=True,
+        lookup_field="uuid",
+        view_name="zaakobject-detail",
+        source="zaakobject_set",
     )
 
     kenmerken = ZaakKenmerkSerializer(
@@ -235,7 +256,10 @@ class ZaakSerializer(
             "relevante_andere_zaken",
             "eigenschappen",
             # read-only veld, on-the-fly opgevraagd
+            "rollen",
             "status",
+            "zaakinformatieobjecten",
+            "zaakobjecten",
             # Writable inline resource, as opposed to eigenschappen for demo
             # purposes. Eventually, we need to choose one form.
             "kenmerken",

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -37,6 +37,7 @@ from openzaak.components.documenten.api.fields import EnkelvoudigInformatieObjec
 from openzaak.utils.api import create_remote_oio
 from openzaak.utils.auth import get_auth
 from openzaak.utils.exceptions import DetermineProcessEndDateException
+from openzaak.utils.serializers import ExpandSerializer
 from openzaak.utils.validators import (
     LooseFkIsImmutableValidator,
     LooseFkResourceValidator,
@@ -123,271 +124,6 @@ class RelevanteZaakSerializer(serializers.HyperlinkedModelSerializer):
 
         value_display_mapping = add_choice_values_help_text(AardZaakRelatie)
         self.fields["aard_relatie"].help_text += f"\n\n{value_display_mapping}"
-
-
-class ZaakSerializer(
-    NestedGegevensGroepMixin,
-    NestedCreateMixin,
-    NestedUpdateMixin,
-    serializers.HyperlinkedModelSerializer,
-):
-    eigenschappen = NestedHyperlinkedRelatedField(
-        many=True,
-        read_only=True,
-        lookup_field="uuid",
-        view_name="zaakeigenschap-detail",
-        parent_lookup_kwargs={"zaak_uuid": "zaak__uuid"},
-        source="zaakeigenschap_set",
-    )
-    rollen = NestedHyperlinkedRelatedField(
-        many=True,
-        read_only=True,
-        lookup_field="uuid",
-        view_name="rol-detail",
-        source="rol_set",
-    )
-    status = serializers.HyperlinkedRelatedField(
-        source="current_status_uuid",
-        read_only=True,
-        allow_null=True,
-        view_name="status-detail",
-        lookup_url_kwarg="uuid",
-        help_text=_("Indien geen status bekend is, dan is de waarde 'null'"),
-    )
-    zaakinformatieobjecten = NestedHyperlinkedRelatedField(
-        many=True,
-        read_only=True,
-        lookup_field="uuid",
-        view_name="zaakinformatieobject-detail",
-        source="zaakinformatieobject_set",
-    )
-    zaakobjecten = NestedHyperlinkedRelatedField(
-        many=True,
-        read_only=True,
-        lookup_field="uuid",
-        view_name="zaakobject-detail",
-        source="zaakobject_set",
-    )
-
-    kenmerken = ZaakKenmerkSerializer(
-        source="zaakkenmerk_set",
-        many=True,
-        required=False,
-        help_text="Lijst van kenmerken. Merk op dat refereren naar gerelateerde objecten "
-        "beter kan via `ZaakObject`.",
-    )
-
-    betalingsindicatie_weergave = serializers.CharField(
-        source="get_betalingsindicatie_display",
-        read_only=True,
-        help_text=_("Uitleg bij `betalingsindicatie`."),
-    )
-
-    verlenging = VerlengingSerializer(
-        required=False,
-        allow_null=True,
-        help_text=_(
-            "Gegevens omtrent het verlengen van de doorlooptijd van de behandeling van de ZAAK"
-        ),
-    )
-
-    opschorting = OpschortingSerializer(
-        required=False,
-        allow_null=True,
-        help_text=_(
-            "Gegevens omtrent het tijdelijk opschorten van de behandeling van de ZAAK"
-        ),
-    )
-
-    deelzaken = serializers.HyperlinkedRelatedField(
-        read_only=True,
-        many=True,
-        view_name="zaak-detail",
-        lookup_url_kwarg="uuid",
-        lookup_field="uuid",
-        help_text=_("URL-referenties naar deel ZAAKen."),
-    )
-
-    resultaat = serializers.HyperlinkedRelatedField(
-        read_only=True,
-        allow_null=True,
-        view_name="resultaat-detail",
-        lookup_url_kwarg="uuid",
-        lookup_field="uuid",
-        help_text=_(
-            "URL-referentie naar het RESULTAAT. Indien geen resultaat bekend is, dan is de waarde 'null'"
-        ),
-    )
-
-    relevante_andere_zaken = RelevanteZaakSerializer(
-        many=True, required=False, help_text=_("Een lijst van relevante andere zaken.")
-    )
-
-    class Meta:
-        model = Zaak
-        fields = (
-            "url",
-            "uuid",
-            "identificatie",
-            "bronorganisatie",
-            "omschrijving",
-            "toelichting",
-            "zaaktype",
-            "registratiedatum",
-            "verantwoordelijke_organisatie",
-            "startdatum",
-            "einddatum",
-            "einddatum_gepland",
-            "uiterlijke_einddatum_afdoening",
-            "publicatiedatum",
-            "communicatiekanaal",
-            # TODO: add shape validator once we know the shape
-            "producten_of_diensten",
-            "vertrouwelijkheidaanduiding",
-            "betalingsindicatie",
-            "betalingsindicatie_weergave",
-            "laatste_betaaldatum",
-            "zaakgeometrie",
-            "verlenging",
-            "opschorting",
-            "selectielijstklasse",
-            "hoofdzaak",
-            "deelzaken",
-            "relevante_andere_zaken",
-            "eigenschappen",
-            # read-only veld, on-the-fly opgevraagd
-            "rollen",
-            "status",
-            "zaakinformatieobjecten",
-            "zaakobjecten",
-            # Writable inline resource, as opposed to eigenschappen for demo
-            # purposes. Eventually, we need to choose one form.
-            "kenmerken",
-            # Archiving
-            "archiefnominatie",
-            "archiefstatus",
-            "archiefactiedatum",
-            "resultaat",
-        )
-        extra_kwargs = {
-            "url": {"lookup_field": "uuid"},
-            "uuid": {"read_only": True},
-            "zaaktype": {
-                "lookup_field": "uuid",
-                "max_length": 1000,
-                "min_length": 1,
-                "validators": [
-                    LooseFkResourceValidator("ZaakType", settings.ZTC_API_SPEC),
-                    LooseFkIsImmutableValidator(),
-                    PublishValidator(),
-                ],
-            },
-            "zaakgeometrie": {
-                "help_text": "Punt, lijn of (multi-)vlak geometrie-informatie, in GeoJSON."
-            },
-            "identificatie": {"validators": [IsImmutableValidator()]},
-            "einddatum": {"read_only": True, "allow_null": True},
-            "communicatiekanaal": {
-                "validators": [
-                    ResourceValidator(
-                        "CommunicatieKanaal", settings.REFERENTIELIJSTEN_API_SPEC
-                    )
-                ]
-            },
-            "vertrouwelijkheidaanduiding": {
-                "required": False,
-                "help_text": _(
-                    "Aanduiding van de mate waarin het zaakdossier van de "
-                    "ZAAK voor de openbaarheid bestemd is. Optioneel - indien "
-                    "geen waarde gekozen wordt, dan wordt de waarde van het "
-                    "ZAAKTYPE overgenomen. Dit betekent dat de API _altijd_ een "
-                    "waarde teruggeeft."
-                ),
-            },
-            "selectielijstklasse": {
-                "validators": [
-                    ResourceValidator(
-                        "Resultaat",
-                        settings.REFERENTIELIJSTEN_API_SPEC,
-                        get_auth=get_auth,
-                    )
-                ]
-            },
-            "hoofdzaak": {
-                "lookup_field": "uuid",
-                "queryset": Zaak.objects.all(),
-                "validators": [NotSelfValidator(), HoofdzaakValidator()],
-            },
-            "laatste_betaaldatum": {"validators": [UntilNowValidator()]},
-        }
-        # Replace a default "unique together" constraint.
-        validators = [
-            UniekeIdentificatieValidator(),
-            ZaakArchiveIOsArchivedValidator(),
-        ]
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        value_display_mapping = add_choice_values_help_text(BetalingsIndicatie)
-        self.fields["betalingsindicatie"].help_text += f"\n\n{value_display_mapping}"
-
-        value_display_mapping = add_choice_values_help_text(Archiefstatus)
-        self.fields["archiefstatus"].help_text += f"\n\n{value_display_mapping}"
-
-        value_display_mapping = add_choice_values_help_text(Archiefnominatie)
-        self.fields["archiefnominatie"].help_text += f"\n\n{value_display_mapping}"
-
-    def validate(self, attrs):
-        super().validate(attrs)
-
-        default_betalingsindicatie = (
-            self.instance.betalingsindicatie if self.instance else None
-        )
-        betalingsindicatie = attrs.get("betalingsindicatie", default_betalingsindicatie)
-        if betalingsindicatie == BetalingsIndicatie.nvt and attrs.get(
-            "laatste_betaaldatum"
-        ):
-            raise serializers.ValidationError(
-                {
-                    "laatste_betaaldatum": _(
-                        'Laatste betaaldatum kan niet gezet worden als de betalingsindicatie "nvt" is'
-                    )
-                },
-                code="betaling-nvt",
-            )
-
-        # check that productenOfDiensten are part of the ones on the zaaktype
-        default_zaaktype = self.instance.zaaktype if self.instance else None
-        zaaktype = attrs.get("zaaktype", default_zaaktype)
-        assert zaaktype, "Should not have passed validation - a zaaktype is needed"
-
-        producten_of_diensten = attrs.get("producten_of_diensten")
-        if producten_of_diensten:
-            if not set(producten_of_diensten).issubset(
-                set(zaaktype.producten_of_diensten)
-            ):
-                raise serializers.ValidationError(
-                    {
-                        "producten_of_diensten": _(
-                            "Niet alle producten/diensten komen voor in "
-                            "de producten/diensten op het zaaktype"
-                        )
-                    },
-                    code="invalid-products-services",
-                )
-
-        return attrs
-
-    def create(self, validated_data: dict):
-        # set the derived value from ZTC
-        if "vertrouwelijkheidaanduiding" not in validated_data:
-            zaaktype = validated_data["zaaktype"]
-            validated_data[
-                "vertrouwelijkheidaanduiding"
-            ] = zaaktype.vertrouwelijkheidaanduiding
-
-        return super().create(validated_data)
 
 
 class GeoWithinSerializer(serializers.Serializer):
@@ -825,4 +561,297 @@ class ZaakBesluitSerializer(NestedHyperlinkedModelSerializer):
 
     def create(self, validated_data):
         validated_data["zaak"] = self.context["parent_object"]
+        return super().create(validated_data)
+
+
+class ZaakSerializer(
+    NestedGegevensGroepMixin,
+    NestedCreateMixin,
+    NestedUpdateMixin,
+    serializers.HyperlinkedModelSerializer,
+):
+    eigenschappen = ExpandSerializer(
+        source="zaakeigenschap_set",
+        default_serializer=NestedHyperlinkedRelatedField,
+        expanded_serializer=ZaakEigenschapSerializer,
+        read_only=True,
+        common_kwargs={"many": True, "read_only": True,},
+        default_serializer_kwargs={
+            "parent_lookup_kwargs": {"zaak_uuid": "zaak__uuid"},
+            "lookup_field": "uuid",
+            "view_name": "zaakeigenschap-detail",
+        },
+    )
+    rollen = ExpandSerializer(
+        source="rol_set",
+        default_serializer=NestedHyperlinkedRelatedField,
+        expanded_serializer=RolSerializer,
+        read_only=True,
+        common_kwargs={"many": True, "read_only": True,},
+        default_serializer_kwargs={"lookup_field": "uuid", "view_name": "rol-detail",},
+    )
+    status = ExpandSerializer(
+        source="current_status",
+        default_serializer=serializers.HyperlinkedRelatedField,
+        expanded_serializer=StatusSerializer,
+        read_only=True,
+        common_kwargs={"allow_null": True, "read_only": True,},
+        default_serializer_kwargs={
+            "lookup_field": "uuid",
+            "view_name": "status-detail",
+        },
+        help_text=_("Indien geen status bekend is, dan is de waarde 'null'"),
+    )
+    zaakinformatieobjecten = ExpandSerializer(
+        source="zaakinformatieobject_set",
+        default_serializer=NestedHyperlinkedRelatedField,
+        expanded_serializer=ZaakInformatieObjectSerializer,
+        read_only=True,
+        common_kwargs={"many": True, "read_only": True,},
+        default_serializer_kwargs={
+            "lookup_field": "uuid",
+            "view_name": "zaakinformatieobject-detail",
+        },
+    )
+    zaakobjecten = ExpandSerializer(
+        source="zaakobject_set",
+        default_serializer=NestedHyperlinkedRelatedField,
+        expanded_serializer="openzaak.components.zaken.api.serializers.zaakobjecten.ZaakObjectSerializer",
+        read_only=True,
+        common_kwargs={"many": True, "read_only": True,},
+        default_serializer_kwargs={
+            "lookup_field": "uuid",
+            "view_name": "zaakobject-detail",
+        },
+    )
+
+    kenmerken = ZaakKenmerkSerializer(
+        source="zaakkenmerk_set",
+        many=True,
+        required=False,
+        help_text="Lijst van kenmerken. Merk op dat refereren naar gerelateerde objecten "
+        "beter kan via `ZaakObject`.",
+    )
+
+    betalingsindicatie_weergave = serializers.CharField(
+        source="get_betalingsindicatie_display",
+        read_only=True,
+        help_text=_("Uitleg bij `betalingsindicatie`."),
+    )
+
+    verlenging = VerlengingSerializer(
+        required=False,
+        allow_null=True,
+        help_text=_(
+            "Gegevens omtrent het verlengen van de doorlooptijd van de behandeling van de ZAAK"
+        ),
+    )
+
+    opschorting = OpschortingSerializer(
+        required=False,
+        allow_null=True,
+        help_text=_(
+            "Gegevens omtrent het tijdelijk opschorten van de behandeling van de ZAAK"
+        ),
+    )
+
+    deelzaken = serializers.HyperlinkedRelatedField(
+        read_only=True,
+        many=True,
+        view_name="zaak-detail",
+        lookup_url_kwarg="uuid",
+        lookup_field="uuid",
+        help_text=_("URL-referenties naar deel ZAAKen."),
+    )
+
+    resultaat = ExpandSerializer(
+        default_serializer=serializers.HyperlinkedRelatedField,
+        expanded_serializer=ResultaatSerializer,
+        read_only=True,
+        common_kwargs={"allow_null": True, "read_only": True,},
+        default_serializer_kwargs={
+            "lookup_field": "uuid",
+            "view_name": "resultaat-detail",
+        },
+        help_text=_(
+            "URL-referentie naar het RESULTAAT. Indien geen resultaat bekend is, dan is de waarde 'null'"
+        ),
+    )
+
+    relevante_andere_zaken = RelevanteZaakSerializer(
+        many=True, required=False, help_text=_("Een lijst van relevante andere zaken.")
+    )
+
+    class Meta:
+        model = Zaak
+        fields = (
+            "url",
+            "uuid",
+            "identificatie",
+            "bronorganisatie",
+            "omschrijving",
+            "toelichting",
+            "zaaktype",
+            "registratiedatum",
+            "verantwoordelijke_organisatie",
+            "startdatum",
+            "einddatum",
+            "einddatum_gepland",
+            "uiterlijke_einddatum_afdoening",
+            "publicatiedatum",
+            "communicatiekanaal",
+            # TODO: add shape validator once we know the shape
+            "producten_of_diensten",
+            "vertrouwelijkheidaanduiding",
+            "betalingsindicatie",
+            "betalingsindicatie_weergave",
+            "laatste_betaaldatum",
+            "zaakgeometrie",
+            "verlenging",
+            "opschorting",
+            "selectielijstklasse",
+            "hoofdzaak",
+            "deelzaken",
+            "relevante_andere_zaken",
+            "eigenschappen",
+            # read-only veld, on-the-fly opgevraagd
+            "rollen",
+            "status",
+            "zaakinformatieobjecten",
+            "zaakobjecten",
+            # Writable inline resource, as opposed to eigenschappen for demo
+            # purposes. Eventually, we need to choose one form.
+            "kenmerken",
+            # Archiving
+            "archiefnominatie",
+            "archiefstatus",
+            "archiefactiedatum",
+            "resultaat",
+        )
+        extra_kwargs = {
+            "url": {"lookup_field": "uuid"},
+            "uuid": {"read_only": True},
+            "zaaktype": {
+                "lookup_field": "uuid",
+                "max_length": 1000,
+                "min_length": 1,
+                "validators": [
+                    LooseFkResourceValidator("ZaakType", settings.ZTC_API_SPEC),
+                    LooseFkIsImmutableValidator(),
+                    PublishValidator(),
+                ],
+            },
+            "zaakgeometrie": {
+                "help_text": "Punt, lijn of (multi-)vlak geometrie-informatie, in GeoJSON."
+            },
+            "identificatie": {"validators": [IsImmutableValidator()]},
+            "einddatum": {"read_only": True, "allow_null": True},
+            "communicatiekanaal": {
+                "validators": [
+                    ResourceValidator(
+                        "CommunicatieKanaal", settings.REFERENTIELIJSTEN_API_SPEC
+                    )
+                ]
+            },
+            "vertrouwelijkheidaanduiding": {
+                "required": False,
+                "help_text": _(
+                    "Aanduiding van de mate waarin het zaakdossier van de "
+                    "ZAAK voor de openbaarheid bestemd is. Optioneel - indien "
+                    "geen waarde gekozen wordt, dan wordt de waarde van het "
+                    "ZAAKTYPE overgenomen. Dit betekent dat de API _altijd_ een "
+                    "waarde teruggeeft."
+                ),
+            },
+            "selectielijstklasse": {
+                "validators": [
+                    ResourceValidator(
+                        "Resultaat",
+                        settings.REFERENTIELIJSTEN_API_SPEC,
+                        get_auth=get_auth,
+                    )
+                ]
+            },
+            "hoofdzaak": {
+                "lookup_field": "uuid",
+                "queryset": Zaak.objects.all(),
+                "validators": [NotSelfValidator(), HoofdzaakValidator()],
+            },
+            "laatste_betaaldatum": {"validators": [UntilNowValidator()]},
+        }
+        # Replace a default "unique together" constraint.
+        validators = [
+            UniekeIdentificatieValidator(),
+            ZaakArchiveIOsArchivedValidator(),
+        ]
+        expandable_fields = [
+            "status",
+            "resultaat",
+            "eigenschappen",
+            "rollen",
+            "zaakobjecten",
+            "zaakinformatieobjecten",
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        value_display_mapping = add_choice_values_help_text(BetalingsIndicatie)
+        self.fields["betalingsindicatie"].help_text += f"\n\n{value_display_mapping}"
+
+        value_display_mapping = add_choice_values_help_text(Archiefstatus)
+        self.fields["archiefstatus"].help_text += f"\n\n{value_display_mapping}"
+
+        value_display_mapping = add_choice_values_help_text(Archiefnominatie)
+        self.fields["archiefnominatie"].help_text += f"\n\n{value_display_mapping}"
+
+    def validate(self, attrs):
+        super().validate(attrs)
+
+        default_betalingsindicatie = (
+            self.instance.betalingsindicatie if self.instance else None
+        )
+        betalingsindicatie = attrs.get("betalingsindicatie", default_betalingsindicatie)
+        if betalingsindicatie == BetalingsIndicatie.nvt and attrs.get(
+            "laatste_betaaldatum"
+        ):
+            raise serializers.ValidationError(
+                {
+                    "laatste_betaaldatum": _(
+                        'Laatste betaaldatum kan niet gezet worden als de betalingsindicatie "nvt" is'
+                    )
+                },
+                code="betaling-nvt",
+            )
+
+        # check that productenOfDiensten are part of the ones on the zaaktype
+        default_zaaktype = self.instance.zaaktype if self.instance else None
+        zaaktype = attrs.get("zaaktype", default_zaaktype)
+        assert zaaktype, "Should not have passed validation - a zaaktype is needed"
+
+        producten_of_diensten = attrs.get("producten_of_diensten")
+        if producten_of_diensten:
+            if not set(producten_of_diensten).issubset(
+                set(zaaktype.producten_of_diensten)
+            ):
+                raise serializers.ValidationError(
+                    {
+                        "producten_of_diensten": _(
+                            "Niet alle producten/diensten komen voor in "
+                            "de producten/diensten op het zaaktype"
+                        )
+                    },
+                    code="invalid-products-services",
+                )
+
+        return attrs
+
+    def create(self, validated_data: dict):
+        # set the derived value from ZTC
+        if "vertrouwelijkheidaanduiding" not in validated_data:
+            zaaktype = validated_data["zaaktype"]
+            validated_data[
+                "vertrouwelijkheidaanduiding"
+            ] = zaaktype.vertrouwelijkheidaanduiding
+
         return super().create(validated_data)

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -35,6 +35,7 @@ from vng_api_common.validators import (
 
 from openzaak.components.documenten.api.fields import EnkelvoudigInformatieObjectField
 from openzaak.utils.api import create_remote_oio
+from openzaak.utils.apidoc import mark_oas_difference
 from openzaak.utils.auth import get_auth
 from openzaak.utils.exceptions import DetermineProcessEndDateException
 from openzaak.utils.serializers import ExpandSerializer
@@ -593,6 +594,7 @@ class ZaakSerializer(
         read_only=True,
         common_kwargs={"read_only": True,},
         default_serializer_kwargs={"lookup_field": "uuid", "view_name": "rol-detail",},
+        help_text=_("Lijst van gerelateerde ROLlen"),
     )
     status = ExpandSerializer(
         name="status",
@@ -619,6 +621,7 @@ class ZaakSerializer(
             "lookup_field": "uuid",
             "view_name": "zaakinformatieobject-detail",
         },
+        help_text=_("Lijst van gerelateerde ZAAKINFORMATIEOBJECTen"),
     )
     zaakobjecten = ExpandSerializer(
         name="zaakobjecten",
@@ -632,6 +635,7 @@ class ZaakSerializer(
             "lookup_field": "uuid",
             "view_name": "zaakobject-detail",
         },
+        help_text=_("Lijst van gerelateerde ZAAKOBJECTen"),
     )
 
     kenmerken = ZaakKenmerkSerializer(
@@ -814,6 +818,17 @@ class ZaakSerializer(
 
         value_display_mapping = add_choice_values_help_text(Archiefnominatie)
         self.fields["archiefnominatie"].help_text += f"\n\n{value_display_mapping}"
+
+        # Document OAS deviations from Zaken API standard
+        self.fields["rollen"].help_text = mark_oas_difference(
+            self.fields["rollen"].help_text
+        )
+        self.fields["zaakobjecten"].help_text = mark_oas_difference(
+            self.fields["zaakobjecten"].help_text
+        )
+        self.fields["zaakinformatieobjecten"].help_text = mark_oas_difference(
+            self.fields["zaakinformatieobjecten"].help_text
+        )
 
     def validate(self, attrs):
         super().validate(attrs)

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -571,11 +571,13 @@ class ZaakSerializer(
     serializers.HyperlinkedModelSerializer,
 ):
     eigenschappen = ExpandSerializer(
+        name="eigenschappen",
         source="zaakeigenschap_set",
         default_serializer=NestedHyperlinkedRelatedField,
         expanded_serializer=ZaakEigenschapSerializer,
+        many=True,
         read_only=True,
-        common_kwargs={"many": True, "read_only": True,},
+        common_kwargs={"read_only": True,},
         default_serializer_kwargs={
             "parent_lookup_kwargs": {"zaak_uuid": "zaak__uuid"},
             "lookup_field": "uuid",
@@ -583,14 +585,17 @@ class ZaakSerializer(
         },
     )
     rollen = ExpandSerializer(
+        name="rollen",
         source="rol_set",
         default_serializer=NestedHyperlinkedRelatedField,
         expanded_serializer=RolSerializer,
+        many=True,
         read_only=True,
-        common_kwargs={"many": True, "read_only": True,},
+        common_kwargs={"read_only": True,},
         default_serializer_kwargs={"lookup_field": "uuid", "view_name": "rol-detail",},
     )
     status = ExpandSerializer(
+        name="status",
         source="current_status",
         default_serializer=serializers.HyperlinkedRelatedField,
         expanded_serializer=StatusSerializer,
@@ -603,22 +608,26 @@ class ZaakSerializer(
         help_text=_("Indien geen status bekend is, dan is de waarde 'null'"),
     )
     zaakinformatieobjecten = ExpandSerializer(
+        name="zaakinformatieobjecten",
         source="zaakinformatieobject_set",
         default_serializer=NestedHyperlinkedRelatedField,
         expanded_serializer=ZaakInformatieObjectSerializer,
+        many=True,
         read_only=True,
-        common_kwargs={"many": True, "read_only": True,},
+        common_kwargs={"read_only": True,},
         default_serializer_kwargs={
             "lookup_field": "uuid",
             "view_name": "zaakinformatieobject-detail",
         },
     )
     zaakobjecten = ExpandSerializer(
+        name="zaakobjecten",
         source="zaakobject_set",
         default_serializer=NestedHyperlinkedRelatedField,
         expanded_serializer="openzaak.components.zaken.api.serializers.zaakobjecten.ZaakObjectSerializer",
+        many=True,
         read_only=True,
-        common_kwargs={"many": True, "read_only": True,},
+        common_kwargs={"read_only": True,},
         default_serializer_kwargs={
             "lookup_field": "uuid",
             "view_name": "zaakobject-detail",
@@ -665,6 +674,7 @@ class ZaakSerializer(
     )
 
     resultaat = ExpandSerializer(
+        name="resultaat",
         default_serializer=serializers.HyperlinkedRelatedField,
         expanded_serializer=ResultaatSerializer,
         read_only=True,

--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -217,6 +217,9 @@ class ZaakViewSet(
             models.Prefetch(
                 "status_set", queryset=Status.objects.order_by("-datum_status_gezet")
             ),
+            "rol_set",
+            "zaakobject_set",
+            "zaakinformatieobject_set",
         )
         .order_by("-pk")
     )

--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -8,6 +8,8 @@ from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
 
 from django_loose_fk.virtual_models import ProxyMixin
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import mixins, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied, ValidationError
@@ -243,6 +245,20 @@ class ZaakViewSet(
     }
     notifications_kanaal = KANAAL_ZAKEN
     audit = AUDIT_ZRC
+
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter(
+                "expand",
+                openapi.IN_QUERY,
+                description="Haal details van inline resources direct op.",
+                type=openapi.TYPE_STRING,
+                enum=ZaakSerializer.Meta.expandable_fields,
+            )
+        ]
+    )
+    def retrieve(self, request, *args, **kwargs):
+        return super().retrieve(request, *args, **kwargs)
 
     @action(methods=("post",), detail=False)
     def _zoek(self, request, *args, **kwargs):

--- a/src/openzaak/components/zaken/models/zaken.py
+++ b/src/openzaak/components/zaken/models/zaken.py
@@ -337,9 +337,9 @@ class Zaak(AuditTrailMixin, APIMixin, models.Model):
         super().save(*args, **kwargs)
 
     @property
-    def current_status_uuid(self):
+    def current_status(self):
         status = self.status_set.first()
-        return status.uuid if status else None
+        return status
 
     @property
     def is_closed(self) -> bool:

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -1913,6 +1913,19 @@ paths:
         required: false
         schema:
           type: string
+      - name: expand
+        in: query
+        description: Haal details van inline resources direct op.
+        required: false
+        schema:
+          type: string
+          enum:
+          - status
+          - resultaat
+          - eigenschappen
+          - rollen
+          - zaakobjecten
+          - zaakinformatieobjecten
       - name: ordering
         in: query
         description: Which field to use when ordering the results.
@@ -2214,6 +2227,18 @@ paths:
       summary: Een specifieke ZAAK opvragen.
       description: Een specifieke ZAAK opvragen.
       parameters:
+      - name: expand
+        in: query
+        description: Haal details van inline resources direct op.
+        schema:
+          type: string
+          enum:
+          - status
+          - resultaat
+          - eigenschappen
+          - rollen
+          - zaakobjecten
+          - zaakinformatieobjecten
       - name: Accept-Crs
         in: header
         description: Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
@@ -5849,6 +5874,33 @@ components:
           description: Een korte identificatie van de organisatorische eenheid.
           type: string
           minLength: 1
+        expand:
+          title: Expand
+          description: 'Haal details van inline resources direct op.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `status` - status
+
+            * `resultaat` - resultaat
+
+            * `eigenschappen` - eigenschappen
+
+            * `rollen` - rollen
+
+            * `zaakobjecten` - zaakobjecten
+
+            * `zaakinformatieobjecten` - zaakinformatieobjecten'
+          type: string
+          enum:
+          - status
+          - resultaat
+          - eigenschappen
+          - rollen
+          - zaakobjecten
+          - zaakinformatieobjecten
         ordering:
           title: Ordering
           description: Which field to use when ordering the results.

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -1915,7 +1915,7 @@ paths:
           type: string
       - name: expand
         in: query
-        description: Haal details van inline resources direct op.
+        description: '***AFWIJKING:** Haal details van inline resources direct op.'
         required: false
         schema:
           type: string
@@ -5547,8 +5547,10 @@ components:
           readOnly: true
           uniqueItems: true
         rollen:
+          description: '***AFWIJKING:** Lijst van gerelateerde ROLlen'
           type: array
           items:
+            description: Lijst van gerelateerde ROLlen
             type: string
             format: uri
           readOnly: true
@@ -5561,15 +5563,19 @@ components:
           readOnly: true
           nullable: true
         zaakinformatieobjecten:
+          description: '***AFWIJKING:** Lijst van gerelateerde ZAAKINFORMATIEOBJECTen'
           type: array
           items:
+            description: Lijst van gerelateerde ZAAKINFORMATIEOBJECTen
             type: string
             format: uri
           readOnly: true
           uniqueItems: true
         zaakobjecten:
+          description: '***AFWIJKING:** Lijst van gerelateerde ZAAKOBJECTen'
           type: array
           items:
+            description: Lijst van gerelateerde ZAAKOBJECTen
             type: string
             format: uri
           readOnly: true
@@ -5876,7 +5882,7 @@ components:
           minLength: 1
         expand:
           title: Expand
-          description: 'Haal details van inline resources direct op.
+          description: '***AFWIJKING:** Haal details van inline resources direct op.
 
 
             Uitleg bij mogelijke waarden:

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -5521,6 +5521,13 @@ components:
             format: uri
           readOnly: true
           uniqueItems: true
+        rollen:
+          type: array
+          items:
+            type: string
+            format: uri
+          readOnly: true
+          uniqueItems: true
         status:
           title: Status
           description: Indien geen status bekend is, dan is de waarde 'null'
@@ -5528,6 +5535,20 @@ components:
           format: uri
           readOnly: true
           nullable: true
+        zaakinformatieobjecten:
+          type: array
+          items:
+            type: string
+            format: uri
+          readOnly: true
+          uniqueItems: true
+        zaakobjecten:
+          type: array
+          items:
+            type: string
+            format: uri
+          readOnly: true
+          uniqueItems: true
         kenmerken:
           description: Lijst van kenmerken. Merk op dat refereren naar gerelateerde
             objecten beter kan via `ZaakObject`.

--- a/src/openzaak/components/zaken/resources.md
+++ b/src/openzaak/components/zaken/resources.md
@@ -215,10 +215,10 @@ Uitleg bij mogelijke waarden:
 | deelzaken | URL-referenties naar deel ZAAKen. | array | nee | ~~C~~​R​~~U~~​~~D~~ |
 | relevanteAndereZaken | Een lijst van relevante andere zaken. | array | nee | C​R​U​D |
 | eigenschappen |  | array | nee | ~~C~~​R​~~U~~​~~D~~ |
-| rollen |  | array | nee | ~~C~~​R​~~U~~​~~D~~ |
+| rollen | ***AFWIJKING:** Lijst van gerelateerde ROLlen | array | nee | ~~C~~​R​~~U~~​~~D~~ |
 | status | Indien geen status bekend is, dan is de waarde &#39;null&#39; | string | nee | ~~C~~​R​~~U~~​~~D~~ |
-| zaakinformatieobjecten |  | array | nee | ~~C~~​R​~~U~~​~~D~~ |
-| zaakobjecten |  | array | nee | ~~C~~​R​~~U~~​~~D~~ |
+| zaakinformatieobjecten | ***AFWIJKING:** Lijst van gerelateerde ZAAKINFORMATIEOBJECTen | array | nee | ~~C~~​R​~~U~~​~~D~~ |
+| zaakobjecten | ***AFWIJKING:** Lijst van gerelateerde ZAAKOBJECTen | array | nee | ~~C~~​R​~~U~~​~~D~~ |
 | kenmerken | Lijst van kenmerken. Merk op dat refereren naar gerelateerde objecten beter kan via `ZaakObject`. | array | nee | C​R​U​D |
 | archiefnominatie | Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde termijn vernietigd moet worden.
 

--- a/src/openzaak/components/zaken/resources.md
+++ b/src/openzaak/components/zaken/resources.md
@@ -215,7 +215,10 @@ Uitleg bij mogelijke waarden:
 | deelzaken | URL-referenties naar deel ZAAKen. | array | nee | ~~C~~​R​~~U~~​~~D~~ |
 | relevanteAndereZaken | Een lijst van relevante andere zaken. | array | nee | C​R​U​D |
 | eigenschappen |  | array | nee | ~~C~~​R​~~U~~​~~D~~ |
+| rollen |  | array | nee | ~~C~~​R​~~U~~​~~D~~ |
 | status | Indien geen status bekend is, dan is de waarde &#39;null&#39; | string | nee | ~~C~~​R​~~U~~​~~D~~ |
+| zaakinformatieobjecten |  | array | nee | ~~C~~​R​~~U~~​~~D~~ |
+| zaakobjecten |  | array | nee | ~~C~~​R​~~U~~​~~D~~ |
 | kenmerken | Lijst van kenmerken. Merk op dat refereren naar gerelateerde objecten beter kan via `ZaakObject`. | array | nee | C​R​U​D |
 | archiefnominatie | Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde termijn vernietigd moet worden.
 

--- a/src/openzaak/components/zaken/swagger2.0.json
+++ b/src/openzaak/components/zaken/swagger2.0.json
@@ -6876,6 +6876,15 @@
                     "readOnly": true,
                     "uniqueItems": true
                 },
+                "rollen": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    "readOnly": true,
+                    "uniqueItems": true
+                },
                 "status": {
                     "title": "Status",
                     "description": "Indien geen status bekend is, dan is de waarde 'null'",
@@ -6883,6 +6892,24 @@
                     "format": "uri",
                     "readOnly": true,
                     "x-nullable": true
+                },
+                "zaakinformatieobjecten": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    "readOnly": true,
+                    "uniqueItems": true
+                },
+                "zaakobjecten": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    "readOnly": true,
+                    "uniqueItems": true
                 },
                 "kenmerken": {
                     "description": "Lijst van kenmerken. Merk op dat refereren naar gerelateerde objecten beter kan via `ZaakObject`.",

--- a/src/openzaak/components/zaken/swagger2.0.json
+++ b/src/openzaak/components/zaken/swagger2.0.json
@@ -2593,6 +2593,21 @@
                         "type": "string"
                     },
                     {
+                        "name": "expand",
+                        "in": "query",
+                        "description": "Haal details van inline resources direct op.",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "status",
+                            "resultaat",
+                            "eigenschappen",
+                            "rollen",
+                            "zaakobjecten",
+                            "zaakinformatieobjecten"
+                        ]
+                    },
+                    {
                         "name": "ordering",
                         "in": "query",
                         "description": "Which field to use when ordering the results.",
@@ -2978,6 +2993,20 @@
                 "summary": "Een specifieke ZAAK opvragen.",
                 "description": "Een specifieke ZAAK opvragen.",
                 "parameters": [
+                    {
+                        "name": "expand",
+                        "in": "query",
+                        "description": "Haal details van inline resources direct op.",
+                        "type": "string",
+                        "enum": [
+                            "status",
+                            "resultaat",
+                            "eigenschappen",
+                            "rollen",
+                            "zaakobjecten",
+                            "zaakinformatieobjecten"
+                        ]
+                    },
                     {
                         "name": "Accept-Crs",
                         "in": "header",
@@ -7136,6 +7165,19 @@
                     "description": "Een korte identificatie van de organisatorische eenheid.",
                     "type": "string",
                     "minLength": 1
+                },
+                "expand": {
+                    "title": "Expand",
+                    "description": "Haal details van inline resources direct op.\n\nUitleg bij mogelijke waarden:\n\n* `status` - status\n* `resultaat` - resultaat\n* `eigenschappen` - eigenschappen\n* `rollen` - rollen\n* `zaakobjecten` - zaakobjecten\n* `zaakinformatieobjecten` - zaakinformatieobjecten",
+                    "type": "string",
+                    "enum": [
+                        "status",
+                        "resultaat",
+                        "eigenschappen",
+                        "rollen",
+                        "zaakobjecten",
+                        "zaakinformatieobjecten"
+                    ]
                 },
                 "ordering": {
                     "title": "Ordering",

--- a/src/openzaak/components/zaken/swagger2.0.json
+++ b/src/openzaak/components/zaken/swagger2.0.json
@@ -2595,7 +2595,7 @@
                     {
                         "name": "expand",
                         "in": "query",
-                        "description": "Haal details van inline resources direct op.",
+                        "description": "***AFWIJKING:** Haal details van inline resources direct op.",
                         "required": false,
                         "type": "string",
                         "enum": [
@@ -6906,8 +6906,10 @@
                     "uniqueItems": true
                 },
                 "rollen": {
+                    "description": "***AFWIJKING:** Lijst van gerelateerde ROLlen",
                     "type": "array",
                     "items": {
+                        "description": "Lijst van gerelateerde ROLlen",
                         "type": "string",
                         "format": "uri"
                     },
@@ -6923,8 +6925,10 @@
                     "x-nullable": true
                 },
                 "zaakinformatieobjecten": {
+                    "description": "***AFWIJKING:** Lijst van gerelateerde ZAAKINFORMATIEOBJECTen",
                     "type": "array",
                     "items": {
+                        "description": "Lijst van gerelateerde ZAAKINFORMATIEOBJECTen",
                         "type": "string",
                         "format": "uri"
                     },
@@ -6932,8 +6936,10 @@
                     "uniqueItems": true
                 },
                 "zaakobjecten": {
+                    "description": "***AFWIJKING:** Lijst van gerelateerde ZAAKOBJECTen",
                     "type": "array",
                     "items": {
+                        "description": "Lijst van gerelateerde ZAAKOBJECTen",
                         "type": "string",
                         "format": "uri"
                     },
@@ -7168,7 +7174,7 @@
                 },
                 "expand": {
                     "title": "Expand",
-                    "description": "Haal details van inline resources direct op.\n\nUitleg bij mogelijke waarden:\n\n* `status` - status\n* `resultaat` - resultaat\n* `eigenschappen` - eigenschappen\n* `rollen` - rollen\n* `zaakobjecten` - zaakobjecten\n* `zaakinformatieobjecten` - zaakinformatieobjecten",
+                    "description": "***AFWIJKING:** Haal details van inline resources direct op.\n\nUitleg bij mogelijke waarden:\n\n* `status` - status\n* `resultaat` - resultaat\n* `eigenschappen` - eigenschappen\n* `rollen` - rollen\n* `zaakobjecten` - zaakobjecten\n* `zaakinformatieobjecten` - zaakinformatieobjecten",
                     "type": "string",
                     "enum": [
                         "status",

--- a/src/openzaak/components/zaken/tests/test_auth.py
+++ b/src/openzaak/components/zaken/tests/test_auth.py
@@ -191,7 +191,7 @@ class ZaakListPerformanceTests(JWTAuthMixin, APITestCase):
         # queries because of the permission checks
         PERMISSION_CHECK_NUM_QUERIES = 2
         # queries because of the list endpoint itself
-        ENDPOINT_NUM_QUERIES = 8
+        ENDPOINT_NUM_QUERIES = 11
         TOTAL_EXPECTED_QUERIES = (
             BASE_NUM_QUERIES + PERMISSION_CHECK_NUM_QUERIES + ENDPOINT_NUM_QUERIES
         )

--- a/src/openzaak/components/zaken/tests/test_zaken.py
+++ b/src/openzaak/components/zaken/tests/test_zaken.py
@@ -39,8 +39,10 @@ from ..constants import BetalingsIndicatie
 from ..models import Medewerker, NatuurlijkPersoon, OrganisatorischeEenheid, Zaak
 from .constants import POLYGON_AMSTERDAM_CENTRUM
 from .factories import (
+    ResultaatFactory,
     RolFactory,
     StatusFactory,
+    ZaakEigenschapFactory,
     ZaakFactory,
     ZaakInformatieObjectFactory,
     ZaakObjectFactory,
@@ -995,3 +997,256 @@ class ZakenWerkVoorraadTests(JWTAuthMixin, APITestCase):
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual(response.data["count"], 1)
+
+
+class ZakenExpandTests(JWTAuthMixin, APITestCase):
+
+    scopes = [SCOPE_ZAKEN_CREATE, SCOPE_ZAKEN_BIJWERKEN, SCOPE_ZAKEN_ALLES_LEZEN]
+    component = ComponentTypes.zrc
+    maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.zaaktype = ZaakTypeFactory.create(concept=False)
+        cls.zaaktype_url = reverse(cls.zaaktype)
+        cls.statustype = StatusTypeFactory.create(zaaktype=cls.zaaktype)
+        cls.statustype_url = reverse(cls.statustype)
+        cls.statustype2 = StatusTypeFactory.create(zaaktype=cls.zaaktype)
+        cls.statustype2_url = reverse(cls.statustype2)
+
+        super().setUpTestData()
+
+    def test_list_expand(self):
+        zaak = ZaakFactory.create(startdatum="2019-01-01", zaaktype=self.zaaktype)
+        zaak_url = reverse(zaak)
+
+        # Create related resources
+        RolFactory.create_batch(2, zaak=zaak)
+        ZaakObjectFactory.create_batch(2, zaak=zaak)
+        ZaakInformatieObjectFactory.create_batch(2, zaak=zaak)
+        ZaakEigenschapFactory.create_batch(2, zaak=zaak)
+        zaak_status = StatusFactory.create(zaak=zaak)
+        resultaat = ResultaatFactory.create(zaak=zaak)
+
+        # Create unrelated resources
+        RolFactory.create_batch(2)
+        ZaakObjectFactory.create_batch(2)
+        ZaakInformatieObjectFactory.create_batch(2)
+        ZaakEigenschapFactory.create_batch(2)
+        StatusFactory.create_batch(2)
+        ResultaatFactory.create_batch(2)
+
+        url = reverse("zaak-list")
+
+        for resource in [
+            "status",
+            "resultaat",
+            "eigenschappen",
+            "rollen",
+            "zaakobjecten",
+            "zaakinformatieobjecten",
+        ]:
+            with self.subTest(resource=resource):
+                response = self.client.get(
+                    url, {"expand": resource}, **ZAAK_READ_KWARGS
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(response.data["count"], 1)
+
+                inline_resources = response.data["results"][0][resource]
+
+                if resource == "status":
+                    self.assertEqual(
+                        inline_resources["zaak"], f"http://testserver{zaak_url}"
+                    )
+                    self.assertEqual(inline_resources["uuid"], str(zaak_status.uuid))
+                elif resource == "resultaat":
+                    self.assertEqual(
+                        inline_resources["zaak"], f"http://testserver{zaak_url}"
+                    )
+                    self.assertEqual(inline_resources["uuid"], str(resultaat.uuid))
+                else:
+                    self.assertEqual(len(inline_resources), 2)
+                    self.assertEqual(
+                        *[r["zaak"] for r in inline_resources],
+                        f"http://testserver{zaak_url}",
+                    )
+
+    def test_list_expand_some(self):
+        zaak = ZaakFactory.create(startdatum="2019-01-01", zaaktype=self.zaaktype)
+        zaak_url = reverse(zaak)
+        RolFactory.create_batch(2, zaak=zaak)
+        ZaakObjectFactory.create_batch(2, zaak=zaak)
+        ZaakInformatieObjectFactory.create_batch(2, zaak=zaak)
+
+        # Create unrelated resources
+        RolFactory.create_batch(2)
+        ZaakObjectFactory.create_batch(2)
+        ZaakInformatieObjectFactory.create_batch(2)
+
+        url = reverse("zaak-list")
+
+        # for resource in ["rollen", "zaakobjecten", "zaakinformatieobjecten"]:
+        response = self.client.get(
+            url,
+            {"expand": ["zaakobjecten", "zaakinformatieobjecten"]},
+            **ZAAK_READ_KWARGS,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+        zaakobjecten = response.data["results"][0]["zaakobjecten"]
+        self.assertEqual(len(zaakobjecten), 2)
+        self.assertEqual(
+            *[r["zaak"] for r in zaakobjecten], f"http://testserver{zaak_url}",
+        )
+
+        zaakinformatieobjecten = response.data["results"][0]["zaakinformatieobjecten"]
+        self.assertEqual(len(zaakinformatieobjecten), 2)
+        self.assertEqual(
+            *[r["zaak"] for r in zaakinformatieobjecten],
+            f"http://testserver{zaak_url}",
+        )
+
+        # Rollen should not be expanded
+        rollen = response.data["results"][0]["rollen"]
+        self.assertEqual(len(rollen), 2)
+        self.assertTrue(*[isinstance(r, str) for r in rollen])
+
+    def test_list_expand_all(self):
+        zaak = ZaakFactory.create(startdatum="2019-01-01", zaaktype=self.zaaktype)
+        zaak_url = reverse(zaak)
+
+        # Create related resources
+        RolFactory.create_batch(2, zaak=zaak)
+        ZaakObjectFactory.create_batch(2, zaak=zaak)
+        ZaakInformatieObjectFactory.create_batch(2, zaak=zaak)
+        ZaakEigenschapFactory.create_batch(2, zaak=zaak)
+        zaak_status = StatusFactory.create(zaak=zaak)
+        resultaat = ResultaatFactory.create(zaak=zaak)
+
+        # Create unrelated resources
+        RolFactory.create_batch(2)
+        ZaakObjectFactory.create_batch(2)
+        ZaakInformatieObjectFactory.create_batch(2)
+        ZaakEigenschapFactory.create_batch(2)
+        StatusFactory.create_batch(2)
+        ResultaatFactory.create_batch(2)
+
+        url = reverse(Zaak)
+
+        resources = [
+            "status",
+            "resultaat",
+            "eigenschappen",
+            "rollen",
+            "zaakobjecten",
+            "zaakinformatieobjecten",
+        ]
+
+        response = self.client.get(url, {"expand": resources}, **ZAAK_READ_KWARGS)
+
+        for resource in resources:
+            with self.subTest(resource=resource):
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(response.data["count"], 1)
+
+                inline_resources = response.data["results"][0][resource]
+
+                if resource == "status":
+                    self.assertEqual(
+                        inline_resources["zaak"], f"http://testserver{zaak_url}"
+                    )
+                    self.assertEqual(inline_resources["uuid"], str(zaak_status.uuid))
+                elif resource == "resultaat":
+                    self.assertEqual(
+                        inline_resources["zaak"], f"http://testserver{zaak_url}"
+                    )
+                    self.assertEqual(inline_resources["uuid"], str(resultaat.uuid))
+                else:
+                    self.assertEqual(len(inline_resources), 2)
+                    self.assertEqual(
+                        *[r["zaak"] for r in inline_resources],
+                        f"http://testserver{zaak_url}",
+                    )
+
+    def test_detail_expand(self):
+        zaak = ZaakFactory.create(startdatum="2019-01-01", zaaktype=self.zaaktype)
+        zaak_url = reverse(zaak)
+
+        # Create related resources
+        RolFactory.create_batch(2, zaak=zaak)
+        ZaakObjectFactory.create_batch(2, zaak=zaak)
+        ZaakInformatieObjectFactory.create_batch(2, zaak=zaak)
+        ZaakEigenschapFactory.create_batch(2, zaak=zaak)
+        zaak_status = StatusFactory.create(zaak=zaak)
+        resultaat = ResultaatFactory.create(zaak=zaak)
+
+        # Create unrelated resources
+        RolFactory.create_batch(2)
+        ZaakObjectFactory.create_batch(2)
+        ZaakInformatieObjectFactory.create_batch(2)
+        ZaakEigenschapFactory.create_batch(2)
+        StatusFactory.create_batch(2)
+        ResultaatFactory.create_batch(2)
+
+        url = reverse(zaak)
+
+        for resource in [
+            "status",
+            "resultaat",
+            "eigenschappen",
+            "rollen",
+            "zaakobjecten",
+            "zaakinformatieobjecten",
+        ]:
+            with self.subTest(resource=resource):
+                response = self.client.get(
+                    url, {"expand": resource}, **ZAAK_READ_KWARGS
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                inline_resources = response.data[resource]
+
+                if resource == "status":
+                    self.assertEqual(
+                        inline_resources["zaak"], f"http://testserver{zaak_url}"
+                    )
+                    self.assertEqual(inline_resources["uuid"], str(zaak_status.uuid))
+                elif resource == "resultaat":
+                    self.assertEqual(
+                        inline_resources["zaak"], f"http://testserver{zaak_url}"
+                    )
+                    self.assertEqual(inline_resources["uuid"], str(resultaat.uuid))
+                else:
+                    self.assertEqual(len(inline_resources), 2)
+                    self.assertEqual(
+                        *[r["zaak"] for r in inline_resources],
+                        f"http://testserver{zaak_url}",
+                    )
+
+    def test_list_expand_invalid_parameter(self):
+        ZaakFactory.create(startdatum="2019-01-01", zaaktype=self.zaaktype)
+
+        url = reverse(Zaak)
+
+        response = self.client.get(url, {"expand": "foo"}, **ZAAK_READ_KWARGS)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "expand")
+        self.assertEqual(error["code"], "invalid_choice")
+
+    def test_detail_expand_invalid_parameter(self):
+        zaak = ZaakFactory.create(startdatum="2019-01-01", zaaktype=self.zaaktype)
+
+        url = reverse(zaak)
+
+        response = self.client.get(url, {"expand": "foo"}, **ZAAK_READ_KWARGS)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "expand")
+        self.assertEqual(error["code"], "invalid_choice")

--- a/src/openzaak/utils/apidoc.py
+++ b/src/openzaak/utils/apidoc.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: EUPL-1.2
-# Copyright (C) 2019 - 2020 Dimpact
+# Copyright (C) 2019 - 2021 Dimpact
 DOC_AUTH_JWT = """
 ### Autorisatie
 
@@ -35,3 +35,19 @@ UNIX-timestamp die aangeeft op welk moment het token gegenereerd is.
 vrije velden met als enige beperking dat de lengte maximaal de lengte van
 de overeenkomstige velden in de audit trail resources is (zie rest API spec).
 """
+
+
+DOC_OAS_DIFFERENCES = """
+### API specificatie afwijkingen
+
+Afwijkingen in de API specificatie ten opzichte van de referentie API specificatie
+zijn aangemerkt met ***AFWIJKING:**
+"""
+
+
+def mark_oas_difference(help_text):
+    """
+    Indicate in help_text that the feature is a deviation from the reference
+    API specification
+    """
+    return f"***AFWIJKING:** {help_text}"

--- a/src/openzaak/utils/filters.py
+++ b/src/openzaak/utils/filters.py
@@ -23,3 +23,17 @@ class MaximaleVertrouwelijkheidaanduidingFilter(filters.ChoiceFilter):
         qs = qs.annotate(**{self.field_name: order_expression})
         numeric_value = VertrouwelijkheidsAanduiding.get_choice(value).order
         return super().filter(qs, numeric_value)
+
+
+# TODO move to vng-api-common
+class ExpandFilter(filters.ChoiceFilter):
+    def __init__(self, *args, **kwargs):
+        serializer_class = kwargs.pop("serializer_class")
+        kwargs.setdefault(
+            "choices", [(x, x) for x in serializer_class.Meta.expandable_fields]
+        )
+
+        super().__init__(*args, **kwargs)
+
+    def filter(self, qs, value):
+        return qs

--- a/src/openzaak/utils/serializers.py
+++ b/src/openzaak/utils/serializers.py
@@ -37,6 +37,9 @@ class ConvertNoneMixin:
 # TODO move to vng-api-common
 class ExpandSerializer(NestedHyperlinkedRelatedField):
     def __init__(self, *args, **kwargs):
+        # For some reason self.field_name is empty for `many=True`
+        self.name = kwargs.pop("name")
+
         self.default_serializer = kwargs.pop("default_serializer")
         self.expanded_serializer = kwargs.pop("expanded_serializer")
 
@@ -62,7 +65,7 @@ class ExpandSerializer(NestedHyperlinkedRelatedField):
 
         if hasattr(self.context["request"], "query_params"):
             expand = self.context["request"].query_params.getlist("expand")
-            if self.field_name in expand:
+            if self.name in expand:
                 serializer_class = self.expanded_serializer
                 if isinstance(self.expanded_serializer, str):
                     serializer_class = import_string(self.expanded_serializer)

--- a/src/openzaak/utils/serializers.py
+++ b/src/openzaak/utils/serializers.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
+from django.utils.module_loading import import_string
+
 from rest_framework import fields as drf_fields
+from rest_framework_nested.serializers import NestedHyperlinkedRelatedField
 
 
 class ConvertNoneMixin:
@@ -29,3 +32,44 @@ class ConvertNoneMixin:
                 representation[field.field_name] = ""
 
         return representation
+
+
+# TODO move to vng-api-common
+class ExpandSerializer(NestedHyperlinkedRelatedField):
+    def __init__(self, *args, **kwargs):
+        self.default_serializer = kwargs.pop("default_serializer")
+        self.expanded_serializer = kwargs.pop("expanded_serializer")
+
+        self.default_serializer_kwargs = kwargs.pop("default_serializer_kwargs", {})
+        self.expanded_serializer_kwargs = kwargs.pop("expanded_serializer_kwargs", {})
+
+        # Update the serializer specific kwargs with the kwargs used for all
+        # serializers
+        common_kwargs = kwargs.pop("common_kwargs")
+        self.default_serializer_kwargs.update(common_kwargs)
+        self.expanded_serializer_kwargs.update(common_kwargs)
+
+        kwargs.update(self.default_serializer_kwargs)
+
+        super().__init__(*args, **kwargs)
+
+    def to_representation(self, value):
+        serializer_class = self.default_serializer
+        if isinstance(self.default_serializer, str):
+            serializer_class = import_string(self.default_serializer)
+        serializer = serializer_class(**self.default_serializer_kwargs)
+        serializer.parent = self
+
+        if hasattr(self.context["request"], "query_params"):
+            expand = self.context["request"].query_params.getlist("expand")
+            if self.field_name in expand:
+                serializer_class = self.expanded_serializer
+                if isinstance(self.expanded_serializer, str):
+                    serializer_class = import_string(self.expanded_serializer)
+                serializer = serializer_class(**self.expanded_serializer_kwargs)
+                serializer.parent = self
+
+        if self.default_serializer_kwargs.get("many", False):
+            value = value.all()
+
+        return serializer.to_representation(value)


### PR DESCRIPTION
Fixes #1044

PR in reference implementation has been merged: https://github.com/VNG-Realisatie/zaken-api/pull/207

**Changes**
* Add `rollen`, `zaakobjecten` and `zaakinformatieobjecten` fields to `ZAAK` resource
* Add `expand` queryparameter, that retrieves the details of specified resources inline. Example: `?expand=status&expand=rollen`
    * Expandable fields:
      * `Zaak.status`
      * `Zaak.resultaat`
      * `Zaak.eigenschappen`
      * `Zaak.rollen`
      * `Zaak.zaakobjecten`
      * `Zaak.zaakinformatieobjecten`

TODO:
- [ ] Validate that user has correct permissions?
- [ ] Expand deelzaken?
