### PR TITLE
Fix styles broken by bootstrap

### DIFF
--- a/src/openzaak/sass/admin/_admin_theme.scss
+++ b/src/openzaak/sass/admin/_admin_theme.scss
@@ -42,6 +42,11 @@ DO NOT PUT ANY TARGET APP-SPECIFIC RULES HERE.
 
 /* Overrides */
 
+// bootstrap is included in some pages, which messes everything up again with the reset...
+body {
+  font-size: 14px;
+}
+
 /**
  * Branding
  */

--- a/src/openzaak/sass/admin/_vendor.scss
+++ b/src/openzaak/sass/admin/_vendor.scss
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: EUPL-1.2 */
+/* Copyright (C) 2022 Dimpact */
+// bootstrap reverts
+.btn {
+  &-primary {
+    background-color: var(--button-bg);
+    border-color: var(--button-bg);
+
+    &:hover {
+      background-color: var(--button-hover-bg);
+      border-color: var(--button-hover-bg);
+    }
+  }
+}

--- a/src/openzaak/sass/admin/admin_overrides.scss
+++ b/src/openzaak/sass/admin/admin_overrides.scss
@@ -4,3 +4,5 @@
 @import "app_overrides";
 
 @import "components/all";
+
+@import "vendor";

--- a/src/openzaak/templates/admin/base.html
+++ b/src/openzaak/templates/admin/base.html
@@ -1,0 +1,108 @@
+{% comment %} SPDX-License-Identifier: EUPL-1.2 {% endcomment %}
+{% comment %} Copyright (C) 2022 Dimpact {% endcomment %}
+{# Template overriden to add an extra block before the closing body tag, for bootstrap modals. #}
+{% load i18n static %}<!DOCTYPE html>
+{% get_current_language as LANGUAGE_CODE %}{% get_current_language_bidi as LANGUAGE_BIDI %}
+<html lang="{{ LANGUAGE_CODE|default:"en-us" }}" dir="{{ LANGUAGE_BIDI|yesno:'rtl,ltr,auto' }}">
+<head>
+<title>{% block title %}{% endblock %}</title>
+<link rel="stylesheet" type="text/css" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}">
+{% if not is_popup and is_nav_sidebar_enabled %}
+  <link rel="stylesheet" type="text/css" href="{% static "admin/css/nav_sidebar.css" %}">
+  <script src="{% static 'admin/js/nav_sidebar.js' %}" defer></script>
+{% endif %}
+{% block extrastyle %}{% endblock %}
+{% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% block stylesheet_rtl %}{% static "admin/css/rtl.css" %}{% endblock %}">{% endif %}
+{% block extrahead %}{% endblock %}
+{% block responsive %}
+    <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <link rel="stylesheet" type="text/css" href="{% static "admin/css/responsive.css" %}">
+    {% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% static "admin/css/responsive_rtl.css" %}">{% endif %}
+{% endblock %}
+{% block blockbots %}<meta name="robots" content="NONE,NOARCHIVE">{% endblock %}
+</head>
+{% load i18n %}
+
+<body class="{% if is_popup %}popup {% endif %}{% block bodyclass %}{% endblock %}"
+  data-admin-utc-offset="{% now "Z" %}">
+
+<!-- Container -->
+<div id="container">
+
+    {% if not is_popup %}
+    <!-- Header -->
+    <div id="header">
+        <div id="branding">
+        {% block branding %}{% endblock %}
+        </div>
+        {% block usertools %}
+        {% if has_permission %}
+        <div id="user-tools">
+            {% block welcome-msg %}
+                {% translate 'Welcome,' %}
+                <strong>{% firstof user.get_short_name user.get_username %}</strong>.
+            {% endblock %}
+            {% block userlinks %}
+                {% if site_url %}
+                    <a href="{{ site_url }}">{% translate 'View site' %}</a> /
+                {% endif %}
+                {% if user.is_active and user.is_staff %}
+                    {% url 'django-admindocs-docroot' as docsroot %}
+                    {% if docsroot %}
+                        <a href="{{ docsroot }}">{% translate 'Documentation' %}</a> /
+                    {% endif %}
+                {% endif %}
+                {% if user.has_usable_password %}
+                <a href="{% url 'admin:password_change' %}">{% translate 'Change password' %}</a> /
+                {% endif %}
+                <a href="{% url 'admin:logout' %}">{% translate 'Log out' %}</a>
+            {% endblock %}
+        </div>
+        {% endif %}
+        {% endblock %}
+        {% block nav-global %}{% endblock %}
+    </div>
+    <!-- END Header -->
+    {% block breadcrumbs %}
+    <div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+    {% if title %} &rsaquo; {{ title }}{% endif %}
+    </div>
+    {% endblock %}
+    {% endif %}
+
+    <div class="main shifted" id="main">
+      {% if not is_popup and is_nav_sidebar_enabled %}
+        {% block nav-sidebar %}
+          {% include "admin/nav_sidebar.html" %}
+        {% endblock %}
+      {% endif %}
+      <div class="content">
+        {% block messages %}
+          {% if messages %}
+            <ul class="messagelist">{% for message in messages %}
+              <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message|capfirst }}</li>
+            {% endfor %}</ul>
+          {% endif %}
+        {% endblock messages %}
+        <!-- Content -->
+        <div id="content" class="{% block coltype %}colM{% endblock %}">
+          {% block pretitle %}{% endblock %}
+          {% block content_title %}{% if title %}<h1>{{ title }}</h1>{% endif %}{% endblock %}
+          {% block content_subtitle %}{% if subtitle %}<h2>{{ subtitle }}</h2>{% endif %}{% endblock %}
+          {% block content %}
+            {% block object-tools %}{% endblock %}
+            {{ content }}
+          {% endblock %}
+          {% block sidebar %}{% endblock %}
+          <br class="clear">
+        </div>
+        <!-- END Content -->
+        {% block footer %}<div id="footer"></div>{% endblock %}
+      </div>
+    </div>
+</div>
+<!-- END Container -->
+{% block modals %}{% endblock modals %}
+</body>
+</html>

--- a/src/openzaak/templates/admin/object_history.html
+++ b/src/openzaak/templates/admin/object_history.html
@@ -11,8 +11,8 @@
 {% endblock %}
 
 {% block extrastyle %}
-    {{ block.super }}
     <link rel="stylesheet" href="{% static 'vng_api_common/libs/bootstrap/css/bootstrap.min.css' %}">
+    {{ block.super }}
 {% endblock %}
 
 {% block content %}
@@ -46,64 +46,6 @@
                 <td>{{ audit.toelichting }}</td>
                 <td><button class="btn btn-primary" data-toggle="modal" data-target="#myModal-{{forloop.counter}}">{% trans 'Toon wijzigingen' %}</button></td>
             </tr>
-
-            <div class="modal hide fade" tabindex="-1" id="myModal-{{forloop.counter}}" role="dialog">
-                <div class="modal-dialog modal-lg" role="document">
-                    <div class="modal-content">
-                        <div class="modal-header">
-                            <h5 class="modal-title">Gewijzigde velden</h5>
-                            <button type="button" class="close" data-dismiss="modal">
-                                <span aria-hidden="true">&times;</span>
-                            </button>
-                        </div>
-                        <div class="modal-body">
-                            <div class="container bordered">
-                                <div class="row">
-                                    <div class="col">
-                                        <h4>{% trans 'Veld' %}</h4>
-                                    </div>
-                                    <div class="col">
-                                        <h4>{% trans 'Oud' %}</h4>
-                                    </div>
-                                    <div class="col">
-                                        <h4>{% trans 'Nieuw' %}</h4>
-                                    </div>
-                                </div>
-                                {% for change in changes %}
-                                    {% if change.0 == 'add' %}
-                                        {% for field, diff in change.1.items %}
-                                            <div class="row">
-                                                <div class="col"><code>{{ field }}</code></div>
-                                                <div class="col"></div>
-                                                <div class="col"><p>{{ diff }}</p></div>
-                                            </div>
-                                            <hr/>
-                                        {% endfor %}
-                                    {% elif change.0 == 'change' %}
-                                        {% for field, diff in change.1.items %}
-                                            <div class="row">
-                                                <div class="col"><code>{{ field }}</code></div>
-                                                <div class="col">{{ diff.0 }}</div>
-                                                <div class="col lg-2">{{ diff.1 }}</div>
-                                            </div>
-                                            <hr/>
-                                        {% endfor %}
-                                    {% elif change.0 == 'remove' %}
-                                        {% for field, diff in change.1.items %}
-                                            <div class="row">
-                                                <div class="col"><code>{{ field }}</code></div>
-                                                <div class="col">{{ diff }}</div>
-                                                <div class="col lg-2"></div>
-                                            </div>
-                                            <hr/>
-                                        {% endfor %}
-                                    {% endif %}
-                                {% endfor %}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
         {% endfor %}
         </tbody>
     </table>
@@ -118,3 +60,66 @@
     {{ block.super }}
 
 {% endblock %}
+
+
+{% block modals %}
+{% for audit, changes in object.audittrail %}
+    <div class="modal hide fade" tabindex="-1" id="myModal-{{forloop.counter}}" role="dialog">
+        <div class="modal-dialog modal-lg" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Gewijzigde velden</h5>
+                    <button type="button" class="close" data-dismiss="modal">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <div class="container bordered">
+                        <div class="row">
+                            <div class="col">
+                                <h4>{% trans 'Veld' %}</h4>
+                            </div>
+                            <div class="col">
+                                <h4>{% trans 'Oud' %}</h4>
+                            </div>
+                            <div class="col">
+                                <h4>{% trans 'Nieuw' %}</h4>
+                            </div>
+                        </div>
+                        {% for change in changes %}
+                            {% if change.0 == 'add' %}
+                                {% for field, diff in change.1.items %}
+                                    <div class="row">
+                                        <div class="col"><code>{{ field }}</code></div>
+                                        <div class="col"></div>
+                                        <div class="col"><p>{{ diff }}</p></div>
+                                    </div>
+                                    <hr/>
+                                {% endfor %}
+                            {% elif change.0 == 'change' %}
+                                {% for field, diff in change.1.items %}
+                                    <div class="row">
+                                        <div class="col"><code>{{ field }}</code></div>
+                                        <div class="col">{{ diff.0 }}</div>
+                                        <div class="col lg-2">{{ diff.1 }}</div>
+                                    </div>
+                                    <hr/>
+                                {% endfor %}
+                            {% elif change.0 == 'remove' %}
+                                {% for field, diff in change.1.items %}
+                                    <div class="row">
+                                        <div class="col"><code>{{ field }}</code></div>
+                                        <div class="col">{{ diff }}</div>
+                                        <div class="col lg-2"></div>
+                                    </div>
+                                    <hr/>
+                                {% endfor %}
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endfor %}
+{% endblock modals %}


### PR DESCRIPTION
Fixes #1122

**Changes**

* Included custom overrides after bootstrap stylesheets to leverage the
  cascading nature of CSS. This ensures our own values for CSS vars are
  used instead of bootstrap's reboot.
* Copied django admin/base.html template and added an extra block for
  modals. The alignment of django-admin z-indices combined with where
  bootstrap injects the modal backdrop requires this change to break
  everything modal-related outside of the nested document structure.