### PR TITLE
:arrow_up: Bump Django, babel and sqlparse

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -89,7 +89,7 @@ django-solo==1.1.3
     #   mozilla-django-oidc-db
     #   vng-api-common
     #   zgw-consumers
-django==2.2.24
+django==2.2.25
     # via
     #   -r requirements/base.in
     #   django-auth-adfs
@@ -242,7 +242,7 @@ six==1.11.0
     #   mozilla-django-oidc
     #   pyopenssl
     #   python-dateutil
-sqlparse==0.3.0
+sqlparse==0.4.2
     # via django
 unidecode==1.0.22
     # via vng-api-common

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -129,7 +129,7 @@ django-solo==1.1.3
     #   zgw-consumers
 django-webtest==1.9.7
     # via -r requirements/test-tools.in
-django==2.2.24
+django==2.2.25
     # via
     #   -r requirements/base.txt
     #   django-auth-adfs
@@ -359,7 +359,7 @@ six==1.11.0
     #   webtest
 soupsieve==1.9.5
     # via beautifulsoup4
-sqlparse==0.3.0
+sqlparse==0.4.2
     # via
     #   -r requirements/base.txt
     #   django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,7 +21,7 @@ attrs==19.3.0
     #   jsonschema
 autopep8==1.5.2
     # via django-silk
-babel==2.7.0
+babel==2.9.1
     # via sphinx
 beautifulsoup4==4.8.1
     # via
@@ -161,7 +161,7 @@ django-solo==1.1.3
     #   zgw-consumers
 django-webtest==1.9.7
     # via -r requirements/ci.txt
-django==2.2.24
+django==2.2.25
     # via
     #   -r requirements/ci.txt
     #   django-auth-adfs
@@ -518,7 +518,7 @@ sphinxcontrib-qthelp==1.0.2
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.3
     # via sphinx
-sqlparse==0.3.0
+sqlparse==0.4.2
     # via
     #   -r requirements/ci.txt
     #   django


### PR DESCRIPTION
**Changes**

* Bumped to Django 2.2.25
* Bumped to sqlparse 0.4.2
* Bump dev dependency Babel to 2.9.1

