### PR TITLE
:bug: [#1042] Disallow mutating published ZaakTypen via the admin

### DIFF
--- a/src/openzaak/components/catalogi/admin/mixins.py
+++ b/src/openzaak/components/catalogi/admin/mixins.py
@@ -415,6 +415,9 @@ class ReadOnlyPublishedParentMixin(ReadOnlyPublishedBaseMixin):
         if self.get_concept(obj):
             return super().has_change_permission(request, obj)
 
+        if request.method == "GET":
+            return False
+
         # If the new ZaakType is published and the form is valid, the user should have
         # read-only access. If the new ZaakType is published and the form is invalid,
         # the permissions for the old ZaakType apply

--- a/src/openzaak/components/catalogi/models/eigenschap.py
+++ b/src/openzaak/components/catalogi/models/eigenschap.py
@@ -206,13 +206,15 @@ class Eigenschap(ETagMixin, models.Model):
             "URL-referentie naar het ZAAKTYPE van de ZAAKen waarvoor deze EIGENSCHAP van belang is."
         ),
         on_delete=models.CASCADE,
-        validators=[validate_zaaktype_concept],
     )
 
     class Meta:
         unique_together = ("zaaktype", "eigenschapnaam")
         verbose_name = _("Eigenschap")
         verbose_name_plural = _("Eigenschappen")
+
+    def clean(self):
+        validate_zaaktype_concept(self.zaaktype)
 
     def __str__(self):
         return self.eigenschapnaam

--- a/src/openzaak/components/catalogi/models/eigenschap.py
+++ b/src/openzaak/components/catalogi/models/eigenschap.py
@@ -11,7 +11,11 @@ from django_better_admin_arrayfield.models.fields import ArrayField
 from vng_api_common.caching import ETagMixin
 
 from ..constants import FormaatChoices
-from .validators import validate_kardinaliteit, validate_letters_numbers_underscores
+from .validators import (
+    validate_kardinaliteit,
+    validate_letters_numbers_underscores,
+    validate_zaaktype_concept,
+)
 
 
 class EigenschapSpecificatie(models.Model):
@@ -202,6 +206,7 @@ class Eigenschap(ETagMixin, models.Model):
             "URL-referentie naar het ZAAKTYPE van de ZAAKen waarvoor deze EIGENSCHAP van belang is."
         ),
         on_delete=models.CASCADE,
+        validators=[validate_zaaktype_concept],
     )
 
     class Meta:

--- a/src/openzaak/components/catalogi/models/resultaattype.py
+++ b/src/openzaak/components/catalogi/models/resultaattype.py
@@ -17,6 +17,8 @@ from vng_api_common.descriptors import GegevensGroepType
 
 from openzaak.utils.fields import DurationField
 
+from .validators import validate_zaaktype_concept
+
 
 class ResultaatType(ETagMixin, models.Model):
     """
@@ -58,6 +60,7 @@ class ResultaatType(ETagMixin, models.Model):
             "URL-referentie naar het ZAAKTYPE van ZAAKen waarin resultaten van "
             "dit RESULTAATTYPE bereikt kunnen worden."
         ),
+        validators=[validate_zaaktype_concept],
     )
 
     # core data - used by ZRC to calculate archival-related dates

--- a/src/openzaak/components/catalogi/models/resultaattype.py
+++ b/src/openzaak/components/catalogi/models/resultaattype.py
@@ -60,7 +60,6 @@ class ResultaatType(ETagMixin, models.Model):
             "URL-referentie naar het ZAAKTYPE van ZAAKen waarin resultaten van "
             "dit RESULTAATTYPE bereikt kunnen worden."
         ),
-        validators=[validate_zaaktype_concept],
     )
 
     # core data - used by ZRC to calculate archival-related dates
@@ -258,6 +257,9 @@ class ResultaatType(ETagMixin, models.Model):
             )
 
         super().save(*args, **kwargs)
+
+    def clean(self):
+        validate_zaaktype_concept(self.zaaktype)
 
     def __str__(self):
         return f"{self.zaaktype} - {self.omschrijving}"

--- a/src/openzaak/components/catalogi/models/roltype.py
+++ b/src/openzaak/components/catalogi/models/roltype.py
@@ -55,13 +55,15 @@ class RolType(ETagMixin, models.Model):
         help_text=_(
             "URL-referentie naar het ZAAKTYPE waar deze ROLTYPEn betrokken kunnen zijn."
         ),
-        validators=[validate_zaaktype_concept],
     )
 
     class Meta:
         unique_together = ("zaaktype", "omschrijving")
         verbose_name = _("Roltype")
         verbose_name_plural = _("Roltypen")
+
+    def clean(self):
+        validate_zaaktype_concept(self.zaaktype)
 
     def __str__(self):
         return self.omschrijving

--- a/src/openzaak/components/catalogi/models/roltype.py
+++ b/src/openzaak/components/catalogi/models/roltype.py
@@ -8,6 +8,8 @@ from django.utils.translation import ugettext_lazy as _
 from vng_api_common.caching import ETagMixin
 from vng_api_common.constants import RolOmschrijving
 
+from .validators import validate_zaaktype_concept
+
 
 class RolType(ETagMixin, models.Model):
     """
@@ -53,6 +55,7 @@ class RolType(ETagMixin, models.Model):
         help_text=_(
             "URL-referentie naar het ZAAKTYPE waar deze ROLTYPEn betrokken kunnen zijn."
         ),
+        validators=[validate_zaaktype_concept],
     )
 
     class Meta:

--- a/src/openzaak/components/catalogi/models/statustype.py
+++ b/src/openzaak/components/catalogi/models/statustype.py
@@ -36,7 +36,6 @@ class StatusType(ETagMixin, models.Model):
         help_text=_(
             "URL-referentie naar het ZAAKTYPE van ZAAKen waarin STATUSsen van dit STATUSTYPE bereikt kunnen worden."
         ),
-        validators=[validate_zaaktype_concept],
     )
 
     # attributes
@@ -94,6 +93,9 @@ class StatusType(ETagMixin, models.Model):
         verbose_name = _("Statustype")
         verbose_name_plural = _("Statustypen")
         ordering = ("zaaktype", "-statustypevolgnummer")
+
+    def clean(self):
+        validate_zaaktype_concept(self.zaaktype)
 
     def is_eindstatus(self):
         """

--- a/src/openzaak/components/catalogi/models/statustype.py
+++ b/src/openzaak/components/catalogi/models/statustype.py
@@ -8,6 +8,8 @@ from django.utils.translation import ugettext_lazy as _
 
 from vng_api_common.caching import ETagMixin
 
+from .validators import validate_zaaktype_concept
+
 
 class StatusType(ETagMixin, models.Model):
     """
@@ -34,6 +36,7 @@ class StatusType(ETagMixin, models.Model):
         help_text=_(
             "URL-referentie naar het ZAAKTYPE van ZAAKen waarin STATUSsen van dit STATUSTYPE bereikt kunnen worden."
         ),
+        validators=[validate_zaaktype_concept],
     )
 
     # attributes

--- a/src/openzaak/components/catalogi/models/validators.py
+++ b/src/openzaak/components/catalogi/models/validators.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
 from dataclasses import dataclass
+from typing import Union
 
 from django.apps import apps
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator, _lazy_re_compile
+from django.db import models
 from django.utils.deconstruct import deconstructible
 from django.utils.translation import ugettext_lazy as _
 
@@ -72,15 +74,17 @@ class ConceptStatusValidator:
     app_name: str
     model_name: str
 
-    def __call__(self, pk):
-        model = apps.get_model(self.app_name, self.model_name)
-        obj = model.objects.get(pk=pk)
+    def __call__(self, instance_or_pk: Union[models.Model, int]):
+        obj = instance_or_pk
+        if not isinstance(obj, models.Model):
+            model = apps.get_model(self.app_name, self.model_name)
+            obj = model.objects.get(pk=instance_or_pk)
 
         if not obj.concept:
             raise ValidationError(
                 _(
                     "Creating a relation to non-concept {resource_name} is forbidden"
-                ).format(resource_name=self.model_name.lower())
+                ).format(resource_name=obj._meta.model_name)
             )
 
 

--- a/src/openzaak/components/catalogi/models/validators.py
+++ b/src/openzaak/components/catalogi/models/validators.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
+from dataclasses import dataclass
+
+from django.apps import apps
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator, _lazy_re_compile
 from django.utils.deconstruct import deconstructible
@@ -62,3 +65,23 @@ letters_numbers_underscores_spaces_validator = RegexValidator(
 
 def validate_letters_numbers_underscores_spaces(value):
     return letters_numbers_underscores_spaces_validator(value)
+
+
+@dataclass
+class ConceptStatusValidator:
+    app_name: str
+    model_name: str
+
+    def __call__(self, pk):
+        model = apps.get_model(self.app_name, self.model_name)
+        obj = model.objects.get(pk=pk)
+
+        if not obj.concept:
+            raise ValidationError(
+                _(
+                    "Creating a relation to non-concept {resource_name} is forbidden"
+                ).format(resource_name=self.model_name.lower())
+            )
+
+
+validate_zaaktype_concept = ConceptStatusValidator("catalogi", "ZaakType")

--- a/src/openzaak/components/catalogi/models/validators.py
+++ b/src/openzaak/components/catalogi/models/validators.py
@@ -73,6 +73,7 @@ def validate_letters_numbers_underscores_spaces(value):
 class ConceptStatusValidator:
     app_name: str
     model_name: str
+    field_name: str
 
     def __call__(self, instance_or_pk: Union[models.Model, int]):
         obj = instance_or_pk
@@ -82,10 +83,12 @@ class ConceptStatusValidator:
 
         if not obj.concept:
             raise ValidationError(
-                _(
-                    "Creating a relation to non-concept {resource_name} is forbidden"
-                ).format(resource_name=obj._meta.model_name)
+                {
+                    self.field_name: _(
+                        "Creating a relation to non-concept {resource_name} is forbidden"
+                    ).format(resource_name=obj._meta.model_name)
+                }
             )
 
 
-validate_zaaktype_concept = ConceptStatusValidator("catalogi", "ZaakType")
+validate_zaaktype_concept = ConceptStatusValidator("catalogi", "ZaakType", "zaaktype")

--- a/src/openzaak/components/catalogi/tests/admin/test_eigenschap_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_eigenschap_admin.py
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
+from django.test import tag
 from django.urls import reverse
+from django.utils.translation import gettext as _
 
 from django_webtest import WebTest
 
 from openzaak.accounts.tests.factories import SuperUserFactory
 
-from ...models import EigenschapSpecificatie
-from ..factories import EigenschapSpecificatieFactory
+from ...models import Eigenschap, EigenschapSpecificatie
+from ..factories import EigenschapSpecificatieFactory, ZaakTypeFactory
 
 
 class EigenschapSpecificatieAdminTests(WebTest):
@@ -49,3 +51,44 @@ class EigenschapSpecificatieAdminTests(WebTest):
 
         new_specificatie = EigenschapSpecificatie.objects.get()
         self.assertEqual(new_specificatie.lengte, "5,3")
+
+
+@tag("gh-1042")
+class EigenschapAdminTests(WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = SuperUserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+
+        self.app.set_user(self.user)
+
+    def test_create_eigenschap_for_published_zaaktype_not_allowed(self):
+        zaaktype = ZaakTypeFactory.create(concept=False)
+        specificatie = EigenschapSpecificatieFactory.create(
+            waardenverzameling=["some,comma", "bla"]
+        )
+
+        response = self.app.get(reverse("admin:catalogi_eigenschap_add"))
+
+        response.form["eigenschapnaam"] = "foo"
+        response.form["definitie"] = "bar"
+        response.form["specificatie_van_eigenschap"] = specificatie.id
+        response.form["toelichting"] = "baz"
+        response.form["zaaktype"] = zaaktype.id
+        response = response.form.submit()
+
+        self.assertEqual(
+            response.context["adminform"].errors,
+            {
+                "zaaktype": [
+                    _(
+                        "Creating a relation to non-concept {resource} is forbidden"
+                    ).format(resource="zaaktype")
+                ]
+            },
+        )
+        self.assertEqual(Eigenschap.objects.count(), 0)

--- a/src/openzaak/components/catalogi/tests/admin/test_roltype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_roltype_admin.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2020 Dimpact
+from django.test import tag
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from django_webtest import WebTest
+from vng_api_common.constants import RolOmschrijving
+
+from openzaak.accounts.tests.factories import SuperUserFactory
+
+from ...models import RolType
+from ..factories import ZaakTypeFactory
+
+
+@tag("gh-1042")
+class RolTypeAdminTests(WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = SuperUserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+
+        self.app.set_user(self.user)
+
+    def test_create_roltype_for_published_zaaktype_not_allowed(self):
+        zaaktype = ZaakTypeFactory.create(concept=False)
+
+        response = self.app.get(reverse("admin:catalogi_roltype_add"))
+
+        response.form["omschrijving"] = "foo"
+        response.form["omschrijving_generiek"] = RolOmschrijving.adviseur
+        response.form["zaaktype"] = zaaktype.id
+        response = response.form.submit()
+
+        self.assertEqual(
+            response.context["adminform"].errors,
+            {
+                "zaaktype": [
+                    _(
+                        "Creating a relation to non-concept {resource} is forbidden"
+                    ).format(resource="zaaktype")
+                ]
+            },
+        )
+        self.assertEqual(RolType.objects.count(), 0)

--- a/src/openzaak/components/catalogi/tests/admin/test_statustype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_statustype_admin.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2020 Dimpact
+from django.test import tag
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from django_webtest import WebTest
+
+from openzaak.accounts.tests.factories import SuperUserFactory
+
+from ...models import StatusType
+from ..factories import ZaakTypeFactory
+
+
+@tag("gh-1042")
+class StatusTypeAdminTests(WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = SuperUserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+
+        self.app.set_user(self.user)
+
+    def test_create_statustype_for_published_zaaktype_not_allowed(self):
+        zaaktype = ZaakTypeFactory.create(concept=False)
+
+        response = self.app.get(reverse("admin:catalogi_statustype_add"))
+
+        response.form["statustype_omschrijving"] = "foo"
+        response.form["statustypevolgnummer"] = 1
+        response.form["zaaktype"] = zaaktype.id
+        response = response.form.submit()
+
+        self.assertEqual(
+            response.context["adminform"].errors,
+            {
+                "zaaktype": [
+                    _(
+                        "Creating a relation to non-concept {resource} is forbidden"
+                    ).format(resource="zaaktype")
+                ]
+            },
+        )
+        self.assertEqual(StatusType.objects.count(), 0)


### PR DESCRIPTION
Fixes #1042 

**Changes**

* Disallow mutating published ZaakTypen via the admin
* Fix change form incorrectly displaying as readonly

