### PR TITLE
:lock: Check JWT expiry for audittrails and nested Zaak resources

### DIFF
--- a/src/openzaak/components/besluiten/api/viewsets.py
+++ b/src/openzaak/components/besluiten/api/viewsets.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: EUPL-1.2
-# Copyright (C) 2019 - 2020 Dimpact
+# Copyright (C) 2019 - 2022 Dimpact
 from django.db import transaction
 from django.utils.translation import ugettext_lazy as _
 
@@ -24,6 +24,7 @@ from openzaak.components.zaken.api.mixins import ClosedZaakMixin
 from openzaak.components.zaken.api.utils import delete_remote_zaakbesluit
 from openzaak.utils.api import delete_remote_oio
 from openzaak.utils.data_filtering import ListFilterByAuthorizationsMixin
+from openzaak.utils.permissions import AuthRequired
 
 from ..models import Besluit, BesluitInformatieObject
 from .audits import AUDIT_BRC
@@ -283,3 +284,4 @@ class BesluitAuditTrailViewSet(AuditTrailViewSet):
     """
 
     main_resource_lookup_field = "besluit_uuid"
+    permission_classes = (AuthRequired,)

--- a/src/openzaak/components/besluiten/tests/test_audittrails.py
+++ b/src/openzaak/components/besluiten/tests/test_audittrails.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: EUPL-1.2
-# Copyright (C) 2019 - 2020 Dimpact
+# Copyright (C) 2019 - 2022 Dimpact
 from copy import deepcopy
 
+from django.test import override_settings
+from django.utils import timezone
+
+from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.test import APITestCase
 from vng_api_common.audittrails.models import AuditTrail
@@ -12,9 +16,10 @@ from openzaak.components.catalogi.tests.factories import BesluitTypeFactory
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.utils.tests import JWTAuthMixin
+from openzaak.utils.tests import JWTAuthMixin, generate_jwt_auth
 
 from ..models import Besluit, BesluitInformatieObject
+from .factories import BesluitFactory
 
 
 class AuditTrailTests(JWTAuthMixin, APITestCase):
@@ -206,3 +211,54 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Verify that the resource weergave stored in the AuditTrail matches
         # the unique representation as defined in the besluit model
         self.assertIn(audittrail.resource_weergave, besluit_unique_representation)
+
+
+class BesluitAuditTrailJWTExpiryTests(JWTAuthMixin, APITestCase):
+    heeft_alle_autorisaties = True
+
+    @freeze_time("2019-01-01T12:00:00")
+    def setUp(self):
+        super().setUp()
+        token = generate_jwt_auth(
+            self.client_id,
+            self.secret,
+            user_id=self.user_id,
+            user_representation=self.user_representation,
+            nbf=int(timezone.now().timestamp()),
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=token)
+
+    @override_settings(JWT_EXPIRY=60 * 60)
+    @freeze_time("2019-01-01T13:00:00")
+    def test_besluit_audittrail_list_jwt_expired(self):
+        besluit = BesluitFactory.create()
+        url = reverse(besluit)
+
+        AuditTrail.objects.create(hoofd_object=url, resource="Besluit", resultaat=200)
+
+        audit_url = reverse("audittrail-list", kwargs={"besluit_uuid": besluit.uuid},)
+
+        response = self.client.get(audit_url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data["code"], "jwt-expired")
+
+    @override_settings(JWT_EXPIRY=60 * 60)
+    @freeze_time("2019-01-01T13:00:00")
+    def test_besluit_audittrail_detail_jwt_expired(self):
+        besluit = BesluitFactory.create()
+        url = reverse(besluit)
+
+        audittrail = AuditTrail.objects.create(
+            hoofd_object=url, resource="Besluit", resultaat=200
+        )
+
+        audit_url = reverse(
+            "audittrail-detail",
+            kwargs={"besluit_uuid": besluit.uuid, "uuid": audittrail.uuid},
+        )
+
+        response = self.client.get(audit_url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data["code"], "jwt-expired")

--- a/src/openzaak/components/documenten/api/viewsets.py
+++ b/src/openzaak/components/documenten/api/viewsets.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: EUPL-1.2
-# Copyright (C) 2019 - 2020 Dimpact
+# Copyright (C) 2019 - 2022 Dimpact
 from django.conf import settings
 from django.db import transaction
 from django.http import FileResponse
@@ -24,6 +24,7 @@ from vng_api_common.viewsets import CheckQueryParamsMixin
 
 from openzaak.utils.data_filtering import ListFilterByAuthorizationsMixin
 from openzaak.utils.mixins import CMISConnectionPoolMixin, ConvertCMISAdapterExceptions
+from openzaak.utils.permissions import AuthRequired
 from openzaak.utils.schema import COMMON_ERROR_RESPONSES, use_ref
 
 from ..models import (
@@ -429,6 +430,7 @@ class EnkelvoudigInformatieObjectAuditTrailViewSet(
     """
 
     main_resource_lookup_field = "enkelvoudiginformatieobject_uuid"
+    permission_classes = (AuthRequired,)
 
 
 class ObjectInformatieObjectViewSet(

--- a/src/openzaak/components/documenten/tests/test_audittrails.py
+++ b/src/openzaak/components/documenten/tests/test_audittrails.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: EUPL-1.2
-# Copyright (C) 2019 - 2020 Dimpact
+# Copyright (C) 2019 - 2022 Dimpact
 import uuid
 from base64 import b64encode
 from datetime import datetime
+
+from django.test import override_settings
+from django.utils import timezone
 
 from freezegun import freeze_time
 from rest_framework import status
@@ -12,7 +15,7 @@ from vng_api_common.tests import reverse, reverse_lazy
 from vng_api_common.utils import get_uuid_from_path
 
 from openzaak.components.catalogi.tests.factories import InformatieObjectTypeFactory
-from openzaak.utils.tests import JWTAuthMixin
+from openzaak.utils.tests import JWTAuthMixin, generate_jwt_auth
 
 from ..models import (
     EnkelvoudigInformatieObject,
@@ -293,3 +296,61 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Verify that the resource weergave stored in the AuditTrail matches
         # the unique representation as defined in the Zaak model
         self.assertIn(audittrail.resource_weergave, eio_unique_representation)
+
+
+class EnkelvoudigInformatieObjectAuditTrailJWTExpiryTests(JWTAuthMixin, APITestCase):
+    heeft_alle_autorisaties = True
+
+    @freeze_time("2019-01-01T12:00:00")
+    def setUp(self):
+        super().setUp()
+        token = generate_jwt_auth(
+            self.client_id,
+            self.secret,
+            user_id=self.user_id,
+            user_representation=self.user_representation,
+            nbf=int(timezone.now().timestamp()),
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=token)
+
+    @override_settings(JWT_EXPIRY=60 * 60)
+    @freeze_time("2019-01-01T13:00:00")
+    def test_eio_audittrail_list_jwt_expired(self):
+        eio = EnkelvoudigInformatieObjectFactory.create()
+        url = reverse(eio)
+
+        AuditTrail.objects.create(
+            hoofd_object=url, resource="EnkelvoudigInformatieObject", resultaat=200
+        )
+
+        audit_url = reverse(
+            "audittrail-list", kwargs={"enkelvoudiginformatieobject_uuid": eio.uuid},
+        )
+
+        response = self.client.get(audit_url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data["code"], "jwt-expired")
+
+    @override_settings(JWT_EXPIRY=60 * 60)
+    @freeze_time("2019-01-01T13:00:00")
+    def test_eio_audittrail_detail_jwt_expired(self):
+        eio = EnkelvoudigInformatieObjectFactory.create()
+        url = reverse(eio)
+
+        audittrail = AuditTrail.objects.create(
+            hoofd_object=url, resource="EnkelvoudigInformatieObject", resultaat=200
+        )
+
+        audit_url = reverse(
+            "audittrail-detail",
+            kwargs={
+                "enkelvoudiginformatieobject_uuid": eio.uuid,
+                "uuid": audittrail.uuid,
+            },
+        )
+
+        response = self.client.get(audit_url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data["code"], "jwt-expired")

--- a/src/openzaak/components/zaken/api/permissions.py
+++ b/src/openzaak/components/zaken/api/permissions.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: EUPL-1.2
-# Copyright (C) 2019 - 2020 Dimpact
+# Copyright (C) 2019 - 2022 Dimpact
 from rest_framework.request import Request
 from vng_api_common.permissions import bypass_permissions, get_required_scopes
 
@@ -20,6 +20,9 @@ class ZaakNestedAuthRequired(ZaakAuthRequired):
     def has_permission(self, request: Request, view) -> bool:
         if bypass_permissions(request):
             return True
+
+        # JWTs are only valid for a short amount of time
+        self.check_jwt_expiry(request.jwt_auth.payload)
 
         scopes_required = get_required_scopes(view)
         component = self.get_component(view)

--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: EUPL-1.2
-# Copyright (C) 2019 - 2020 Dimpact
+# Copyright (C) 2019 - 2022 Dimpact
 import logging
 
 from django.db import models, transaction
@@ -35,6 +35,7 @@ from zgw_consumers.models import Service
 
 from openzaak.utils.api import delete_remote_oio
 from openzaak.utils.data_filtering import ListFilterByAuthorizationsMixin
+from openzaak.utils.permissions import AuthRequired
 
 from ..models import (
     KlantContact,
@@ -845,6 +846,7 @@ class ZaakAuditTrailViewSet(AuditTrailViewSet):
     """
 
     main_resource_lookup_field = "zaak_uuid"
+    permission_classes = (AuthRequired,)
 
 
 class ZaakBesluitViewSet(

--- a/src/openzaak/components/zaken/tests/test_zaakeigenschap.py
+++ b/src/openzaak/components/zaken/tests/test_zaakeigenschap.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: EUPL-1.2
-# Copyright (C) 2019 - 2020 Dimpact
+# Copyright (C) 2019 - 2022 Dimpact
 """
 Als behandelaar wil ik locatie- en/of objectinformatie bij de melding
 ontvangen, zodat ik voldoende details weet om de melding op te volgen.
@@ -7,14 +7,16 @@ ontvangen, zodat ik voldoende details weet om de melding op te volgen.
 ref: https://github.com/VNG-Realisatie/gemma-zaken/issues/52
 """
 from django.test import override_settings, tag
+from django.utils import timezone
 
 import requests_mock
+from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.test import APITestCase
 from vng_api_common.tests import TypeCheckMixin, get_validation_errors, reverse
 
 from openzaak.components.catalogi.tests.factories import EigenschapFactory
-from openzaak.utils.tests import JWTAuthMixin
+from openzaak.utils.tests import JWTAuthMixin, generate_jwt_auth
 
 from ..models import ZaakEigenschap
 from .factories import ZaakEigenschapFactory, ZaakFactory
@@ -221,3 +223,63 @@ class ZaakEigenschapCreateExternalURLsTests(JWTAuthMixin, APITestCase):
 
         error = get_validation_errors(response, "nonFieldErrors")
         self.assertEqual(error["code"], "zaaktype-mismatch")
+
+
+class ZaakEigenschapJWTExpiryTests(JWTAuthMixin, APITestCase):
+    heeft_alle_autorisaties = True
+
+    @freeze_time("2019-01-01T12:00:00")
+    def setUp(self):
+        super().setUp()
+        token = generate_jwt_auth(
+            self.client_id,
+            self.secret,
+            user_id=self.user_id,
+            user_representation=self.user_representation,
+            nbf=int(timezone.now().timestamp()),
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=token)
+
+    @override_settings(JWT_EXPIRY=60 * 60)
+    @freeze_time("2019-01-01T13:00:00")
+    def test_zaakeigenschap_list_jwt_expired(self):
+        zaak = ZaakFactory.create()
+        url = reverse("zaakeigenschap-list", kwargs={"zaak_uuid": zaak.uuid})
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data["code"], "jwt-expired")
+
+    @override_settings(JWT_EXPIRY=60 * 60)
+    @freeze_time("2019-01-01T13:00:00")
+    def test_zaakeigenschap_detail_jwt_expired(self):
+        eigenschap = ZaakEigenschapFactory.create()
+        url = reverse(
+            "zaakeigenschap-detail",
+            kwargs={"zaak_uuid": eigenschap.zaak.uuid, "uuid": eigenschap.uuid},
+        )
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data["code"], "jwt-expired")
+
+    @override_settings(JWT_EXPIRY=60 * 60)
+    @freeze_time("2019-01-01T13:00:00")
+    def test_zaakeigenschap_create_jwt_expired(self):
+        zaak = ZaakFactory.create()
+        eigenschap = EigenschapFactory.create(eigenschapnaam="foobar")
+        url = get_operation_url("zaakeigenschap_create", zaak_uuid=zaak.uuid)
+        zaak_url = get_operation_url("zaak_read", uuid=zaak.uuid)
+        eigenschap_url = reverse(eigenschap)
+        data = {
+            "zaak": zaak_url,
+            "eigenschap": f"http://testserver{eigenschap_url}",
+            "waarde": "overlast_water",
+        }
+
+        response = self.client.post(url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data["code"], "jwt-expired")


### PR DESCRIPTION
Fixes: https://github.com/open-zaak/security-issues/issues/3

**Changes**

* Use the proper permission_classes for audittrail viewsets, to enable checking for expired JWTs
* Check JWT expiry for nested Zaak resources

