### PR TITLE
:mute: Do not output logging for caught API errors

### DIFF
--- a/src/openzaak/notifications/tests/utils.py
+++ b/src/openzaak/notifications/tests/utils.py
@@ -24,6 +24,11 @@ LOGGING_SETTINGS = {
             "level": "WARNING",
             "propagate": False,
         },
+        "vng_api_common.exception_handling": {
+            "handlers": [],
+            "level": "CRITICAL",
+            "propagate": False,
+        },
     },
 }
 


### PR DESCRIPTION
HTTP 4xx and HTTP 5xx can be expected at times. If the exception
is caught, we should not be seeing a traceback in CI for this.
