### PR TITLE
Allow updating a zaaktype with relations to published documenttypes

### DIFF
--- a/src/openzaak/components/catalogi/api/serializers/zaaktype.py
+++ b/src/openzaak/components/catalogi/api/serializers/zaaktype.py
@@ -193,7 +193,7 @@ class ZaakTypeSerializer(
             RelationCatalogValidator("besluittypen"),
             ConceptUpdateValidator(),
             M2MConceptCreateValidator(["besluittypen", "informatieobjecttypen"]),
-            M2MConceptUpdateValidator(["besluittypen", "informatieobjecttypen"]),
+            M2MConceptUpdateValidator(["besluittypen"]),
             DeelzaaktypeCatalogusValidator(),
             VerlengingsValidator(),
         ]

--- a/src/openzaak/components/catalogi/api/validators.py
+++ b/src/openzaak/components/catalogi/api/validators.py
@@ -280,25 +280,21 @@ class DeelzaaktypeCatalogusValidator:
 class ConceptUpdateValidator:
     message = _("Het is niet toegestaan om een non-concept object bij te werken")
     code = "non-concept-object"
+    requires_context = True
 
-    def set_context(self, serializer):
-        """
-        This hook is called by the serializer instance,
-        prior to the validation call being made.
-        """
+    def __call__(self, attrs, serializer):
         # Determine the existing instance, if this is an update operation.
-        self.instance = getattr(serializer, "instance", None)
-        self.request = serializer.context["request"]
+        instance = getattr(serializer, "instance", None)
+        request = serializer.context["request"]
 
-    def __call__(self, attrs):
-        if not self.instance:
+        if not instance:
             return
 
         einde_geldigheid = attrs.get("datum_einde_geldigheid")
-        if einde_geldigheid and len(self.request.data) == 1:
+        if einde_geldigheid and len(request.data) == 1:
             return
 
-        if not self.instance.concept:
+        if not instance.concept:
             raise ValidationError(self.message, code=self.code)
 
 
@@ -350,20 +346,15 @@ class M2MConceptCreateValidator:
     """
 
     code = "non-concept-relation"
+    requires_context = True
 
     def __init__(self, concept_related_fields):
         self.concept_related_fields = concept_related_fields
 
-    def set_context(self, serializer):
-        """
-        This hook is called by the serializer instance,
-        prior to the validation call being made.
-        """
+    def __call__(self, attrs, serializer):
         # Determine the existing instance, if this is an update operation.
-        self.instance = getattr(serializer, "instance", None)
-
-    def __call__(self, attrs):
-        if self.instance:
+        instance = getattr(serializer, "instance", None)
+        if instance:
             return
 
         for field_name in self.concept_related_fields:
@@ -383,29 +374,24 @@ class M2MConceptUpdateValidator:
     """
 
     code = "non-concept-relation"
+    requires_context = True
 
     def __init__(self, concept_related_fields):
         self.concept_related_fields = concept_related_fields
 
-    def set_context(self, serializer):
-        """
-        This hook is called by the serializer instance,
-        prior to the validation call being made.
-        """
+    def __call__(self, attrs, serializer):
         # Determine the existing instance, if this is an update operation.
-        self.instance = getattr(serializer, "instance", None)
-        self.request = serializer.context["request"]
-
-    def __call__(self, attrs):
-        if not self.instance:
+        instance = getattr(serializer, "instance", None)
+        request = serializer.context["request"]
+        if not instance:
             return
 
         einde_geldigheid = attrs.get("datum_einde_geldigheid")
-        if einde_geldigheid and len(self.request.data) == 1:
+        if einde_geldigheid and len(request.data) == 1:
             return
 
         for field_name in self.concept_related_fields:
-            field = getattr(self.instance, field_name)
+            field = getattr(instance, field_name)
             related_non_concepts = field.filter(concept=False)
             if related_non_concepts.exists():
                 msg = _(f"Objects related to non-concept {field_name} can't be updated")

--- a/src/openzaak/components/catalogi/tests/test_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/test_zaaktype.py
@@ -991,7 +991,9 @@ class ZaakTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(error["code"], M2MConceptUpdateValidator.code)
         zaaktype.delete()
 
-    def test_update_zaaktype_related_to_non_concept_informatieobjecttype_fails(self):
+    def test_update_zaaktype_related_to_non_concept_informatieobjecttype_is_allowed(
+        self,
+    ):
         catalogus = CatalogusFactory.create()
 
         zaaktype = ZaakTypeFactory.create(catalogus=catalogus)
@@ -1038,11 +1040,7 @@ class ZaakTypeAPITests(TypeCheckMixin, APITestCase):
 
         response = self.client.put(zaaktype_url, data)
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-        error = get_validation_errors(response, "nonFieldErrors")
-        self.assertEqual(error["code"], M2MConceptUpdateValidator.code)
-        zaaktype.delete()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_update_zaaktype_add_relation_to_non_concept_besluittype_fails(self):
         catalogus = CatalogusFactory.create()
@@ -1151,7 +1149,7 @@ class ZaakTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(response.data["aanleiding"], "aangepast")
         zaaktype.delete()
 
-    def test_partial_update_zaaktype_related_to_non_concept_informatieobjecttype_fails(
+    def test_partial_update_zaaktype_related_to_non_concept_informatieobjecttype_allowed(
         self,
     ):
         catalogus = CatalogusFactory.create()
@@ -1168,11 +1166,7 @@ class ZaakTypeAPITests(TypeCheckMixin, APITestCase):
 
         response = self.client.patch(zaaktype_url, {"aanleiding": "aangepast"})
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-        error = get_validation_errors(response, "nonFieldErrors")
-        self.assertEqual(error["code"], M2MConceptUpdateValidator.code)
-        zaaktype.delete()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_partial_update_zaaktype_add_relation_to_non_concept_besluittype_fails(
         self,

--- a/src/openzaak/components/catalogi/tests/test_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/test_zaaktype.py
@@ -1032,7 +1032,6 @@ class ZaakTypeAPITests(TypeCheckMixin, APITestCase):
             ],
             "referentieproces": {"naam": "ReferentieProces 0", "link": ""},
             "catalogus": reverse(catalogus),
-            # 'informatieobjecttypen': [f'http://testserver{informatieobjecttype_url}'],
             "besluittypen": [],
             "beginGeldigheid": "2018-01-01",
             "versiedatum": "2018-01-01",


### PR DESCRIPTION
Fixes #983

**Changes**

Updated validator to not check for related published documenttypes (and modified the test), as this falls under the exception for ZTC-10 and ZTC-11 rules.

I've also checked the behaviour for creating those relations and think we cover it correctly with the tests/validators.

I am however curious if this bug is also present in the VNG test suite, so I'm expecting potential build failures there. If that's the case, we need to get that test-suite fixed as well.