### PR TITLE
Validate selectielijst resultaattypen in zaaktype admin + add reset option

### DIFF
--- a/src/openzaak/components/catalogi/admin/forms.py
+++ b/src/openzaak/components/catalogi/admin/forms.py
@@ -37,6 +37,18 @@ from .widgets import CatalogusFilterFKRawIdWidget, CatalogusFilterM2MRawIdWidget
 
 
 class ZaakTypeForm(forms.ModelForm):
+    selectielijst_reset = forms.BooleanField(
+        label=_("Reset selectielijst configuration"),
+        required=False,
+        initial=False,
+        help_text=_(
+            "Reset the selectielijstprocestype for the zaaktype and all "
+            "selectielijstklassen specified for the attached resultaattypen. You need "
+            "to check this if you want to change the selectielijstprocestype of a "
+            "zaaktype."
+        ),
+    )
+
     class Meta:
         model = ZaakType
         fields = "__all__"
@@ -94,6 +106,10 @@ class ZaakTypeForm(forms.ModelForm):
         procestype_url = self.cleaned_data["selectielijst_procestype"]
         # create instead of update -> no validation required
         if not self.instance.pk:
+            return procestype_url
+
+        # if we are resetting, there's no reason to run validation
+        if self.cleaned_data.get("selectielijst_reset"):
             return procestype_url
 
         selectielijstklassen = (

--- a/src/openzaak/components/catalogi/admin/forms.py
+++ b/src/openzaak/components/catalogi/admin/forms.py
@@ -220,7 +220,9 @@ class ResultaatTypeForm(forms.ModelForm):
             return
 
         try:
-            client.retrieve("resultaat", url=selectielijstklasse)
+            selectielijst_resultaat = client.retrieve(
+                "resultaat", url=selectielijstklasse
+            )
         except ClientError as exc:
             msg = (
                 _("URL %s for selectielijstklasse did not resolve")
@@ -237,7 +239,7 @@ class ResultaatTypeForm(forms.ModelForm):
             err = forms.ValidationError(exc.detail[0], code=exc.detail[0].code)
             raise forms.ValidationError({"selectielijstklasse": err}) from exc
 
-        procestype = response.json()["procesType"]
+        procestype = selectielijst_resultaat["procesType"]
         if procestype != zaaktype.selectielijst_procestype:
             if not zaaktype.selectielijst_procestype:
                 edit_zaaktype = reverse(

--- a/src/openzaak/components/catalogi/admin/forms.py
+++ b/src/openzaak/components/catalogi/admin/forms.py
@@ -126,7 +126,6 @@ class ZaakTypeForm(forms.ModelForm):
         for url in selectielijstklassen:
             client = Service.get_client(url)
             if client is None:
-                # TOOD
                 self.add_error(
                     None, _("Could not build a client for {url}").format(url=url)
                 )

--- a/src/openzaak/components/catalogi/admin/zaaktypen.py
+++ b/src/openzaak/components/catalogi/admin/zaaktypen.py
@@ -292,14 +292,17 @@ class ZaakTypeAdmin(
                 localize=False,
             )
         if db_field.name == "selectielijst_procestype":
+            referentielijst_config = ReferentieLijstConfig.get_solo()
+            config_default = referentielijst_config.default_year
+
             if "object_id" in request.resolver_match.kwargs:
                 obj = ZaakType.objects.get(
                     id=str(request.resolver_match.kwargs["object_id"])
                 )
-                procestype_jaar = obj.selectielijst_procestype_jaar
+                procestype_jaar = obj.selectielijst_procestype_jaar or config_default
             else:
-                referentielijst_config = ReferentieLijstConfig.get_solo()
-                procestype_jaar = referentielijst_config.default_year
+                procestype_jaar = config_default
+
             try:
                 return get_procestype_field(
                     db_field, request, procestype_jaar, **kwargs

--- a/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
@@ -87,6 +87,14 @@ class MockSelectielijst:
                 "procestypen/e1b73b12-b2f6-4c4e-8929-94f84dd2a57d"
             ),
         )
+        mock_resource_get(
+            mocker,
+            "resultaten",
+            (
+                "https://selectielijst.openzaak.nl/api/v1/"
+                "resultaten/cc5ae4e3-a9e6-4386-bcee-46be4986a829"
+            ),
+        )
 
 
 class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
@@ -113,6 +121,7 @@ class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
             catalogus=catalogus,
             vertrouwelijkheidaanduiding="openbaar",
             zaaktype_omschrijving="bla",
+            selectielijst_procestype=f"{self.base}api/v1/procestypen/e1b73b12-b2f6-4c4e-8929-94f84dd2a57d",
         )
         informatieobjecttype = InformatieObjectTypeFactory.create(
             catalogus=catalogus, vertrouwelijkheidaanduiding="openbaar"
@@ -143,7 +152,7 @@ class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
                 brondatum_archiefprocedure_registratie="bla",
                 brondatum_archiefprocedure_objecttype="besluit",
                 resultaattypeomschrijving=resultaattypeomschrijving,
-                selectielijstklasse=f"{self.base}/resultaten/cc5ae4e3-a9e6-4386-bcee-46be4986a829",
+                selectielijstklasse=f"{self.base}resultaten/cc5ae4e3-a9e6-4386-bcee-46be4986a829",
             )
 
         eigenschap = EigenschapFactory.create(zaaktype=zaaktype, definitie="bla")
@@ -239,6 +248,7 @@ class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
             catalogus=catalogus,
             vertrouwelijkheidaanduiding="openbaar",
             zaaktype_omschrijving="bla",
+            selectielijst_procestype=f"{self.base}api/v1/procestypen/e1b73b12-b2f6-4c4e-8929-94f84dd2a57d",
         )
         informatieobjecttype = InformatieObjectTypeFactory.create(
             catalogus=catalogus, vertrouwelijkheidaanduiding="openbaar"
@@ -269,7 +279,7 @@ class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
                 brondatum_archiefprocedure_registratie="bla",
                 brondatum_archiefprocedure_objecttype="besluit",
                 resultaattypeomschrijving=resultaattypeomschrijving,
-                selectielijstklasse=f"{self.base}/resultaten/cc5ae4e3-a9e6-4386-bcee-46be4986a829",
+                selectielijstklasse=f"{self.base}resultaten/cc5ae4e3-a9e6-4386-bcee-46be4986a829",
             )
 
         eigenschap = EigenschapFactory.create(zaaktype=zaaktype, definitie="bla")

--- a/src/openzaak/components/catalogi/tests/admin/test_published_readonly.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_published_readonly.py
@@ -31,6 +31,8 @@ from ..factories import (
 class ReadonlyAdminTests(ReferentieLijstServiceMixin, ClearCachesMixin, WebTest):
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
+
         cls.user = SuperUserFactory.create()
 
     def setUp(self):

--- a/src/openzaak/components/catalogi/tests/admin/test_resultaattype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_resultaattype_admin.py
@@ -27,6 +27,7 @@ from ..factories import ResultaatTypeFactory, ZaakTypeFactory
 class ResultaattypeAdminTests(ReferentieLijstServiceMixin, ClearCachesMixin, WebTest):
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
         cls.user = SuperUserFactory.create()
 
     def setUp(self):

--- a/src/openzaak/components/catalogi/tests/admin/test_zaaktype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_zaaktype_admin.py
@@ -45,6 +45,8 @@ class ZaaktypeAdminTests(
 ):
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
+
         cls.user = SuperUserFactory.create()
 
         # there are TransactionTestCases that truncate the DB, so we need to ensure

--- a/src/openzaak/components/catalogi/tests/admin/test_zaaktype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_zaaktype_admin.py
@@ -151,13 +151,16 @@ class ZaaktypeAdminTests(
             vertrouwelijkheidaanduiding="openbaar",
             trefwoorden=["test"],
             verantwoordingsrelatie=["bla"],
+            selectielijst_procestype="",
         )
         # reverse fk relations
         statustype_old = StatusTypeFactory.create(zaaktype=zaaktype_old)
         resultaattypeomschrijving = "https://example.com/resultaattypeomschrijving/1"
         m.register_uri("GET", resultaattypeomschrijving, json={"omschrijving": "init"})
         resultaattype_old = ResultaatTypeFactory.create(
-            zaaktype=zaaktype_old, resultaattypeomschrijving=resultaattypeomschrijving
+            zaaktype=zaaktype_old,
+            resultaattypeomschrijving=resultaattypeomschrijving,
+            selectielijstklasse="",
         )
         roltype_old = RolTypeFactory.create(zaaktype=zaaktype_old)
         eigenschap_old = EigenschapFactory.create(zaaktype=zaaktype_old)

--- a/src/openzaak/selectielijst/tests/mixins.py
+++ b/src/openzaak/selectielijst/tests/mixins.py
@@ -1,22 +1,48 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
-from zgw_consumers.constants import APITypes
+import requests_mock
+from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.models import Service
 
 from openzaak.selectielijst.models import ReferentieLijstConfig
 
+from . import mock_oas_get, mock_resource_list
 
-class ReferentieLijstServiceMixin:
-    def setUp(self):
-        super().setUp()
+
+class SelectieLijstMixin:
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        # there are TransactionTestCases that truncate the DB, so we need to ensure
+        # there are available years
         config = ReferentieLijstConfig.get_solo()
+        config.allowed_years = [2017, 2020]
+        config.save()
+        cls.base = config.api_root
+
         Service.objects.update_or_create(
-            api_root=config.api_root,
+            api_root=cls.base,
             defaults=dict(
                 api_type=APITypes.orc,
-                client_id="test",
-                secret="test",
-                user_id="test",
-                user_representation="Test",
+                label="external selectielijst",
+                auth_type=AuthTypes.no_auth,
             ),
         )
+
+    def setUp(self):
+        super().setUp()
+
+        mocker = requests_mock.Mocker()
+        mocker.start()
+        self.addCleanup(mocker.stop)
+
+        mock_oas_get(mocker)
+
+        mock_resource_list(mocker, "procestypen")
+        mock_resource_list(mocker, "resultaten")
+        self.requests_mocker = mocker
+
+
+# backwards compatible alias
+ReferentieLijstServiceMixin = SelectieLijstMixin


### PR DESCRIPTION
Fixes #970

**Changes**

* When editing the zaaktype procestype (selectielijst), this is now checked for integrity against related resultaattypen
* Because you cannot modify resultaattype with a selectielijstklasse that doesn't belong to the zaaktype.procestype, this cross-validation blocked edits completely. To mitigate this, a reset option is added which resets all selectielijst-related configuration in the entire zaaktype (including resultaattypen)
* Fixed tests and cleaned up some divergent patterns into single mixin
