### PR TITLE
:wrench: Set DATA_UPLOAD_MAX_NUMBER_FIELDS to 10000

### DIFF
--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -430,6 +430,12 @@ SILENCED_SYSTEM_CHECKS = [
     "debug_toolbar.W006",
 ]
 
+
+#
+# Increase number of parameters for GET/POST requests
+#
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
+
 #
 # Custom settings
 #


### PR DESCRIPTION
to fix failing exports for large catalogi

I noticed that this setting was removed in https://github.com/open-zaak/open-zaak/pull/998, but when attempting to export a large catalogus, it raised issues again