### PR TITLE
Validate deelzaak zaaktype with hoofdzaak.zaaktype.deelzaaktypen

### DIFF
--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -64,6 +64,7 @@ from ..validators import (
     DateNotInFutureValidator,
     EndStatusIOsIndicatieGebruiksrechtValidator,
     EndStatusIOsUnlockedValidator,
+    HoofdZaaktypeRelationValidator,
     HoofdzaakValidator,
     NotSelfValidator,
     RolOccurenceValidator,
@@ -300,6 +301,7 @@ class ZaakSerializer(
         validators = [
             UniekeIdentificatieValidator(),
             ZaakArchiveIOsArchivedValidator(),
+            HoofdZaaktypeRelationValidator(),
         ]
 
     def __init__(self, *args, **kwargs):

--- a/src/openzaak/components/zaken/tests/test_validation.py
+++ b/src/openzaak/components/zaken/tests/test_validation.py
@@ -24,7 +24,6 @@ from vng_api_common.validators import (
     URLValidator,
 )
 
-from openzaak.components.catalogi.models import catalogus
 from openzaak.components.catalogi.tests.factories import (
     EigenschapFactory,
     ResultaatTypeFactory,
@@ -35,6 +34,7 @@ from openzaak.components.catalogi.tests.factories import (
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
+from openzaak.tests.utils import mock_service_oas_get
 from openzaak.utils.tests import JWTAuthMixin, get_eio_response, mock_client
 
 from ..constants import AardZaakRelatie, BetalingsIndicatie
@@ -47,7 +47,7 @@ from .factories import (
     ZaakInformatieObjectFactory,
     ZaakObjectFactory,
 )
-from .utils import ZAAK_WRITE_KWARGS, isodatetime
+from .utils import ZAAK_WRITE_KWARGS, get_zaaktype_response, isodatetime
 
 
 class ZaakValidationTests(JWTAuthMixin, APITestCase):
@@ -519,8 +519,6 @@ class DeelZaakValidationTests(JWTAuthMixin, APITestCase):
         """
         # set up zaaktypen
         hoofdzaaktype = ZaakTypeFactory.create()
-        deelzaaktype = ZaakTypeFactory.create(catalogus=hoofdzaaktype.catalogus)
-        hoofdzaaktype.deelzaaktypen.set([deelzaaktype])
         unrelated_zaaktype = ZaakTypeFactory.create(
             catalogus=hoofdzaaktype.catalogus, concept=False
         )
@@ -540,6 +538,46 @@ class DeelZaakValidationTests(JWTAuthMixin, APITestCase):
             },
             **ZAAK_WRITE_KWARGS,
         )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "hoofdzaak")
+        self.assertEqual(error["code"], "invalid-deelzaaktype")
+
+    @tag("gh-992", "external-urls")
+    def test_validate_hoofdzaaktype_deelzaaktypen_remote_zaaktype(self):
+        """
+        Assert that the zaatkype allowed deelzaaktypen is validated.
+        """
+        # set up zaaktypen
+        catalogus = "https://externe.catalogus.nl/api/v1/catalogussen/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
+        hoofdzaaktype = "https://externe.catalogus.nl/api/v1/zaaktypen/b71f72ef-198d-44d8-af64-ae1932df830a"
+        unrelated_zaaktype = "https://externe.catalogus.nl/api/v1/zaaktypen/fd2fe097-d033-4a9f-99f4-78abd652e6fd"
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "ztc", oas_url=settings.ZTC_API_SPEC)
+            m.get(
+                hoofdzaaktype,
+                json=get_zaaktype_response(catalogus, hoofdzaaktype, deelzaaktypen=[]),
+            )
+            m.get(
+                unrelated_zaaktype,
+                json=get_zaaktype_response(catalogus, unrelated_zaaktype),
+            )
+            # set up hoofdzaak
+            hoofdzaak = ZaakFactory.create(zaaktype=hoofdzaaktype)
+            url = reverse("zaak-list")
+
+            response = self.client.post(
+                url,
+                {
+                    "zaaktype": unrelated_zaaktype,
+                    "hoofdzaak": reverse(hoofdzaak),
+                    "bronorganisatie": "123456782",
+                    "verantwoordelijkeOrganisatie": "123456782",
+                    "startdatum": "1970-01-01",
+                },
+                **ZAAK_WRITE_KWARGS,
+            )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 

--- a/src/openzaak/components/zaken/tests/test_validation.py
+++ b/src/openzaak/components/zaken/tests/test_validation.py
@@ -365,7 +365,8 @@ class ZaakValidationTests(JWTAuthMixin, APITestCase):
         self.assertEqual(validation_error["code"], "bad-url")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    def test_validate_selectielijstklasse_invalid_resource(self):
+    @patch("vng_api_common.validators.obj_has_shape", return_value=False)
+    def test_validate_selectielijstklasse_invalid_resource(self, mock_has_shape):
         url = reverse("zaak-list")
         responses = {"https://ztc.com/resultaten/1234": {"some": "incorrect property"}}
 

--- a/src/openzaak/components/zaken/tests/utils.py
+++ b/src/openzaak/components/zaken/tests/utils.py
@@ -26,7 +26,7 @@ def get_operation_url(operation, **kwargs):
     return _get_operation_url(operation, spec_path=settings.SPEC_URL["zaken"], **kwargs)
 
 
-def get_zaaktype_response(catalogus: str, zaaktype: str) -> dict:
+def get_zaaktype_response(catalogus: str, zaaktype: str, **overrides) -> dict:
     return {
         "url": zaaktype,
         "catalogus": catalogus,
@@ -66,6 +66,7 @@ def get_zaaktype_response(catalogus: str, zaaktype: str) -> dict:
         "beginGeldigheid": "2019-11-20",
         "versiedatum": "2019-11-20",
         "concept": False,
+        **overrides,
     }
 
 


### PR DESCRIPTION
Fixes #992

**Changes**

* Added validator to check that zaak.zaaktype is in zaak.hoofdzaak.zaaktype.deelzaaktypen
* Added tests for both local/remote zaaktypen
* Worked around some broken test isolation because of process-level caches

