### PR TITLE
Bump to patched vng-api-common

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -300,7 +300,7 @@ urllib3==1.26.9
     #   sentry-sdk
 uwsgi==2.0.20
     # via -r requirements/base.in
-vng-api-common==1.7.7
+vng-api-common==1.7.8
     # via
     #   -r requirements/base.in
     #   drc-cmis

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -433,7 +433,7 @@ urllib3==1.26.9
     #   sentry-sdk
 uwsgi==2.0.20
     # via -r requirements/base.txt
-vng-api-common==1.7.7
+vng-api-common==1.7.8
     # via
     #   -r requirements/base.txt
     #   drc-cmis

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -593,7 +593,7 @@ urllib3==1.26.9
     #   sentry-sdk
 uwsgi==2.0.20
     # via -r requirements/ci.txt
-vng-api-common==1.7.7
+vng-api-common==1.7.8
     # via
     #   -r requirements/ci.txt
     #   drc-cmis


### PR DESCRIPTION
Fixes #1186

**Changes**

Bumped to vng-api-common 1.7.8 which includes "smart" migrations to detect the right course of action.

