### PR TITLE
Updating mozilla-django-oidc-db to 0.11.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -212,7 +212,7 @@ markupsafe==2.1.1
     # via jinja2
 mozilla-django-oidc==2.0.0
     # via mozilla-django-oidc-db
-mozilla-django-oidc-db==0.10.1
+mozilla-django-oidc-db==0.11.0
     # via -r requirements/base.in
 orderedmultidict==1.0.1
     # via furl

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -303,7 +303,7 @@ mozilla-django-oidc==2.0.0
     # via
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db==0.10.1
+mozilla-django-oidc-db==0.11.0
     # via -r requirements/base.txt
 orderedmultidict==1.0.1
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -364,7 +364,7 @@ mozilla-django-oidc==2.0.0
     # via
     #   -r requirements/ci.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db==0.10.1
+mozilla-django-oidc-db==0.11.0
     # via -r requirements/ci.txt
 oauthlib==3.1.0
     # via requests-oauthlib


### PR DESCRIPTION
Fixes Taiga DH 405

**Changes**

Updating of mozilla-django-oidc-db to 0.11.0 to allow configuration of default permissions in OpenZaak

Replaces PR #1250 