### PR TITLE
Remove real_http=True in test mocks

### DIFF
--- a/src/openzaak/components/besluiten/tests/test_besluit_create.py
+++ b/src/openzaak/components/besluiten/tests/test_besluit_create.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2019 - 2020 Dimpact
 from datetime import date
 
+from django.conf import settings
 from django.test import override_settings, tag
 
 import requests_mock
@@ -15,6 +16,7 @@ from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
 from openzaak.components.zaken.tests.factories import ZaakFactory
+from openzaak.tests.utils import mock_service_oas_get
 from openzaak.utils.tests import JWTAuthMixin
 
 from ..constants import VervalRedenen
@@ -212,15 +214,13 @@ class BesluitCreateExternalURLsTests(TypeCheckMixin, JWTAuthMixin, APITestCase):
         besluittype = "https://externe.catalogus.nl/api/v1/besluittypen/b71f72ef-198d-44d8-af64-ae1932df830a"
         url = get_operation_url("besluit_create")
 
-        with requests_mock.Mocker(real_http=True) as m:
-            m.register_uri(
-                "GET",
-                besluittype,
-                json=get_besluittype_response(catalogus, besluittype),
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "ztc", oas_url=settings.ZTC_API_SPEC)
+            m.get(
+                besluittype, json=get_besluittype_response(catalogus, besluittype),
             )
 
-            m.register_uri(
-                "GET",
+            m.get(
                 catalogus,
                 json={
                     "url": catalogus,
@@ -305,9 +305,9 @@ class BesluitCreateExternalURLsTests(TypeCheckMixin, JWTAuthMixin, APITestCase):
         besluittype = "https://externe.catalogus.nl/api/v1/besluittypen/b71f72ef-198d-44d8-af64-ae1932df830a"
         url = get_operation_url("besluit_create")
 
-        with requests_mock.Mocker(real_http=True) as m:
-            m.register_uri(
-                "GET",
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "ztc", oas_url=settings.ZTC_API_SPEC)
+            m.get(
                 besluittype,
                 json={
                     "url": besluittype,
@@ -319,8 +319,7 @@ class BesluitCreateExternalURLsTests(TypeCheckMixin, JWTAuthMixin, APITestCase):
                     "concept": False,
                 },
             )
-            m.register_uri(
-                "GET",
+            m.get(
                 catalogus,
                 json={
                     "url": catalogus,

--- a/src/openzaak/components/besluiten/tests/test_besluit_with_external_zaak.py
+++ b/src/openzaak/components/besluiten/tests/test_besluit_with_external_zaak.py
@@ -52,7 +52,7 @@ class BesluitCreateExternalZaakTests(TypeCheckMixin, JWTAuthMixin, APITestCase):
         zaakbesluit_data = get_zaakbesluit_response(zaak)
 
         # create besluit
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
             m.get(zaak, json=get_zaak_response(zaak, zaaktype_url))
             m.post(f"{zaak}/besluiten", json=zaakbesluit_data)
             besluit = BesluitFactory.create(
@@ -73,7 +73,7 @@ class BesluitCreateExternalZaakTests(TypeCheckMixin, JWTAuthMixin, APITestCase):
         zaakbesluit_data = get_zaakbesluit_response(zaak)
         url = get_operation_url("besluit_create")
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
             mock_service_oas_get(m, APITypes.zrc, self.base)
             m.get(zaak, json=get_zaak_response(zaak, zaaktype_url))
             m.post(f"{zaak}/besluiten", json=zaakbesluit_data, status_code=201)
@@ -117,7 +117,7 @@ class BesluitCreateExternalZaakTests(TypeCheckMixin, JWTAuthMixin, APITestCase):
         zaak = f"{self.base}zaken/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
         url = get_operation_url("besluit_create")
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
             mock_service_oas_get(m, APITypes.zrc, self.base)
             m.get(zaak, json=get_zaak_response(zaak, zaaktype_url))
             m.post(f"{zaak}/besluiten", status_code=404, text="Not Found")
@@ -156,7 +156,7 @@ class BesluitCreateExternalZaakTests(TypeCheckMixin, JWTAuthMixin, APITestCase):
         zaakbesluit_new_data = get_zaakbesluit_response(zaak_new)
         besluit_url = f"http://testserver{reverse(besluit)}"
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
             mock_service_oas_get(m, APITypes.zrc, self.base)
             m.get(zaak_old, json=get_zaak_response(zaak_old, zaaktype_url))
             m.get(zaak_new, json=get_zaak_response(zaak_new, zaaktype_url))
@@ -200,7 +200,7 @@ class BesluitCreateExternalZaakTests(TypeCheckMixin, JWTAuthMixin, APITestCase):
         zaakbesluit_new_data = get_zaakbesluit_response(zaak_new)
         besluit_url = f"http://testserver{reverse(besluit)}"
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
             mock_service_oas_get(m, APITypes.zrc, self.base)
             m.get(zaak_old, json=get_zaak_response(zaak_old, zaaktype_url))
             m.get(zaak_new, json=get_zaak_response(zaak_new, zaaktype_url))
@@ -224,7 +224,7 @@ class BesluitCreateExternalZaakTests(TypeCheckMixin, JWTAuthMixin, APITestCase):
         zaaktype = besluit.besluittype.zaaktypen.get()
         zaaktype_url = f"http://testserver{reverse(zaaktype)}"
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
             mock_service_oas_get(m, APITypes.zrc, self.base)
             m.get(zaak, json=get_zaak_response(zaak, zaaktype_url))
             m.delete(zaakbesluit_url, status_code=204)
@@ -251,7 +251,7 @@ class BesluitCreateExternalZaakTests(TypeCheckMixin, JWTAuthMixin, APITestCase):
         zaaktype = besluit.besluittype.zaaktypen.get()
         zaaktype_url = f"http://testserver{reverse(zaaktype)}"
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
             mock_service_oas_get(m, APITypes.zrc, self.base)
             m.get(zaak, json=get_zaak_response(zaak, zaaktype_url))
             m.delete(zaakbesluit_url, status_code=404, text="Not found")

--- a/src/openzaak/components/besluiten/tests/test_besluitinformatieobjecten.py
+++ b/src/openzaak/components/besluiten/tests/test_besluitinformatieobjecten.py
@@ -233,8 +233,8 @@ class ExternalDocumentsAPITests(JWTAuthMixin, APITestCase):
         oio_response = get_oio_response(document, besluit_url, "besluit")
 
         with self.subTest(section="bio-create"):
-            with requests_mock.Mocker(real_http=True) as m:
-                mock_service_oas_get(m, APITypes.drc, self.base)
+            with requests_mock.Mocker() as m:
+                mock_service_oas_get(m, "drc", oas_url=settings.DRC_API_SPEC)
                 m.get(document, json=eio_response)
                 m.post(
                     "https://external.documenten.nl/api/v1/objectinformatieobjecten",
@@ -321,7 +321,8 @@ class ExternalDocumentsAPITests(JWTAuthMixin, APITestCase):
         informatieobjecttype_url = f"http://openzaak.nl{reverse(informatieobjecttype)}"
         informatieobjecttype.besluittypen.add(besluit.besluittype)
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "drc", oas_url=settings.DRC_API_SPEC)
             m.get(
                 document,
                 json={
@@ -440,7 +441,8 @@ class ExternalInformatieObjectAPITests(JWTAuthMixin, APITestCase):
             informatieobjecttype=f"http://openbesluit.nl{reverse(informatieobjecttype)}",
         )
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "drc", oas_url=settings.DRC_API_SPEC)
             m.get(self.document, json=eio_response)
             response = self.client.post(
                 self.list_url,
@@ -464,8 +466,8 @@ class ExternalInformatieObjectAPITests(JWTAuthMixin, APITestCase):
         besluittype_data = get_besluittype_response(catalogus, besluittype)
         besluittype_data["informatieobjecttypen"] = [informatieobjecttype]
 
-        with requests_mock.Mocker(real_http=True) as m:
-            mock_service_oas_get(m, APITypes.drc, self.base)
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "drc", oas_url=settings.DRC_API_SPEC)
             m.get(besluittype, json=besluittype_data)
             m.get(
                 informatieobjecttype,
@@ -498,7 +500,8 @@ class ExternalInformatieObjectAPITests(JWTAuthMixin, APITestCase):
         besluit_url = f"http://openbesluit.nl{reverse(besluit)}"
         informatieobjecttype = f"{self.base}informatieobjecttypen/{uuid.uuid4()}"
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "drc", oas_url=settings.DRC_API_SPEC)
             m.get(besluittype, json=get_besluittype_response(catalogus, besluittype))
             m.get(
                 informatieobjecttype,
@@ -530,7 +533,8 @@ class ExternalInformatieObjectAPITests(JWTAuthMixin, APITestCase):
         informatieobjecttype = f"{self.base}informatieobjecttypen/{uuid.uuid4()}"
         catalogus = f"{self.base}catalogussen/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "drc", oas_url=settings.DRC_API_SPEC)
             m.get(
                 informatieobjecttype,
                 json=get_informatieobjecttype_response(catalogus, informatieobjecttype),
@@ -569,7 +573,8 @@ class ExternalInformatieObjectAPITests(JWTAuthMixin, APITestCase):
             informatieobjecttype=f"http://openbesluit.nl{reverse(informatieobjecttype)}",
         )
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "drc", oas_url=settings.DRC_API_SPEC)
             m.get(besluittype, json=get_besluittype_response(catalogus, besluittype))
             m.get(self.document, json=eio_response)
 
@@ -611,7 +616,7 @@ class ExternalDocumentDestroyTests(JWTAuthMixin, APITestCase):
         oio = f"{self.base}objectinformatieobjecten/{uuid.uuid4()}"
         informatieobjecttype = InformatieObjectTypeFactory.create()
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
             mock_service_oas_get(m, APITypes.drc, self.base)
             m.get(
                 self.document,
@@ -645,7 +650,7 @@ class ExternalDocumentDestroyTests(JWTAuthMixin, APITestCase):
         oio = f"{self.base}objectinformatieobjecten/{uuid.uuid4()}"
         informatieobjecttype = InformatieObjectTypeFactory.create()
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
             mock_service_oas_get(m, APITypes.drc, self.base)
             m.get(
                 self.document,

--- a/src/openzaak/components/documenten/tests/test_objectinformatieobject.py
+++ b/src/openzaak/components/documenten/tests/test_objectinformatieobject.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2019 - 2020 Dimpact
 import uuid
 
+from django.conf import settings
 from django.test import override_settings, tag
 
 import requests_mock
@@ -348,7 +349,8 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         eio_path = reverse(eio)
         eio_url = f"http://testserver{eio_path}"
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "zrc", oas_url=settings.ZRC_API_SPEC)
             m.get(zaak, json=get_zaak_response(zaak, zaaktype))
 
             response = self.client.post(
@@ -373,7 +375,8 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         eio_path = reverse(eio)
         eio_url = f"http://testserver{eio_path}"
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "brc", oas_url=settings.BRC_API_SPEC)
             m.get(besluit, json=get_besluit_response(besluit, besluittype))
 
             response = self.client.post(
@@ -401,7 +404,8 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         eio = EnkelvoudigInformatieObjectFactory.create()
         eio_url = reverse(eio)
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "zrc", oas_url=settings.ZRC_API_SPEC)
             m.get(
                 zaak,
                 json={
@@ -433,7 +437,8 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         eio = EnkelvoudigInformatieObjectFactory.create()
         eio_url = reverse(eio)
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "brc", oas_url=settings.BRC_API_SPEC)
             m.get(
                 besluit,
                 json={
@@ -468,7 +473,8 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APITestCase):
             informatieobject=eio.canonical, besluit=besluit, object_type="besluit"
         )
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "brc", oas_url=settings.BRC_API_SPEC)
             m.get(besluit, json=get_besluit_response(besluit, besluittype))
 
             response = self.client.post(

--- a/src/openzaak/components/zaken/tests/test_relevantezaakrelatie.py
+++ b/src/openzaak/components/zaken/tests/test_relevantezaakrelatie.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
+from django.conf import settings
 from django.test import override_settings, tag
 
 import requests_mock
@@ -9,6 +10,7 @@ from vng_api_common.constants import VertrouwelijkheidsAanduiding
 from vng_api_common.tests import get_validation_errors, reverse, reverse_lazy
 
 from openzaak.components.catalogi.tests.factories import ZaakTypeFactory
+from openzaak.tests.utils import mock_service_oas_get
 from openzaak.utils.tests import JWTAuthMixin
 
 from ..constants import AardZaakRelatie
@@ -31,12 +33,9 @@ class ExternalRelevanteZakenTestsTestCase(JWTAuthMixin, APITestCase):
             "https://externe.zaken.nl/api/v1/zaken/a620b183-d898-4576-ae94-3f21d43cc576"
         )
 
-        with requests_mock.Mocker(real_http=True) as m:
-            m.register_uri(
-                "GET",
-                zaak_external,
-                json=get_zaak_response(zaak_external, zaaktype_url),
-            )
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "zrc", oas_url=settings.ZRC_API_SPEC)
+            m.get(zaak_external, json=get_zaak_response(zaak_external, zaaktype_url))
 
             response = self.client.post(
                 self.list_url,
@@ -134,8 +133,9 @@ class ExternalRelevanteZakenTestsTestCase(JWTAuthMixin, APITestCase):
             "zaaktype": zaaktype_url,
         }
 
-        with requests_mock.Mocker(real_http=True) as m:
-            m.register_uri("GET", zaak_external, json=zaak_data)
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "zrc", oas_url=settings.ZRC_API_SPEC)
+            m.get(zaak_external, json=zaak_data)
 
             response = self.client.post(
                 self.list_url,

--- a/src/openzaak/components/zaken/tests/test_resultaten.py
+++ b/src/openzaak/components/zaken/tests/test_resultaten.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
+from django.conf import settings
 from django.test import override_settings, tag
 
 import requests_mock
@@ -7,6 +8,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 from vng_api_common.tests import get_validation_errors, reverse
 
+from openzaak.tests.utils import mock_service_oas_get
 from openzaak.utils.tests import JWTAuthMixin
 
 from .factories import ZaakFactory
@@ -27,7 +29,8 @@ class ResultaatCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         zaak = ZaakFactory(zaaktype=zaaktype)
         zaak_url = reverse(zaak)
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "ztc", oas_url=settings.ZTC_API_SPEC)
             m.get(zaaktype, json=get_zaaktype_response(catalogus, zaaktype))
             m.get(
                 resultaattype, json=get_resultaattype_response(resultaattype, zaaktype)
@@ -91,7 +94,8 @@ class ResultaatCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         zaak = ZaakFactory(zaaktype=zaaktype)
         zaak_url = reverse(zaak)
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "ztc", oas_url=settings.ZTC_API_SPEC)
             m.get(zaaktype, json=get_zaaktype_response(catalogus, zaaktype))
             m.get(
                 resultaattype,
@@ -126,7 +130,8 @@ class ResultaatCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         zaak = ZaakFactory(zaaktype=zaaktype1)
         zaak_url = reverse(zaak)
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "ztc", oas_url=settings.ZTC_API_SPEC)
             m.get(zaaktype1, json=get_zaaktype_response(catalogus, zaaktype1))
             m.get(zaaktype2, json=get_zaaktype_response(catalogus, zaaktype2))
             m.get(

--- a/src/openzaak/components/zaken/tests/test_rol.py
+++ b/src/openzaak/components/zaken/tests/test_rol.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
+from django.conf import settings
 from django.test import override_settings, tag
 
 import requests_mock
@@ -10,6 +11,7 @@ from vng_api_common.constants import RolTypes
 from vng_api_common.tests import TypeCheckMixin, get_validation_errors, reverse
 
 from openzaak.components.catalogi.tests.factories import RolTypeFactory
+from openzaak.tests.utils import mock_service_oas_get
 from openzaak.utils.tests import JWTAuthMixin
 
 from ..constants import IndicatieMachtiging
@@ -490,7 +492,8 @@ class RolCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         zaak = ZaakFactory.create(zaaktype=zaaktype)
         zaak_url = reverse(zaak)
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "ztc", oas_url=settings.ZTC_API_SPEC)
             m.get(zaaktype, json=get_zaaktype_response(catalogus, zaaktype))
             m.get(roltype, json=get_roltype_response(roltype, zaaktype))
 
@@ -559,7 +562,8 @@ class RolCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         zaak = ZaakFactory.create(zaaktype=zaaktype)
         zaak_url = reverse(zaak)
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "ztc", oas_url=settings.ZTC_API_SPEC)
             m.get(zaaktype, json=get_zaaktype_response(catalogus, zaaktype))
             m.get(roltype, json={"url": roltype, "zaaktype": zaaktype})
 
@@ -588,7 +592,8 @@ class RolCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         zaak = ZaakFactory(zaaktype=zaaktype1)
         zaak_url = reverse(zaak)
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "ztc", oas_url=settings.ZTC_API_SPEC)
             m.get(zaaktype1, json=get_zaaktype_response(catalogus, zaaktype1))
             m.get(zaaktype2, json=get_zaaktype_response(catalogus, zaaktype2))
             m.get(roltype, json=get_roltype_response(roltype, zaaktype2))

--- a/src/openzaak/components/zaken/tests/test_zaak_archive.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_archive.py
@@ -5,6 +5,7 @@ Ref: https://github.com/VNG-Realisatie/gemma-zaken/issues/345
 """
 from datetime import date
 
+from django.conf import settings
 from django.test import override_settings, tag
 
 import requests_mock
@@ -31,6 +32,7 @@ from openzaak.components.documenten.constants import Statussen
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
+from openzaak.tests.utils import mock_service_oas_get as oz_mock_service_oas_get
 from openzaak.utils.tests import JWTAuthMixin, get_eio_response
 
 from .factories import (
@@ -1069,9 +1071,10 @@ class ExternalDocumentsAPITests(JWTAuthMixin, APITestCase):
             "datumStatusGezet": "2018-10-18T20:00:00Z",
         }
 
-        with requests_mock.Mocker(real_http=True) as m:
-            m.register_uri("GET", zaak2, json=zaak2_data)
-            m.register_uri("GET", zaak3, json=zaak3_data)
+        with requests_mock.Mocker() as m:
+            oz_mock_service_oas_get(m, "zrc", oas_url=settings.ZRC_API_SPEC)
+            m.get(zaak2, json=zaak2_data)
+            m.get(zaak3, json=zaak3_data)
             response = self.client.post(
                 status_create_url, data, HTTP_HOST="testserver.com"
             )

--- a/src/openzaak/components/zaken/tests/test_zaakbesluiten.py
+++ b/src/openzaak/components/zaken/tests/test_zaakbesluiten.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2022 Dimpact
+from django.conf import settings
 from django.test import override_settings, tag
 from django.utils import timezone
 
@@ -11,6 +12,7 @@ from vng_api_common.tests import get_validation_errors, reverse
 
 from openzaak.components.besluiten.tests.factories import BesluitFactory
 from openzaak.components.besluiten.tests.utils import get_besluit_response
+from openzaak.tests.utils import mock_service_oas_get
 from openzaak.utils.tests import JWTAuthMixin, generate_jwt_auth
 
 from ..models import ZaakBesluit
@@ -233,7 +235,8 @@ class ExternalZaakBesluitTests(JWTAuthMixin, APITestCase):
         zaak_url = f"http://testserver{reverse(zaak)}"
         url = reverse("zaakbesluit-list", kwargs={"zaak_uuid": zaak.uuid})
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "brc", oas_url=settings.BRC_API_SPEC)
             m.get(
                 self.besluit,
                 json=get_besluit_response(self.besluit, self.besluittype, zaak_url),
@@ -254,7 +257,8 @@ class ExternalZaakBesluitTests(JWTAuthMixin, APITestCase):
         zaak = ZaakFactory.create()
         zaak_url = f"http://testserver{reverse(zaak)}"
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "brc", oas_url=settings.BRC_API_SPEC)
             m.get(
                 self.besluit,
                 json=get_besluit_response(self.besluit, self.besluittype, zaak_url),

--- a/src/openzaak/components/zaken/tests/test_zaakeigenschap.py
+++ b/src/openzaak/components/zaken/tests/test_zaakeigenschap.py
@@ -6,6 +6,7 @@ ontvangen, zodat ik voldoende details weet om de melding op te volgen.
 
 ref: https://github.com/VNG-Realisatie/gemma-zaken/issues/52
 """
+from django.conf import settings
 from django.test import override_settings, tag
 from django.utils import timezone
 
@@ -16,6 +17,7 @@ from rest_framework.test import APITestCase
 from vng_api_common.tests import TypeCheckMixin, get_validation_errors, reverse
 
 from openzaak.components.catalogi.tests.factories import EigenschapFactory
+from openzaak.tests.utils import mock_service_oas_get
 from openzaak.utils.tests import JWTAuthMixin, generate_jwt_auth
 
 from ..models import ZaakEigenschap
@@ -120,7 +122,8 @@ class ZaakEigenschapCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         zaak_url = reverse(zaak)
         url = get_operation_url("zaakeigenschap_list", zaak_uuid=zaak.uuid)
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "ztc", oas_url=settings.ZTC_API_SPEC)
             m.get(zaaktype, json=get_zaaktype_response(catalogus, zaaktype))
             m.get(eigenschap, json=get_eigenschap_response(eigenschap, zaaktype))
 
@@ -180,7 +183,8 @@ class ZaakEigenschapCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         zaak_url = reverse(zaak)
         url = get_operation_url("zaakeigenschap_list", zaak_uuid=zaak.uuid)
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "ztc", oas_url=settings.ZTC_API_SPEC)
             m.get(zaaktype, json=get_zaaktype_response(catalogus, zaaktype))
             m.get(eigenschap, json={"url": eigenschap, "zaaktype": zaaktype})
 
@@ -208,7 +212,8 @@ class ZaakEigenschapCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         zaak_url = reverse(zaak)
         url = get_operation_url("zaakeigenschap_list", zaak_uuid=zaak.uuid)
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "ztc", oas_url=settings.ZTC_API_SPEC)
             m.get(zaaktype1, json=get_zaaktype_response(catalogus, zaaktype1))
             m.get(zaaktype2, json=get_zaaktype_response(catalogus, zaaktype2))
             m.get(eigenschap, json=get_eigenschap_response(eigenschap, zaaktype2))

--- a/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten.py
+++ b/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten.py
@@ -257,7 +257,8 @@ class ZaakInformatieObjectAPITests(JWTAuthMixin, APITestCase):
             informatieobjecttype=f"http://openzaak.nl{reverse(zio_type.informatieobjecttype)}",
         )
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "drc", oas_url=settings.DRC_API_SPEC)
             mock_service_oas_get(m, APITypes.drc, base)
             m.get(document1, json=eio1_response)
             m.post(
@@ -543,7 +544,8 @@ class ExternalDocumentsAPITests(JWTAuthMixin, APITestCase):
         zaak = ZaakFactory.create(zaaktype=zio_type.zaaktype)
         zaak_url = f"http://openzaak.nl{reverse(zaak)}"
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "drc", oas_url=settings.DRC_API_SPEC)
             m.get(
                 document,
                 json={
@@ -707,7 +709,8 @@ class ExternalInformatieObjectAPITests(JWTAuthMixin, APITestCase):
             informatieobjecttype=f"http://openzaak.nl{reverse(informatieobjecttype)}",
         )
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "drc", oas_url=settings.DRC_API_SPEC)
             m.get(self.document, json=eio_response)
             response = self.client.post(
                 self.list_url,
@@ -731,7 +734,7 @@ class ExternalInformatieObjectAPITests(JWTAuthMixin, APITestCase):
         zaaktype_data = get_zaaktype_response(catalogus, zaaktype)
         zaaktype_data["informatieobjecttypen"] = [informatieobjecttype]
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
             mock_service_oas_get(m, "drc", self.base)
             m.get(zaaktype, json=zaaktype_data)
             m.get(
@@ -765,7 +768,8 @@ class ExternalInformatieObjectAPITests(JWTAuthMixin, APITestCase):
         zaak_url = f"http://openzaak.nl{reverse(zaak)}"
         informatieobjecttype = f"{self.base}informatieobjecttypen/{uuid.uuid4()}"
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "drc", oas_url=settings.DRC_API_SPEC)
             m.get(zaaktype, json=get_zaaktype_response(catalogus, zaaktype))
             m.get(
                 informatieobjecttype,
@@ -797,7 +801,8 @@ class ExternalInformatieObjectAPITests(JWTAuthMixin, APITestCase):
         informatieobjecttype = f"{self.base}informatieobjecttypen/{uuid.uuid4()}"
         catalogus = f"{self.base}catalogussen/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "drc", oas_url=settings.DRC_API_SPEC)
             m.get(
                 informatieobjecttype,
                 json=get_informatieobjecttype_response(catalogus, informatieobjecttype),
@@ -836,7 +841,8 @@ class ExternalInformatieObjectAPITests(JWTAuthMixin, APITestCase):
             informatieobjecttype=f"http://openzaak.nl{reverse(informatieobjecttype)}",
         )
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
+            mock_service_oas_get(m, "drc", oas_url=settings.DRC_API_SPEC)
             m.get(zaaktype, json=get_zaaktype_response(catalogus, zaaktype))
             m.get(self.document, json=eio_response)
 
@@ -878,7 +884,7 @@ class ExternalDocumentDestroyTests(JWTAuthMixin, APITestCase):
         oio = f"{self.base}objectinformatieobjecten/{uuid.uuid4()}"
         informatieobjecttype = InformatieObjectTypeFactory.create()
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
             mock_service_oas_get(m, "drc", self.base)
             m.get(
                 self.document,
@@ -912,7 +918,7 @@ class ExternalDocumentDestroyTests(JWTAuthMixin, APITestCase):
         oio = f"{self.base}objectinformatieobjecten/{uuid.uuid4()}"
         informatieobjecttype = InformatieObjectTypeFactory.create()
 
-        with requests_mock.Mocker(real_http=True) as m:
+        with requests_mock.Mocker() as m:
             mock_service_oas_get(m, "drc", self.base)
             m.get(
                 self.document,


### PR DESCRIPTION
Replace `real_http=True` with proper schema-fetch mocks.

I confirmed the test suite is now running/passing locally with networking disabled :tada: 