### PR TITLE
:bug: [#1227] Validate that remote OIO relation exists

### DIFF
--- a/src/openzaak/components/besluiten/tests/utils.py
+++ b/src/openzaak/components/besluiten/tests/utils.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
+import uuid
 
 from django.conf import settings
 
@@ -45,4 +46,14 @@ def get_besluit_response(besluit: str, besluittype: str, zaak: str = "") -> dict
         "ingangsdatum": "2019-11-18",
         "vervalreden": "",
         "vervalredenWeergave": "",
+    }
+
+
+def get_besluitinformatieobject_response(informatieobject: str, besluit: str) -> dict:
+    bio_uuid = str(uuid.uuid4())
+    return {
+        "url": f"http://testserver/api/v1/besluitinformatieobjecten/{bio_uuid}",
+        "uuid": bio_uuid,
+        "informatieobject": informatieobject,
+        "besluit": besluit,
     }

--- a/src/openzaak/components/zaken/tests/utils.py
+++ b/src/openzaak/components/zaken/tests/utils.py
@@ -122,6 +122,16 @@ def get_zaakbesluit_response(zaak: str) -> dict:
     }
 
 
+def get_zaakinformatieobject_response(informatieobject: str, zaak: str) -> dict:
+    zio_uuid = str(uuid.uuid4())
+    return {
+        "url": f"http://testserver/api/v1/zaakinformatieobjecten/{zio_uuid}",
+        "uuid": zio_uuid,
+        "informatieobject": informatieobject,
+        "zaak": zaak,
+    }
+
+
 def get_resultaattype_response(resultaattype: str, zaaktype: str) -> dict:
     return {
         "url": resultaattype,


### PR DESCRIPTION
Fixes #1227

**Changes**

* Validate if the remote relation exists before creating an ObjectInformatieObject
