### PR TITLE
Implement zaaktype list / filtering in the admin

### DIFF
--- a/src/openzaak/components/catalogi/admin/besluittype.py
+++ b/src/openzaak/components/catalogi/admin/besluittype.py
@@ -6,6 +6,7 @@ from django.utils.translation import ugettext_lazy as _
 from openzaak.utils.admin import UUIDAdminMixin
 
 from ..models import BesluitType
+from .filters import GeldigheidFilter
 from .forms import BesluitTypeAdminForm
 from .mixins import (
     CatalogusContextAdminMixin,
@@ -29,6 +30,7 @@ class BesluitTypeAdmin(
     # List
     list_display = ("omschrijving", "besluitcategorie", "catalogus", "is_published")
     list_filter = (
+        GeldigheidFilter,
         "concept",
         "catalogus",
     )

--- a/src/openzaak/components/catalogi/admin/besluittype.py
+++ b/src/openzaak/components/catalogi/admin/besluittype.py
@@ -28,7 +28,10 @@ class BesluitTypeAdmin(
 ):
     # List
     list_display = ("omschrijving", "besluitcategorie", "catalogus", "is_published")
-    list_filter = ("catalogus",)
+    list_filter = (
+        "concept",
+        "catalogus",
+    )
     search_fields = ("uuid", "omschrijving", "besluitcategorie", "toelichting")
     ordering = ("catalogus", "omschrijving")
     raw_id_fields = (

--- a/src/openzaak/components/catalogi/admin/filters.py
+++ b/src/openzaak/components/catalogi/admin/filters.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2022 Dimpact
+from django.contrib import admin
+from django.db import models
+from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
+
+
+class GeldigheidFilter(admin.SimpleListFilter):
+    title = _("geldigheid")
+    parameter_name = "validity"
+
+    def lookups(self, request, model_admin):
+        lookups = [
+            ("currently", _("Now")),
+            ("past", _("Past")),
+            ("future", _("Future")),
+        ]
+        return lookups
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if not value:
+            return queryset
+
+        today = timezone.now().date()
+        if value == "currently":
+            return queryset.filter(
+                models.Q(datum_einde_geldigheid__isnull=True)
+                | models.Q(datum_einde_geldigheid__gte=today),
+                datum_begin_geldigheid__lte=today,
+            )
+
+        if value == "past":
+            return queryset.filter(datum_einde_geldigheid__lt=today)
+
+        if value == "future":
+            return queryset.filter(datum_begin_geldigheid__gt=today)
+
+        raise ValueError("Unknown lookup value")

--- a/src/openzaak/components/catalogi/admin/filters.py
+++ b/src/openzaak/components/catalogi/admin/filters.py
@@ -37,4 +37,4 @@ class GeldigheidFilter(admin.SimpleListFilter):
         if value == "future":
             return queryset.filter(datum_begin_geldigheid__gt=today)
 
-        raise ValueError("Unknown lookup value")
+        raise ValueError("Unknown lookup value")  # pragma: nocover

--- a/src/openzaak/components/catalogi/admin/informatieobjecttype.py
+++ b/src/openzaak/components/catalogi/admin/informatieobjecttype.py
@@ -84,7 +84,11 @@ class InformatieObjectTypeAdmin(
         "num_zaaktypen",
         "is_published",
     )
-    list_filter = ("catalogus", "concept", "vertrouwelijkheidaanduiding")
+    list_filter = (
+        "concept",
+        "catalogus",
+        "vertrouwelijkheidaanduiding",
+    )
     search_fields = (
         "uuid",
         "omschrijving",

--- a/src/openzaak/components/catalogi/admin/informatieobjecttype.py
+++ b/src/openzaak/components/catalogi/admin/informatieobjecttype.py
@@ -12,6 +12,7 @@ from openzaak.utils.admin import (
 )
 
 from ..models import InformatieObjectType, ZaakTypeInformatieObjectType
+from .filters import GeldigheidFilter
 from .forms import ZaakTypeInformatieObjectTypeAdminForm
 from .mixins import (
     CatalogusContextAdminMixin,
@@ -85,6 +86,7 @@ class InformatieObjectTypeAdmin(
         "is_published",
     )
     list_filter = (
+        GeldigheidFilter,
         "concept",
         "catalogus",
         "vertrouwelijkheidaanduiding",

--- a/src/openzaak/components/catalogi/admin/zaaktypen.py
+++ b/src/openzaak/components/catalogi/admin/zaaktypen.py
@@ -123,6 +123,7 @@ class ZaakTypeAdmin(
         "is_published",
     )
     list_filter = (
+        "concept",
         "catalogus",
         "publicatie_indicatie",
         "verlenging_mogelijk",

--- a/src/openzaak/components/catalogi/admin/zaaktypen.py
+++ b/src/openzaak/components/catalogi/admin/zaaktypen.py
@@ -32,6 +32,7 @@ from ..models import (
     ZaakTypenRelatie,
 )
 from .eigenschap import EigenschapAdmin
+from .filters import GeldigheidFilter
 from .forms import ZaakTypeForm, ZaakTypenRelatieAdminForm
 from .mixins import (
     CatalogusContextAdminMixin,
@@ -121,8 +122,11 @@ class ZaakTypeAdmin(
         "identificatie",
         "versiedatum",
         "is_published",
+        "datum_begin_geldigheid",
+        "datum_einde_geldigheid",
     )
     list_filter = (
+        GeldigheidFilter,
         "concept",
         "catalogus",
         "publicatie_indicatie",


### PR DESCRIPTION
Fixes #510

**Changes**

* Added filter option on concept yes/no
* Implemented a filter on validity, partitioning the data in "valid in the past", "valid now", "valid in the future"
* Display the begin/einde geldigheid in the admin list

