### PR TITLE
Issue/1213 make implicit ordering explicit

### DIFF
--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -372,7 +372,9 @@ class StatusViewSet(
 
     """
 
-    queryset = Status.objects.select_related("_statustype", "zaak").order_by("-pk")
+    queryset = Status.objects.select_related("_statustype", "zaak").order_by(
+        "-datum_status_gezet", "-pk"
+    )
     serializer_class = StatusSerializer
     filterset_class = StatusFilter
     lookup_field = "uuid"


### PR DESCRIPTION
Fixes #1213

**Changes**

* Added explicit Status.Meta.ordering attribute for model-level queries

The API already had the correct ordering.

