### PR TITLE
Fix duplicate results returned in zaak list endpoint

### DIFF
--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -220,6 +220,7 @@ class ZaakViewSet(
             ),
         )
         .order_by("-pk")
+        .distinct()
     )
     serializer_class = ZaakSerializer
     search_input_serializer_class = ZaakZoekSerializer


### PR DESCRIPTION
Fixes #1023

**Changes**

Modified viewset queryset to only emit distinct results.

I looked into specifying the `distinct=True` option to the filterset field, but since this is all going through regular introspection, this solution is much more explicit and easier to understand with the same end-result.

