### PR TITLE
Restructure deployment documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,6 +81,7 @@ todo_include_todos = True
 linkcheck_ignore = [
     r"https?://.*\.gemeente.nl",
     r"http://localhost:\d+/",
+    r"http://127\.0\.0\.1:\d+/",
     r"https://.*sentry\.openzaak\.nl.*",
     # TODO temporary workaround for issue #6218 with Pleio
     r"https://commonground.nl/groups/view/d9c2f667-2f3e-4153-a79b-57dde7f56cc2/team-open-zaak",

--- a/docs/installation/docker_compose.rst
+++ b/docs/installation/docker_compose.rst
@@ -1,0 +1,79 @@
+.. _installation_docker_compose:
+
+============================
+Install using Docker Compose
+============================
+
+This installation is meant for people who want to just try out Open Zaak on
+their own machine.
+
+A `Docker Compose`_ file is available to get the app up and running in minutes.
+It contains 'convenience' settings, which means that no additional
+configuration is needed to run the app. Therefore, it should **not** be used
+for anything other than testing. For example, it includes:
+
+* A default ``SECRET_KEY`` environment variable
+* A predefined database with the environment variable
+  ``POSTGRES_HOST_AUTH_METHOD=trust``. This lets us connect to the database
+  without using a password.
+* Default admin credentials
+* Runs against the latest version of Open Zaak, which may contain bugs.
+
+
+Prerequisites
+=============
+
+You will only need Docker tooling and nothing more:
+
+* `Docker Engine`_ (Desktop or Server)
+* `Docker Compose`_ (sometimes comes bundled with Docker Engine)
+
+On Windows, we support WSL_ as a suitable a Linux-environment.
+
+.. _`Docker Engine`: https://docs.docker.com/engine/install/
+.. _`Docker Compose`: https://docs.docker.com/compose/install/
+.. _`WSL`: https://docs.microsoft.com/en-us/windows/wsl/
+
+
+Getting started
+===============
+
+1. Download the project as ZIP-file:
+
+   .. code:: bash
+
+      $ wget https://github.com/open-zaak/open-zaak/archive/refs/heads/main.zip -O main.zip
+      $ unzip main.zip
+      $ cd open-zaak-main
+
+2. Start the docker containers with ``docker-compose``. If you want to run the
+   containers in the background, add the ``-d`` option to the command below:
+
+   .. code:: bash
+
+      $ docker-compose up
+
+      [+] Running 5/5
+       ⠿ Network open-zaak-main_default    Created      0.0s
+       ⠿ Container open-zaak-main-db-1     Created      0.2s
+       ⠿ Container open-zaak-main-redis-1  Created      0.2s
+       ⠿ Container open-zaak-main-web-1    Created      0.1s
+       ⠿ Container open-zaak-main-nginx-1  Created      0.1s
+
+      ...
+
+3. Navigate to http://127.0.0.1:8000/admin/ and log in with ``admin`` / ``admin``
+   credentials.
+
+4. To stop the containers, press *CTRL-C* or if you used the ``-d`` option:
+
+   .. code:: bash
+
+      $ docker-compose stop
+
+5. If you want to get newer versions, you need to ``pull`` because the
+   ``docker-compose.yml`` contains no explicit versions:
+
+   .. code:: bash
+
+      $ docker-compose pull

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -3,12 +3,23 @@
 Installation
 ============
 
-There are several ways to install Open Zaak. A scalable solution is to use
-:ref:`Kubernetes<deployment_kubernetes>`. You can also run the
-:ref:`Docker containers<deployment_containers>` on a single machine.
+You can install Open Zaak in several ways, depending on your intended purpose and
+expertise.
+
+1. Deploy on :ref:`Kubernetes <installation_kubernetes>` for public testing and
+   production purposes
+2. Deploy on a :ref:`VM, VPS or dedicated server <installation_ansible>` with Docker
+   Engine (or Podman) for public testing and production purposes
+3. Run with :ref:`docker-compose <installation_docker_compose>` on your computer for
+   private testing purposes
+4. Run from :ref:`Python code <development_getting_started>` on your computer for
+   development purposes
 
 Before you begin
 ----------------
+
+.. note:: These requirements are aimed towards public testing and production
+   deployments, though they are _interesting_ to understand the workings of Open Zaak.
 
 * Check the :ref:`minimum system requirements<installation_hardware>` for the target
   machine(s).
@@ -27,7 +38,6 @@ Before you begin
   example ``nlx.<organization.com>``, where your NLX-inway is accessible to the outside
   world.
 
-
 .. _`Open Notificaties`: https://github.com/open-zaak/open-notificaties
 .. _`NLX`: https://nlx.io/
 
@@ -39,8 +49,9 @@ Guides
 
    hardware
    prerequisites
-   deployment/kubernetes
-   deployment/single_server
+   docker_compose
+   kubernetes
+   single_server
    provision_superuser
    config/index
    self_signed

--- a/docs/installation/kubernetes.rst
+++ b/docs/installation/kubernetes.rst
@@ -1,10 +1,10 @@
-.. _deployment_kubernetes:
+.. _installation_kubernetes:
 
-=============================
-Deploying on Kubernetes (K8s)
-=============================
+=====================
+Install on Kubernetes
+=====================
 
-Open Zaak supports deploying on Kubernetes as a first-class citizen, embracing the
+Open Zaak supports deploying on Kubernetes (K8s) as a first-class citizen, embracing the
 `Cloud Native`_ principles.
 
 .. note::
@@ -14,18 +14,22 @@ Open Zaak supports deploying on Kubernetes as a first-class citizen, embracing t
 
 This documentation is aimed at DevOps engineers.
 
-Requirements
-============
+**Quick navigation**
+
+* :ref:`installation_kubernetes_helm`
+* :ref:`installation_kubernetes_ansible`
+
+**Requirements**
 
 We recommend deploying on `Haven`_-compliant clusters. The Open Zaak and Haven teams
-have coordinates the relevant infrastructure specification aspects.
+have coordinated the relevant infrastructure specification aspects.
 
 Don't panic if your cluster is not compliant (yet), as your cluster will likely still be
 capable of hosting Open Zaak.
 
-Features and their requirements:
+Features and their :ref:`requirements <installation_prerequisites>`:
 
-* A PostgreSQL database (10, 11 and 12 are actively tested in CI) with the following extensions:
+* A PostgreSQL database with the following extensions:
 
     - ``pg_trgm``
     - ``postgis``
@@ -37,8 +41,7 @@ Features and their requirements:
 * If you use the Documents API backed by the local file-system, you need a
   ``ReadWriteMany``-capable persistent volume solution, even with a single replica.
 
-Topology
-========
+**Topology**
 
 Traffic from the ingress will enter Open Zaak at one or multiple `NGINX`_
 reverse proxies. NGINX performs one of two possible tasks:
@@ -46,17 +49,45 @@ reverse proxies. NGINX performs one of two possible tasks:
 * pass the request to the Open Zaak application or
 * send the binary data of uploaded files to the client
 
-NGINX exists to serve uploaded files in a secure and performant way.
-
-All other requests are passed to the Open Zaak application containers.
+NGINX exists to serve uploaded files in a secure and performant way.  All other requests
+are passed to the Open Zaak application containers.
 
 The application containers communicate with a PostgreSQL database, which must be
 provisioned upfront. Additionally, Redis is used for caching purposes.
 
-.. _deployment_kubernetes_tooling:
+.. _installation_kubernetes_helm:
 
-Deployment tooling - Ansible
-============================
+Deploy using Helm
+=================
+
+If you're familiar with or prefer Helm_, there are community-provided Helm charts_
+for Open Zaak and Open Notificaties.
+
+.. note::
+
+   These charts are contributed by the community on a best-effort basis. The Technical
+   Steering Group takes no responsibility for the quality or up-to-date being of these
+   charts.
+
+Example:
+
+.. code-block:: bash
+
+    helm repo add open-zaak https://open-zaak.github.io/charts/
+    helm repo update
+
+    helm install open-zaak open-zaak/open-zaak \
+        --set "settings.allowedHosts=open-zaak.gemeente.nl" \
+        --set "ingress.enabled=true" \
+        --set "ingress.hosts={open-zaak.gemeente.nl}"
+
+.. _Helm: https://helm.sh
+.. _charts: https://github.com/open-zaak/charts
+
+.. _installation_kubernetes_ansible:
+
+Deploy using Ansible
+====================
 
 The Open Zaak organization maintains an Ansible_ collection which supports deploying
 on Kubernetes using the open_zaak_k8s_
@@ -137,18 +168,6 @@ To deploy Open Notificaties, some variables need to be set (in ``vars/open-notif
 * ``opennotificaties_secret_key``: generate a key via https://miniwebtool.com/django-secret-key-generator/.
   Make sure to put the value between single quotes!
 
-Deployment tooling - Helm
-=========================
-
-If you're familiar with or prefer Helm_, there are community-provided Helm charts_
-for Open Zaak and Open Notificaties.
-
-.. note::
-
-   These charts are contributed by the community on a best-effort basis. The Technical
-   Steering Group takes no responsibility for the quality or up-to-date being of these
-   charts.
-
 Next steps
 ==========
 
@@ -158,15 +177,20 @@ default setup should be sufficient to get started though.
 To be able to work with Open Zaak, a couple of things have to be configured first,
 see :ref:`installation_configuration` for more details.
 
-.. _deployment_kubernetes_updating:
+.. _installation_kubernetes_updating:
 
-Updating an Open Zaak installation - Ansible
-============================================
+Updating an Open Zaak installation using Ansible
+================================================
 
-Make sure you have the deployment tooling installed - see
-:ref:`deployment_kubernetes_tooling` for more details.
+.. warning::
 
-If you have an existing environment (from the installation), make sure to update it:
+    Make sure you are aware of possible breaking changes or manual interventions by
+    reading the :ref:`development_changelog`!
+
+Ensure you have the deployment tooling installed - see
+:ref:`installation_kubernetes_ansible` for more details.
+
+If you have an existing environment (from the installation), update it:
 
 .. code-block:: shell
 
@@ -185,14 +209,8 @@ If you have an existing environment (from the installation), make sure to update
 Open Zaak deployment code defines variables to specify the Docker image tag to use. This
 is synchronized with the git tag you're checking out.
 
-.. warning::
-
-    Make sure you are aware of possible breaking changes or manual interventions by
-    reading the :ref:`development_changelog`!
-
-
-Next, to perform the upgrade, you run the ``apps.yml`` playbook just like with the
-installation:
+Next, to perform the upgrade, you run the ``apps.yml`` playbook exactly like the
+initial installation:
 
 .. code-block:: shell
 
@@ -216,9 +234,5 @@ installation:
 .. _Cloud Native: https://www.cncf.io/about/who-we-are/
 .. _Haven: https://haven.commonground.nl/
 .. _NGINX: https://www.nginx.com/
-
 .. _Ansible: https://www.ansible.com/
 .. _open_zaak_k8s: https://github.com/open-zaak/ansible-collection/tree/main/roles/open_zaak_k8s
-
-.. _Helm: https://helm.sh
-.. _charts: https://github.com/open-zaak/charts

--- a/docs/installation/updating.rst
+++ b/docs/installation/updating.rst
@@ -25,10 +25,10 @@ The update instructions are split per target environment.
 Updating on Kubernetes
 ----------------------
 
-See :ref:`deployment_kubernetes_updating` for the update instructions on Kubernetes.
+See :ref:`installation_kubernetes_updating` for the update instructions on Kubernetes.
 
 Updating a single server installation
 -------------------------------------
 
 See the steps on how to
-:ref:`update a single server installation<deployment_containers_updating>`.
+:ref:`update a single server installation<installation_ansible_updating>`.


### PR DESCRIPTION
Fixes #1001

**Changes**

* broke out deploy into docker-compose, Kubernetes, single-server and
  local development
* Within Kubernetes, promoted Helm option as first option, then Ansible
* Reworded bits and pieces here and there
* Updated supported OS-list to reflect the reality