### PR TITLE
:whale: Reduce docker build context and image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,19 +1,32 @@
 node_modules
+**/__pycache__
+*.pyc
 Dockerfile*
 docker-compose*
 .dockerignore
 .git
+.github/
 .vscode
+deployment/
+docs/
+docker/
 env/
 
 private-media/
 media/
 static/
 log/
+.coverage
+htmlcov
 
 .env
 includes/local.py
-volumes/
+docker/volumes/
 
+# tests & test assets
+src/**/tests/**
+src/openzaak/tests/schemas/
+
+# compiled static assets
 src/openzaak/static/css/
 src/openzaak/static/js/


### PR DESCRIPTION
This excludes tests, cached bytecode and test assets from ending up in the final container image.
This code is never meant to be run or used in production scenario's,
so we remove dead weight. A nice benefit is that the container image
should be a bit smaller in the end.

