### PR TITLE
Extend admin validations on zaaktype publish

### DIFF
--- a/src/openzaak/components/catalogi/admin/forms.py
+++ b/src/openzaak/components/catalogi/admin/forms.py
@@ -201,6 +201,31 @@ class ZaakTypeForm(forms.ModelForm):
                 ),
             )
 
+        num_roltypen = self.instance.roltype_set.count()
+        if not num_roltypen >= 1:
+            self.add_error(
+                None,
+                _("Publishing a zaaktype requires at least one roltype to be defined."),
+            )
+
+        num_resultaattypen = self.instance.resultaattypen.count()
+        if not num_resultaattypen >= 1:
+            self.add_error(
+                None,
+                _(
+                    "Publishing a zaaktype requires at least one resultaattype to be defined."
+                ),
+            )
+
+        num_statustypen = self.instance.statustypen.count()
+        if not num_statustypen >= 2:
+            self.add_error(
+                None,
+                _(
+                    "Publishing a zaaktype requires at least two statustypes to be defined."
+                ),
+            )
+
 
 class ResultaatTypeForm(forms.ModelForm):
     # set by filthy admin voodoo in ResultaatTypeAdmin.get_form as a class attribute

--- a/src/openzaak/components/catalogi/admin/mixins.py
+++ b/src/openzaak/components/catalogi/admin/mixins.py
@@ -3,7 +3,7 @@
 from copy import deepcopy
 from urllib.parse import parse_qsl, quote as urlquote
 
-from django.contrib import messages
+from django.contrib import admin, messages
 from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
 from django.core.exceptions import PermissionDenied
 from django.core.management import CommandError, call_command
@@ -83,6 +83,7 @@ class PublishAdminMixin:
         """
         return not obj.concept
 
+    @admin.action(description=_("Publish selected %(verbose_name_plural)s"))
     def publish_selected(self, request, queryset):
         published = 0
         already_published = queryset.filter(concept=False).count()
@@ -129,8 +130,6 @@ class PublishAdminMixin:
 
     is_published.short_description = _("gepubliceerd")
     is_published.boolean = True
-
-    publish_selected.short_description = _("Publish selected objects")
 
 
 class SideEffectsMixin:

--- a/src/openzaak/components/catalogi/admin/zaaktypen.py
+++ b/src/openzaak/components/catalogi/admin/zaaktypen.py
@@ -6,7 +6,7 @@ from django.apps import apps
 from django.contrib import admin, messages
 from django.db import transaction
 from django.db.models import Field
-from django.forms import ChoiceField
+from django.forms import ChoiceField, model_to_dict
 from django.http import HttpRequest
 from django.utils.translation import ugettext_lazy as _
 
@@ -273,6 +273,16 @@ class ZaakTypeAdmin(
             or obj.informatieobjecttypen.filter(concept=True).exists()
         ):
             errors.append(_("All related resources should be published"))
+
+        form = self.form(instance=obj, data={**model_to_dict(obj), "_publish": "1"})
+        if not form.is_valid():
+            for field_name, error_list in form.errors.items():
+                if field_name != "__all__":
+                    form_field = form.fields[field_name]
+                    errors += [f"{form_field.label}: {err}" for err in error_list]
+                else:
+                    errors += error_list
+
         return errors
 
     def get_object_actions(self, obj):

--- a/src/openzaak/components/catalogi/tests/admin/test_admin_publish.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_admin_publish.py
@@ -23,6 +23,9 @@ from openzaak.utils.tests import ClearCachesMixin
 from ..factories import (
     BesluitTypeFactory,
     InformatieObjectTypeFactory,
+    ResultaatTypeFactory,
+    RolTypeFactory,
+    StatusTypeFactory,
     ZaakTypeFactory,
     ZaakTypeInformatieObjectTypeFactory,
 )
@@ -59,6 +62,11 @@ class ZaaktypeAdminTests(
         mock_oas_get(m)
         mock_resource_list(m, "procestypen")
         mock_resource_get(m, "procestypen", procestype_url)
+        selectielijst_resultaat = (
+            "https://selectielijst.openzaak.nl/api/v1/"
+            "resultaten/cc5ae4e3-a9e6-4386-bcee-46be4986a829"
+        )
+        mock_resource_get(m, "resultaten", url=selectielijst_resultaat)
         mock_nrc_oas_get(m)
         m.post(
             "https://notificaties-api.vng.cloud/api/v1/notificaties", status_code=201
@@ -71,7 +79,14 @@ class ZaaktypeAdminTests(
             trefwoorden=["test"],
             verantwoordingsrelatie=["bla"],
             selectielijst_procestype=procestype_url,
+            verlenging_mogelijk=False,
         )
+        StatusTypeFactory.create(zaaktype=zaaktype, statustypevolgnummer=1)
+        StatusTypeFactory.create(zaaktype=zaaktype, statustypevolgnummer=2)
+        ResultaatTypeFactory.create(
+            zaaktype=zaaktype, selectielijstklasse=selectielijst_resultaat
+        )
+        RolTypeFactory.create(zaaktype=zaaktype)
         url = reverse("admin:catalogi_zaaktype_change", args=(zaaktype.pk,))
 
         response = self.app.get(url)
@@ -163,7 +178,16 @@ class ZaaktypeAdminTests(
 
     def test_publish_zaaktype_related_to_concept_besluittype_fails(self, m):
         mock_oas_get(m)
+        procestype_url = (
+            "https://selectielijst.openzaak.nl/api/v1/"
+            "procestypen/e1b73b12-b2f6-4c4e-8929-94f84dd2a57d"
+        )
         mock_resource_list(m, "procestypen")
+        selectielijst_resultaat = (
+            "https://selectielijst.openzaak.nl/api/v1/"
+            "resultaten/cc5ae4e3-a9e6-4386-bcee-46be4986a829"
+        )
+        mock_resource_get(m, "resultaten", url=selectielijst_resultaat)
 
         zaaktype = ZaakTypeFactory.create(
             concept=True,
@@ -171,8 +195,16 @@ class ZaaktypeAdminTests(
             vertrouwelijkheidaanduiding="openbaar",
             trefwoorden=["test"],
             verantwoordingsrelatie=["bla"],
+            selectielijst_procestype=procestype_url,
+            verlenging_mogelijk=False,
         )
         BesluitTypeFactory.create(concept=True, zaaktypen=[zaaktype])
+        StatusTypeFactory.create(zaaktype=zaaktype, statustypevolgnummer=1)
+        StatusTypeFactory.create(zaaktype=zaaktype, statustypevolgnummer=2)
+        ResultaatTypeFactory.create(
+            zaaktype=zaaktype, selectielijstklasse=selectielijst_resultaat
+        )
+        RolTypeFactory.create(zaaktype=zaaktype)
         url = reverse("admin:catalogi_zaaktype_change", args=(zaaktype.pk,))
 
         response = self.app.get(url)
@@ -206,7 +238,16 @@ class ZaaktypeAdminTests(
 
     def test_publish_zaaktype_related_to_concept_informatieobjecttype_fails(self, m):
         mock_oas_get(m)
+        procestype_url = (
+            "https://selectielijst.openzaak.nl/api/v1/"
+            "procestypen/e1b73b12-b2f6-4c4e-8929-94f84dd2a57d"
+        )
         mock_resource_list(m, "procestypen")
+        selectielijst_resultaat = (
+            "https://selectielijst.openzaak.nl/api/v1/"
+            "resultaten/cc5ae4e3-a9e6-4386-bcee-46be4986a829"
+        )
+        mock_resource_get(m, "resultaten", url=selectielijst_resultaat)
 
         zaaktype = ZaakTypeFactory.create(
             concept=True,
@@ -214,7 +255,15 @@ class ZaaktypeAdminTests(
             vertrouwelijkheidaanduiding="openbaar",
             trefwoorden=["test"],
             verantwoordingsrelatie=["bla"],
+            selectielijst_procestype=procestype_url,
+            verlenging_mogelijk=False,
         )
+        StatusTypeFactory.create(zaaktype=zaaktype, statustypevolgnummer=1)
+        StatusTypeFactory.create(zaaktype=zaaktype, statustypevolgnummer=2)
+        ResultaatTypeFactory.create(
+            zaaktype=zaaktype, selectielijstklasse=selectielijst_resultaat
+        )
+        RolTypeFactory.create(zaaktype=zaaktype)
         ZaakTypeInformatieObjectTypeFactory.create(
             informatieobjecttype__concept=True, zaaktype=zaaktype
         )


### PR DESCRIPTION
Fixes #1085

**Changes**

* Extra validation runs on zaaktype publish
    * Check that a roltype is defined
    * Check that a resultaattype is defined
    * Check that at least two statustypen are defined
* Also run form-validation on bulk publish and convert the errors in admin messages

