### PR TITLE
Make log level configurable

### DIFF
--- a/docs/installation/config/env_config.md
+++ b/docs/installation/config/env_config.md
@@ -114,6 +114,9 @@ on Docker, since `localhost` is contained within the container:
 * `LOG_QUERIES`: enable (query) logging at the database backend level. Note that you
   must also set `DEBUG=1`, which should be done very sparingly!
 
+* `LOG_LEVEL`: control the verbosity of logging output. Available values are `CRITICAL`,
+  `ERROR`, `WARNING`, `INFO` and `DEBUG`. Defaults to `WARNING`.
+
 * `PROFILE`: whether to enable profiling-tooling or not. Applies to the development
   settings only. Defaults to `False`.
 

--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -248,6 +248,7 @@ DEFAULT_FROM_EMAIL = "openzaak@example.com"
 # LOGGING
 #
 LOG_STDOUT = config("LOG_STDOUT", default=False)
+LOG_LEVEL = config("LOG_LEVEL", default="WARNING")
 LOG_QUERIES = config("LOG_QUERIES", default=False)
 if LOG_QUERIES and not DEBUG:
     warnings.warn(
@@ -256,6 +257,9 @@ if LOG_QUERIES and not DEBUG:
     )
 
 LOGGING_DIR = os.path.join(BASE_DIR, "log")
+
+_root_handlers = ["console"] if LOG_STDOUT else ["project"]
+_django_handlers = ["console"] if LOG_STDOUT else ["django"]
 
 LOGGING = {
     "version": 1,
@@ -331,40 +335,42 @@ LOGGING = {
         },
     },
     "loggers": {
+        "": {"handlers": _root_handlers, "level": "ERROR", "propagate": False,},
         "openzaak": {
-            "handlers": ["project"] if not LOG_STDOUT else ["console"],
-            "level": "INFO",
+            "handlers": _root_handlers,
+            "level": LOG_LEVEL,
             "propagate": True,
         },
-        "mozilla_django_oidc": {
-            "handlers": ["project"] if not LOG_STDOUT else ["console"],
-            "level": "DEBUG",
-        },
+        "mozilla_django_oidc": {"handlers": _root_handlers, "level": LOG_LEVEL,},
         "openzaak.utils.middleware": {
-            "handlers": ["requests"] if not LOG_STDOUT else ["console"],
-            "level": "DEBUG",
+            "handlers": _root_handlers,
+            "level": LOG_LEVEL,
             "propagate": False,
         },
-        "vng_api_common": {"handlers": ["console"], "level": "INFO", "propagate": True},
+        "vng_api_common": {
+            "handlers": ["console"],
+            "level": LOG_LEVEL,
+            "propagate": True,
+        },
         "django.db.backends": {
             "handlers": ["console_db"] if LOG_QUERIES else [],
             "level": "DEBUG",
             "propagate": False,
         },
         "django.request": {
-            "handlers": ["django"] if not LOG_STDOUT else ["console"],
-            "level": "ERROR",
+            "handlers": _django_handlers,
+            "level": LOG_LEVEL,
             "propagate": True,
         },
         "django.template": {
             "handlers": ["console"],
             "level": "INFO",
-            "propagate": True,
+            "propagate": False,
         },
         "vng_api_common.notifications.viewsets": {
             "handlers": [
                 "failed_notification",  # always log this to the database!
-                "project" if not LOG_STDOUT else "console",
+                *_root_handlers,
             ],
             "level": "WARNING",
             "propagate": True,

--- a/src/openzaak/conf/production.py
+++ b/src/openzaak/conf/production.py
@@ -7,6 +7,7 @@ Tweaks the base settings so that caching mechanisms are used where possible,
 and HTTPS is leveraged where possible to further secure things.
 """
 from .includes.base import *  # noqa
+from .includes.base import _django_handlers
 from .includes.environ import config
 
 conn_max_age = config("DB_CONN_MAX_AGE", cast=float, default=None)
@@ -27,24 +28,10 @@ TEMPLATES[0]["OPTIONS"]["loaders"] = [
 STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
 
 # Production logging facility.
-root_handlers, django_handlers = [], []
-
-if "sentry" in LOGGING["handlers"]:
-    root_handlers.append("sentry")
-
-if LOG_STDOUT:
-    root_handlers.append("console")
-    django_handlers.append("console")
-else:
-    root_handlers.append("project")
-    django_handlers.append("django")
-
 LOGGING["loggers"].update(
     {
-        "": {"handlers": root_handlers, "level": "ERROR", "propagate": False},
-        "django": {"handlers": django_handlers, "level": "INFO", "propagate": True},
         "django.security.DisallowedHost": {
-            "handlers": django_handlers,
+            "handlers": _django_handlers,
             "level": "CRITICAL",
             "propagate": False,
         },


### PR DESCRIPTION
Fixes #1145

**Changes**

By default, we now only log WARNING log levels, but this can be overridden through envvars. Before we had varying degrees of `DEBUG` output cluttering the emitted logs.

