### PR TITLE
Allow null eindegeldigheid in catalogi api

### DIFF
--- a/src/openzaak/components/catalogi/api/validators.py
+++ b/src/openzaak/components/catalogi/api/validators.py
@@ -28,34 +28,30 @@ class GeldigheidValidator:
     message = _(
         "Dit {} komt al voor binnen de catalogus en opgegeven geldigheidsperiode."
     )
+    requires_context = True
 
     def __init__(self, omschrijving_field="omschrijving"):
         self.omschrijving_field = omschrijving_field
 
-    def set_context(self, serializer):
-        """
-        This hook is called by the serializer instance,
-        prior to the validation call being made.
-        """
+    def __call__(self, attrs, serializer):
         # Determine the existing instance, if this is an update operation.
-        self.instance = getattr(serializer, "instance", None)
-        self.base_model = getattr(serializer.Meta, "model", None)
+        instance = getattr(serializer, "instance", None)
+        base_model = getattr(serializer.Meta, "model", None)
 
-    def __call__(self, attrs):
         if has_overlapping_objects(
-            model_manager=self.base_model._default_manager,
+            model_manager=base_model._default_manager,
             catalogus=attrs.get("catalogus"),
             omschrijving_query={
                 self.omschrijving_field: attrs.get(self.omschrijving_field)
             },
             begin_geldigheid=attrs.get("datum_begin_geldigheid"),
             einde_geldigheid=attrs.get("datum_einde_geldigheid"),
-            instance=self.instance,
+            instance=instance,
         ):
             raise ValidationError(
                 {
                     "begin_geldigheid": self.message.format(
-                        self.base_model._meta.verbose_name
+                        base_model._meta.verbose_name
                     )
                 },
                 code=self.code,

--- a/src/openzaak/components/catalogi/tests/test_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/test_zaaktype.py
@@ -3,7 +3,7 @@
 import uuid
 from datetime import date
 
-from django.test import TestCase, override_settings
+from django.test import TestCase, override_settings, tag
 from django.urls import reverse as django_reverse
 
 from rest_framework import status
@@ -1207,6 +1207,45 @@ class ZaakTypeAPITests(TypeCheckMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["einde_geldigheid"], "2020-01-01")
+
+    @tag("gh-981")
+    def test_partial_update_non_concept_zaaktype_reset_einde_geldigheid(self):
+        """
+        Assert that ``null`` can be set as value for eindeGeldigheid.
+
+        Regression test for https://github.com/open-zaak/open-zaak/issues/981
+        """
+        zaaktype = ZaakTypeFactory.create(
+            concept=False,
+            zaaktype_omschrijving="GH-981",
+            datum_begin_geldigheid=date(2021, 1, 1),
+            datum_einde_geldigheid=date(2022, 1, 1),
+        )
+        endpoint = reverse(zaaktype)
+
+        with self.subTest("no overlap"):
+            response = self.client.patch(endpoint, {"eindeGeldigheid": None})
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            zaaktype.refresh_from_db()
+            self.assertIsNone(zaaktype.datum_einde_geldigheid)
+
+        with self.subTest("would introduce overlap"):
+            zaaktype_old = ZaakTypeFactory.create(
+                concept=False,
+                catalogus=zaaktype.catalogus,
+                zaaktype_omschrijving="GH-981",
+                datum_begin_geldigheid=date(2020, 1, 1),
+                datum_einde_geldigheid=date(2020, 12, 31),
+            )
+
+            response = self.client.patch(
+                reverse(zaaktype_old), {"eindeGeldigheid": None}
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            error = get_validation_errors(response, "eindeGeldigheid")
+            self.assertEqual(error["code"], "overlap")
 
     def test_partial_update_zaaktype_einde_geldigheid_related_to_non_concept_besluittype(
         self,

--- a/src/openzaak/utils/serializers.py
+++ b/src/openzaak/utils/serializers.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
+from typing import Any
+
 from rest_framework import fields as drf_fields
+from rest_framework.serializers import Serializer
 
 
 class ConvertNoneMixin:
@@ -29,3 +32,19 @@ class ConvertNoneMixin:
                 representation[field.field_name] = ""
 
         return representation
+
+
+def get_from_serializer_data_or_instance(
+    field: str, data: dict, serializer: Serializer
+) -> Any:
+    serializer_field = serializer.fields[field]
+    # TODO: this won't work with source="*" or nested references
+    data_value = data.get(serializer_field.source, drf_fields.empty)
+    if data_value is not drf_fields.empty:
+        return data_value
+
+    instance = serializer.instance
+    if not instance:
+        return None
+
+    return serializer_field.get_attribute(instance)


### PR DESCRIPTION
Fixes #981

**Changes**

* Added test to check the value can be set to null
* Added test to check that changes introducing overlap are still blocked
* Made validation error field context-dependent (if we're patching just the field eindeGeldigheid -> then errors are attached there)
* Fixed bug that prevented patches setting eindeGeldigheid to `None` from succeeding

TODO: backport to reference implementation (probably)