### PR TITLE
Update base images to bullseye-slim from stretch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,9 +5,12 @@ docker-compose*
 .git
 .vscode
 env/
+
 private-media/
 media/
+static/
 log/
+
 .env
 includes/local.py
 volumes/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ env:
   DB_PASSWORD: ''
   DB_USER: postgres
   ALLOWED_HOSTS: openzaak.nl
+  COMPOSE_DOCKER_CLI_BUILD: '1'
+  DOCKER_BUILDKIT: '1'
 
 jobs:
   # determine changed files to decide if certain jobs can be skipped or not


### PR DESCRIPTION
Related to #1097 -- the base images have been updated from Debian oldoldstable to
stable. Django support for libgdal 3.x has been confirmed in later
releases without code modifications.

Additionally, some dockerfile lines have been moved around for better cache
utilization.