### PR TITLE
Added @require_cmis decorator

### DIFF
--- a/src/openzaak/components/besluiten/tests/models/test_bio_block_change_cmis.py
+++ b/src/openzaak/components/besluiten/tests/models/test_bio_block_change_cmis.py
@@ -2,19 +2,19 @@
 # Copyright (C) 2020 Dimpact
 import uuid
 
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.tests.utils import APICMISTestCase
+from openzaak.tests.utils import APICMISTestCase, require_cmis
 from openzaak.utils.query import QueryBlocked
 
 from ...models import BesluitInformatieObject
 from ..factories import BesluitFactory, BesluitInformatieObjectFactory
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class BlockChangeCMISTestCase(APICMISTestCase):
     def setUp(self) -> None:

--- a/src/openzaak/components/besluiten/tests/models/test_unique_representation_cmis.py
+++ b/src/openzaak/components/besluiten/tests/models/test_unique_representation_cmis.py
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.tests.utils import APICMISTestCase
+from openzaak.tests.utils import APICMISTestCase, require_cmis
 
 from ...tests.factories import BesluitFactory, BesluitInformatieObjectFactory
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class UniqueRepresentationTestCMISCase(APICMISTestCase):
     def test_besluitinformatieobject(self):

--- a/src/openzaak/components/besluiten/tests/test_audittrails_cmis.py
+++ b/src/openzaak/components/besluiten/tests/test_audittrails_cmis.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
 from django.contrib.sites.models import Site
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from rest_framework import status
 from vng_api_common.audittrails.models import AuditTrail
@@ -14,13 +14,18 @@ from openzaak.components.catalogi.tests.factories import BesluitTypeFactory
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, serialise_eio
+from openzaak.tests.utils import (
+    APICMISTestCase,
+    JWTAuthMixin,
+    require_cmis,
+    serialise_eio,
+)
 
 from ...zaken.tests.factories import ZaakFactory
 from ..models import Besluit, BesluitInformatieObject
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class AuditTrailCMISTests(JWTAuthMixin, APICMISTestCase):
 

--- a/src/openzaak/components/besluiten/tests/test_auth_cmis.py
+++ b/src/openzaak/components/besluiten/tests/test_auth_cmis.py
@@ -14,7 +14,7 @@ from openzaak.components.catalogi.tests.factories import BesluitTypeFactory
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ...zaken.tests.factories import ZaakFactory
 from ..api.scopes import SCOPE_BESLUITEN_AANMAKEN, SCOPE_BESLUITEN_ALLES_LEZEN
@@ -26,7 +26,7 @@ BESLUITTYPE_EXTERNAL = (
 )
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class BesluitScopeForbiddenCMISTests(AuthCheckMixin, APICMISTestCase):
     def test_cannot_read_without_correct_scope(self):
@@ -48,7 +48,7 @@ class BesluitScopeForbiddenCMISTests(AuthCheckMixin, APICMISTestCase):
                 self.assertForbidden(url, method="get")
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class BioReadCMISTests(JWTAuthMixin, APICMISTestCase):
 
@@ -126,7 +126,8 @@ class BioReadCMISTests(JWTAuthMixin, APICMISTestCase):
         )
 
 
-@tag("external-urls", "cmis")
+@tag("external-urls")
+@require_cmis
 @override_settings(ALLOWED_HOSTS=["testserver"], CMIS_ENABLED=True)
 class InternalBesluittypeScopeTests(JWTAuthMixin, APICMISTestCase):
     scopes = [SCOPE_BESLUITEN_ALLES_LEZEN]
@@ -195,7 +196,8 @@ class InternalBesluittypeScopeTests(JWTAuthMixin, APICMISTestCase):
         )
 
 
-@tag("external-urls", "cmis")
+@tag("external-urls")
+@require_cmis
 @override_settings(ALLOWED_HOSTS=["testserver"], CMIS_ENABLED=True)
 class ExternalBesluittypeScopeCMISTests(JWTAuthMixin, APICMISTestCase):
     scopes = [SCOPE_BESLUITEN_ALLES_LEZEN]

--- a/src/openzaak/components/besluiten/tests/test_besluit_create_cmis.py
+++ b/src/openzaak/components/besluiten/tests/test_besluit_create_cmis.py
@@ -3,7 +3,7 @@
 from datetime import date
 
 from django.contrib.sites.models import Site
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from freezegun import freeze_time
 from rest_framework import status
@@ -13,7 +13,7 @@ from openzaak.components.catalogi.tests.factories import BesluitTypeFactory
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ...zaken.tests.factories import ZaakFactory
 from ..constants import VervalRedenen
@@ -22,7 +22,7 @@ from .factories import BesluitFactory, BesluitInformatieObjectFactory
 from .utils import get_operation_url
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class BesluitCreateCMISTests(TypeCheckMixin, JWTAuthMixin, APICMISTestCase):
 

--- a/src/openzaak/components/besluiten/tests/test_besluit_delete_cmis.py
+++ b/src/openzaak/components/besluiten/tests/test_besluit_delete_cmis.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from rest_framework import status
 
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ...documenten.tests.factories import EnkelvoudigInformatieObjectFactory
 from ..models import Besluit, BesluitInformatieObject
@@ -12,7 +12,7 @@ from .factories import BesluitFactory, BesluitInformatieObjectFactory
 from .utils import get_operation_url
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class BesluitDeleteCMISTestCase(JWTAuthMixin, APICMISTestCase):
 

--- a/src/openzaak/components/besluiten/tests/test_besluitinformatieobjecten_cmis.py
+++ b/src/openzaak/components/besluiten/tests/test_besluitinformatieobjecten_cmis.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
 from django.contrib.sites.models import Site
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from drc_cmis.utils.convert import make_absolute_uri
 from rest_framework import status
@@ -10,13 +10,13 @@ from vng_api_common.tests import get_validation_errors, reverse, reverse_lazy
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ..models import Besluit, BesluitInformatieObject
 from .factories import BesluitFactory, BesluitInformatieObjectFactory
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class BesluitInformatieObjectCMISAPITests(JWTAuthMixin, APICMISTestCase):
 

--- a/src/openzaak/components/besluiten/tests/test_cmis_url_mapping.py
+++ b/src/openzaak/components/besluiten/tests/test_cmis_url_mapping.py
@@ -3,7 +3,7 @@
 import os
 from unittest import skipIf
 
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from drc_cmis.models import UrlMapping
 from drc_cmis.utils.convert import make_absolute_uri
@@ -18,10 +18,10 @@ from openzaak.components.besluiten.tests.factories import (
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 
-@tag("cmis")
+@require_cmis
 @freeze_time("2018-06-27 12:12:12")
 @override_settings(
     CMIS_ENABLED=True, CMIS_URL_MAPPING_ENABLED=True,

--- a/src/openzaak/components/besluiten/tests/test_filters_cmis.py
+++ b/src/openzaak/components/besluiten/tests/test_filters_cmis.py
@@ -1,18 +1,18 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from rest_framework import status
 from vng_api_common.tests import get_validation_errors, reverse
 
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ...documenten.tests.factories import EnkelvoudigInformatieObjectFactory
 from ..models import BesluitInformatieObject
 from .factories import BesluitInformatieObjectFactory
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class BesluitInformatieObjectCMISAPIFilterTests(JWTAuthMixin, APICMISTestCase):
     heeft_alle_autorisaties = True

--- a/src/openzaak/components/besluiten/tests/test_notifications_send_cmis.py
+++ b/src/openzaak/components/besluiten/tests/test_notifications_send_cmis.py
@@ -3,7 +3,7 @@
 import json
 
 from django.contrib.sites.models import Site
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from django_db_logger.models import StatusLog
 from freezegun import freeze_time
@@ -16,13 +16,13 @@ from openzaak.components.documenten.tests.factories import (
 from openzaak.notifications.models import FailedNotification
 from openzaak.notifications.tests.mixins import NotificationServiceMixin
 from openzaak.notifications.tests.utils import LOGGING_SETTINGS
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from .factories import BesluitFactory, BesluitInformatieObjectFactory
 from .utils import get_operation_url
 
 
-@tag("cmis")
+@require_cmis
 @freeze_time("2018-09-07T00:00:00Z")
 @override_settings(NOTIFICATIONS_DISABLED=False, CMIS_ENABLED=True)
 class SendNotifTestCase(NotificationServiceMixin, JWTAuthMixin, APICMISTestCase):
@@ -72,7 +72,7 @@ class SendNotifTestCase(NotificationServiceMixin, JWTAuthMixin, APICMISTestCase)
             self.assertEqual(value, notificatie_request[key])
 
 
-@tag("cmis")
+@require_cmis
 @freeze_time("2019-01-01T12:00:00Z")
 @override_settings(
     NOTIFICATIONS_DISABLED=False, LOGGING=LOGGING_SETTINGS, CMIS_ENABLED=True

--- a/src/openzaak/components/besluiten/tests/test_validation_cmis.py
+++ b/src/openzaak/components/besluiten/tests/test_validation_cmis.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from rest_framework import status
 from vng_api_common.tests import get_validation_errors, reverse
@@ -9,12 +9,17 @@ from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
 from openzaak.components.zaken.tests.factories import ZaakFactory
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, serialise_eio
+from openzaak.tests.utils import (
+    APICMISTestCase,
+    JWTAuthMixin,
+    require_cmis,
+    serialise_eio,
+)
 
 from .factories import BesluitFactory
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class BesluitInformatieObjectCMISTests(JWTAuthMixin, APICMISTestCase):
 

--- a/src/openzaak/components/documenten/tests/admin/test_eio_cmis.py
+++ b/src/openzaak/components/documenten/tests/admin/test_eio_cmis.py
@@ -12,12 +12,12 @@ from rest_framework import status
 from vng_api_common import tests
 
 from openzaak.components.catalogi.tests.factories import InformatieObjectTypeFactory
-from openzaak.tests.utils import AdminTestMixin, APICMISTestCase
+from openzaak.tests.utils import AdminTestMixin, APICMISTestCase, require_cmis
 
 from ..factories import EnkelvoudigInformatieObjectFactory
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class EnkelvoudigInformatieObjectCMISAdminTest(AdminTestMixin, APICMISTestCase):
     heeft_alle_autorisaties = True

--- a/src/openzaak/components/documenten/tests/admin/test_gebruiksrechten_audittrail_cmis.py
+++ b/src/openzaak/components/documenten/tests/admin/test_gebruiksrechten_audittrail_cmis.py
@@ -3,19 +3,19 @@
 import uuid
 from datetime import date, time
 
-from django.test import override_settings, tag
+from django.test import override_settings
 from django.urls import reverse
 
 from rest_framework import status
 from vng_api_common import tests
 
-from openzaak.tests.utils import AdminTestMixin, APICMISTestCase
+from openzaak.tests.utils import AdminTestMixin, APICMISTestCase, require_cmis
 
 from ..factories import EnkelvoudigInformatieObjectFactory, GebruiksrechtenCMISFactory
 from ..utils import get_operation_url
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class GebruiksrechtenCMISAdminTests(AdminTestMixin, APICMISTestCase):
     heeft_alle_autorisaties = True

--- a/src/openzaak/components/documenten/tests/models/test_human_readable_identification_cmis.py
+++ b/src/openzaak/components/documenten/tests/models/test_human_readable_identification_cmis.py
@@ -2,14 +2,14 @@
 # Copyright (C) 2019 - 2020 Dimpact
 from datetime import date
 
-from django.test import override_settings, tag
+from django.test import override_settings
 
-from openzaak.tests.utils import APICMISTestCase
+from openzaak.tests.utils import APICMISTestCase, require_cmis
 
 from ..factories import EnkelvoudigInformatieObjectFactory
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class CMISEIOTests(APICMISTestCase):
     def test_default_identificatie_is_equal_to_uuid(self):

--- a/src/openzaak/components/documenten/tests/models/test_oio_cmis.py
+++ b/src/openzaak/components/documenten/tests/models/test_oio_cmis.py
@@ -13,7 +13,7 @@ from openzaak.components.zaken.tests.factories import (
     ZaakFactory,
     ZaakInformatieObjectFactory,
 )
-from openzaak.tests.utils import APICMISTestCase
+from openzaak.tests.utils import APICMISTestCase, require_cmis
 from openzaak.utils.query import QueryBlocked
 
 from ...models import ObjectInformatieObject
@@ -23,7 +23,8 @@ from ..factories import (
 )
 
 
-@tag("oio", "cmis")
+@tag("oio")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class OIOCMISTests(APICMISTestCase, TestCase):
     def setUp(self) -> None:
@@ -85,7 +86,7 @@ class OIOCMISTests(APICMISTestCase, TestCase):
         self.assertEqual(ObjectInformatieObject.objects.count(), 0)
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class BlockChangeTestCase(APICMISTestCase, TestCase):
     def setUp(self) -> None:

--- a/src/openzaak/components/documenten/tests/models/test_unique_representation_cmis.py
+++ b/src/openzaak/components/documenten/tests/models/test_unique_representation_cmis.py
@@ -5,13 +5,13 @@ from django.test import override_settings, tag
 from vng_api_common.tests import reverse
 
 from openzaak.components.zaken.tests.factories import ZaakFactory
-from openzaak.tests.utils import APICMISTestCase
+from openzaak.tests.utils import APICMISTestCase, require_cmis
 
 from ...models import ObjectInformatieObject
 from ..factories import EnkelvoudigInformatieObjectFactory, GebruiksrechtenCMISFactory
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True, ALLOWED_HOSTS=["testserver", "example.com"])
 class UniqueRepresentationTestCase(APICMISTestCase):
     def test_eio(self):

--- a/src/openzaak/components/documenten/tests/test_audittrails_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_audittrails_cmis.py
@@ -4,7 +4,7 @@ import uuid
 from base64 import b64encode
 from datetime import datetime
 
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from freezegun import freeze_time
 from rest_framework import status
@@ -13,7 +13,7 @@ from vng_api_common.tests import reverse, reverse_lazy
 from vng_api_common.utils import get_uuid_from_path
 
 from openzaak.components.catalogi.tests.factories import InformatieObjectTypeFactory
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ..models import (
     EnkelvoudigInformatieObject,
@@ -23,7 +23,7 @@ from ..models import (
 from .factories import EnkelvoudigInformatieObjectFactory
 
 
-@tag("cmis")
+@require_cmis
 @freeze_time("2019-01-01")
 @override_settings(CMIS_ENABLED=True)
 class AuditTrailTests(JWTAuthMixin, APICMISTestCase):

--- a/src/openzaak/components/documenten/tests/test_auth_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_auth_cmis.py
@@ -21,7 +21,7 @@ from openzaak.components.zaken.tests.factories import (
     ZaakFactory,
     ZaakInformatieObjectFactory,
 )
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ..api.scopes import SCOPE_DOCUMENTEN_AANMAKEN, SCOPE_DOCUMENTEN_ALLES_LEZEN
 from ..models import ObjectInformatieObject
@@ -30,7 +30,7 @@ from .factories import EnkelvoudigInformatieObjectFactory, GebruiksrechtenCMISFa
 IOTYPE_EXTERNAL = "https://externe.catalogus.nl/api/v1/informatieobjecttypen/b71f72ef-198d-44d8-af64-ae1932df830a"
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class InformatieObjectScopeForbiddenTests(AuthCheckMixin, APICMISTestCase):
     def test_cannot_create_io_without_correct_scope(self):
@@ -58,7 +58,7 @@ class InformatieObjectScopeForbiddenTests(AuthCheckMixin, APICMISTestCase):
                 self.assertForbidden(url, method="get")
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class InformatieObjectReadCorrectScopeTests(JWTAuthMixin, APICMISTestCase):
     scopes = [SCOPE_DOCUMENTEN_ALLES_LEZEN]
@@ -162,7 +162,7 @@ class InformatieObjectReadCorrectScopeTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(len(response_data), 4)
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class GebruiksrechtenReadTests(JWTAuthMixin, APICMISTestCase):
 
@@ -260,7 +260,7 @@ class GebruiksrechtenReadTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(response2.status_code, status.HTTP_200_OK)
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class OioReadTests(JWTAuthMixin, APICMISTestCase):
 
@@ -383,7 +383,8 @@ class OioReadTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(response_data[0]["url"], f"http://testserver{reverse(oio1)}")
 
 
-@tag("external-urls", "cmis")
+@tag("external-urls")
+@require_cmis
 @override_settings(ALLOWED_HOSTS=["testserver"], CMIS_ENABLED=True)
 class InternalInformatietypeScopeTests(JWTAuthMixin, APICMISTestCase):
     scopes = [SCOPE_DOCUMENTEN_ALLES_LEZEN]
@@ -516,7 +517,8 @@ class InternalInformatietypeScopeTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(response2.status_code, status.HTTP_403_FORBIDDEN)
 
 
-@tag("external-urls", "cmis")
+@tag("external-urls")
+@require_cmis
 @override_settings(ALLOWED_HOSTS=["testserver"], CMIS_ENABLED=True)
 class ExternalInformatieobjecttypeScopeTests(JWTAuthMixin, APICMISTestCase):
     scopes = [SCOPE_DOCUMENTEN_ALLES_LEZEN]

--- a/src/openzaak/components/documenten/tests/test_cmis_queries.py
+++ b/src/openzaak/components/documenten/tests/test_cmis_queries.py
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
 from django.contrib.sites.models import Site
-from django.test import override_settings, tag
+from django.test import override_settings
 
-from openzaak.tests.utils import APICMISTestCase
+from openzaak.tests.utils import APICMISTestCase, require_cmis
 
 from ..models import EnkelvoudigInformatieObject
 from .factories import EnkelvoudigInformatieObjectFactory
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class QueryTests(APICMISTestCase):
     """

--- a/src/openzaak/components/documenten/tests/test_cmis_url_mapping.py
+++ b/src/openzaak/components/documenten/tests/test_cmis_url_mapping.py
@@ -6,7 +6,7 @@ import uuid
 from base64 import b64encode
 from unittest import skipIf
 
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from drc_cmis.models import CMISConfig, UrlMapping
 from freezegun import freeze_time
@@ -17,14 +17,14 @@ from zgw_consumers.models import Service
 from zgw_consumers.test import mock_service_oas_get
 
 from openzaak.components.catalogi.tests.factories import InformatieObjectTypeFactory
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ...zaken.tests.utils import get_zaak_response
 from ..models import EnkelvoudigInformatieObject, ObjectInformatieObject
 from .factories import EnkelvoudigInformatieObjectFactory, GebruiksrechtenCMISFactory
 
 
-@tag("cmis")
+@require_cmis
 @freeze_time("2018-06-27 12:12:12")
 @override_settings(
     CMIS_ENABLED=True, CMIS_URL_MAPPING_ENABLED=True,

--- a/src/openzaak/components/documenten/tests/test_eio_delete_cascade_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_eio_delete_cascade_cmis.py
@@ -4,7 +4,7 @@
 Ref: https://github.com/VNG-Realisatie/gemma-zaken/issues/349
 """
 from django.conf import settings
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from drc_cmis.models import CMISConfig, UrlMapping
 from rest_framework import status
@@ -12,14 +12,14 @@ from vng_api_common.tests import get_validation_errors, reverse
 
 from openzaak.components.besluiten.tests.factories import BesluitInformatieObjectFactory
 from openzaak.components.zaken.tests.factories import ZaakInformatieObjectFactory
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ..models import EnkelvoudigInformatieObject, Gebruiksrechten
 from .factories import EnkelvoudigInformatieObjectFactory, GebruiksrechtenCMISFactory
 from .utils import get_operation_url
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class US349TestCase(JWTAuthMixin, APICMISTestCase):
     @classmethod

--- a/src/openzaak/components/documenten/tests/test_eio_file_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_eio_file_cmis.py
@@ -7,14 +7,14 @@ import base64
 from datetime import date
 from urllib.parse import urlparse
 
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from rest_framework import status
 from vng_api_common.constants import VertrouwelijkheidsAanduiding
 from vng_api_common.tests import reverse
 
 from openzaak.components.catalogi.tests.factories import InformatieObjectTypeFactory
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ..models import EnkelvoudigInformatieObject
 from .factories import (
@@ -24,7 +24,7 @@ from .factories import (
 from .utils import get_operation_url
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class US39TestCase(JWTAuthMixin, APICMISTestCase):
 

--- a/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject_cmis.py
@@ -16,7 +16,7 @@ from vng_api_common.tests import get_validation_errors, reverse, reverse_lazy
 
 from openzaak.components.catalogi.tests.factories import InformatieObjectTypeFactory
 from openzaak.components.zaken.tests.factories import ZaakInformatieObjectFactory
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ..models import EnkelvoudigInformatieObject, EnkelvoudigInformatieObjectCanonical
 from .factories import EnkelvoudigInformatieObjectFactory
@@ -27,7 +27,7 @@ from .utils import (
 )
 
 
-@tag("cmis")
+@require_cmis
 @freeze_time("2018-06-27 12:12:12")
 @override_settings(CMIS_ENABLED=True)
 class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APICMISTestCase):
@@ -512,7 +512,7 @@ class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class EnkelvoudigInformatieObjectVersionHistoryAPITests(JWTAuthMixin, APICMISTestCase):
     list_url = reverse_lazy(EnkelvoudigInformatieObject)
@@ -798,7 +798,7 @@ class EnkelvoudigInformatieObjectVersionHistoryAPITests(JWTAuthMixin, APICMISTes
         self.assertEqual(response_download.getvalue(), b"inhoud1")
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class EnkelvoudigInformatieObjectPaginationAPITests(JWTAuthMixin, APICMISTestCase):
     list_url = reverse_lazy(EnkelvoudigInformatieObject)
@@ -830,7 +830,8 @@ class EnkelvoudigInformatieObjectPaginationAPITests(JWTAuthMixin, APICMISTestCas
         self.assertIsNone(response_data["next"])
 
 
-@tag("external-urls", "cmis")
+@tag("external-urls")
+@require_cmis
 @override_settings(ALLOWED_HOSTS=["testserver"], CMIS_ENABLED=True)
 class InformatieobjectCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
     heeft_alle_autorisaties = True

--- a/src/openzaak/components/documenten/tests/test_filters_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_filters_cmis.py
@@ -1,17 +1,17 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from rest_framework import status
 from vng_api_common.tests import get_validation_errors, reverse
 
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ..models import Gebruiksrechten, ObjectInformatieObject
 from .factories import EnkelvoudigInformatieObjectFactory, GebruiksrechtenCMISFactory
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class GebruiksrechtenFilterTests(JWTAuthMixin, APICMISTestCase):
     heeft_alle_autorisaties = True
@@ -39,7 +39,7 @@ class GebruiksrechtenFilterTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(response.data, [])
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class ObjectInformatieObjectFilterTests(JWTAuthMixin, APICMISTestCase):
     heeft_alle_autorisaties = True

--- a/src/openzaak/components/documenten/tests/test_gebruiksrechten_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_gebruiksrechten_cmis.py
@@ -2,18 +2,18 @@
 # Copyright (C) 2020 Dimpact
 import datetime
 
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from rest_framework import status
 from vng_api_common.tests import get_validation_errors, reverse
 
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ..models import Gebruiksrechten
 from .factories import EnkelvoudigInformatieObjectFactory, GebruiksrechtenCMISFactory
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class GebruiksrechtenTests(JWTAuthMixin, APICMISTestCase):
     heeft_alle_autorisaties = True

--- a/src/openzaak/components/documenten/tests/test_lock_eio_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_lock_eio_cmis.py
@@ -3,7 +3,7 @@
 import uuid
 from base64 import b64encode
 
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from rest_framework import status
 from vng_api_common.constants import ComponentTypes
@@ -11,14 +11,14 @@ from vng_api_common.tests import get_validation_errors, reverse
 
 from openzaak.components.catalogi.tests.factories import InformatieObjectTypeFactory
 from openzaak.components.documenten.models import EnkelvoudigInformatieObject
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ..api.scopes import SCOPE_DOCUMENTEN_GEFORCEERD_UNLOCK, SCOPE_DOCUMENTEN_LOCK
 from .factories import EnkelvoudigInformatieObjectFactory
 from .utils import get_operation_url
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class EioLockAPITests(JWTAuthMixin, APICMISTestCase):
 
@@ -149,7 +149,7 @@ class EioLockAPITests(JWTAuthMixin, APICMISTestCase):
         self.assertNotIn("lock", response.data)
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class EioUnlockAPITests(JWTAuthMixin, APICMISTestCase):
 

--- a/src/openzaak/components/documenten/tests/test_notifications_send_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_notifications_send_cmis.py
@@ -4,7 +4,7 @@ import base64
 import uuid
 from unittest.mock import patch
 
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from django_db_logger.models import StatusLog
 from freezegun import freeze_time
@@ -17,13 +17,13 @@ from openzaak.components.documenten.models import EnkelvoudigInformatieObject
 from openzaak.notifications.models import FailedNotification
 from openzaak.notifications.tests.mixins import NotificationServiceMixin
 from openzaak.notifications.tests.utils import LOGGING_SETTINGS
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from .factories import EnkelvoudigInformatieObjectFactory, GebruiksrechtenCMISFactory
 from .utils import get_operation_url
 
 
-@tag("cmis")
+@require_cmis
 @freeze_time("2012-01-14")
 @override_settings(NOTIFICATIONS_DISABLED=False)
 class SendNotifTestCase(NotificationServiceMixin, JWTAuthMixin, APICMISTestCase):
@@ -76,7 +76,7 @@ class SendNotifTestCase(NotificationServiceMixin, JWTAuthMixin, APICMISTestCase)
         )
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(
     NOTIFICATIONS_DISABLED=False, LOGGING=LOGGING_SETTINGS, CMIS_ENABLED=True
 )

--- a/src/openzaak/components/documenten/tests/test_objectinformatieobject_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_objectinformatieobject_cmis.py
@@ -35,13 +35,14 @@ from openzaak.components.zaken.tests.utils import (
     get_zaakinformatieobject_response,
     get_zaaktype_response,
 )
-from openzaak.tests.utils import APICMISTestCase
+from openzaak.tests.utils import APICMISTestCase, require_cmis
 
 from ..models import ObjectInformatieObject
 from .factories import EnkelvoudigInformatieObjectFactory
 
 
-@tag("oio", "cmis")
+@tag("oio")
+@require_cmis
 @override_settings(CMIS_ENABLED=True, ALLOWED_HOSTS=["testserver", "example.com"])
 class ObjectInformatieObjectTests(JWTAuthMixin, APICMISTestCase):
     heeft_alle_autorisaties = True
@@ -312,7 +313,7 @@ class ObjectInformatieObjectTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(error["code"], "unknown-parameters")
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class ObjectInformatieObjectDestroyTests(JWTAuthMixin, APICMISTestCase):
     heeft_alle_autorisaties = True
@@ -358,7 +359,8 @@ class ObjectInformatieObjectDestroyTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(error["code"], "remote-relation-exists")
 
 
-@tag("external-urls", "cmis")
+@tag("external-urls")
+@require_cmis
 @override_settings(ALLOWED_HOSTS=["testserver"], CMIS_ENABLED=True)
 class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
     heeft_alle_autorisaties = True

--- a/src/openzaak/components/documenten/tests/test_utils_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_utils_cmis.py
@@ -12,10 +12,11 @@ from openzaak.components.documenten.query.cmis import get_zaak_and_zaaktype_data
 from openzaak.components.zaken.models import ZaakInformatieObject
 from openzaak.components.zaken.tests.factories import ZaakFactory
 from openzaak.components.zaken.tests.utils import get_zaak_response
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 
-@tag("external-urls", "cmis")
+@tag("external-urls")
+@require_cmis
 @override_settings(ALLOWED_HOSTS=["testserver"], CMIS_ENABLED=True)
 class CMISUtilsTests(JWTAuthMixin, APICMISTestCase):
 

--- a/src/openzaak/components/zaken/tests/models/test_unique_representation_cmis.py
+++ b/src/openzaak/components/zaken/tests/models/test_unique_representation_cmis.py
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.tests.utils import APICMISTestCase
+from openzaak.tests.utils import APICMISTestCase, require_cmis
 
 from ..factories import ZaakInformatieObjectFactory
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class UniqueRepresentationCMISTestCase(APICMISTestCase):
     def test_zaakinformatieobject(self):

--- a/src/openzaak/components/zaken/tests/models/test_zio_block_change_cmis.py
+++ b/src/openzaak/components/zaken/tests/models/test_zio_block_change_cmis.py
@@ -1,18 +1,18 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.tests.utils import APICMISTestCase
+from openzaak.tests.utils import APICMISTestCase, require_cmis
 from openzaak.utils.query import QueryBlocked
 
 from ...models import ZaakInformatieObject
 from ..factories import ZaakInformatieObjectFactory
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class BlockChangeCMISTestCase(APICMISTestCase):
     def setUp(self) -> None:

--- a/src/openzaak/components/zaken/tests/test_audittrails_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_audittrails_cmis.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
 from django.contrib.sites.models import Site
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from rest_framework import status
 from vng_api_common.audittrails.models import AuditTrail
@@ -18,13 +18,18 @@ from openzaak.components.catalogi.tests.factories import (
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, serialise_eio
+from openzaak.tests.utils import (
+    APICMISTestCase,
+    JWTAuthMixin,
+    require_cmis,
+    serialise_eio,
+)
 
 from ..models import Zaak, ZaakInformatieObject
 from .utils import ZAAK_WRITE_KWARGS
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class AuditTrailCMISTests(JWTAuthMixin, APICMISTestCase):
 

--- a/src/openzaak/components/zaken/tests/test_auth_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_auth_cmis.py
@@ -14,7 +14,7 @@ from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.models import Service
 
 from openzaak.components.catalogi.tests.factories import ZaakTypeFactory
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ...documenten.tests.factories import EnkelvoudigInformatieObjectFactory
 from ..api.scopes import SCOPE_ZAKEN_ALLES_LEZEN, SCOPE_ZAKEN_BIJWERKEN
@@ -22,7 +22,7 @@ from ..models import ZaakInformatieObject
 from .factories import ZaakFactory, ZaakInformatieObjectFactory
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class ZaakInformatieObjectCMISTests(JWTAuthMixin, APICMISTestCase):
     scopes = [SCOPE_ZAKEN_ALLES_LEZEN, SCOPE_ZAKEN_BIJWERKEN]
@@ -75,7 +75,8 @@ class ZaakInformatieObjectCMISTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(response.data[0]["zaak"], f"http://testserver{zaak_url}")
 
 
-@tag("external-urls", "cmis")
+@tag("external-urls")
+@require_cmis
 @override_settings(ALLOWED_HOSTS=["testserver"], CMIS_ENABLED=True)
 class ExternalZaaktypeScopeCMISTests(JWTAuthMixin, APICMISTestCase):
     scopes = [SCOPE_ZAKEN_ALLES_LEZEN]

--- a/src/openzaak/components/zaken/tests/test_cmis_url_mapping.py
+++ b/src/openzaak/components/zaken/tests/test_cmis_url_mapping.py
@@ -3,7 +3,7 @@
 import os
 from unittest import skipIf
 
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from drc_cmis.models import UrlMapping
 from freezegun import freeze_time
@@ -20,10 +20,10 @@ from openzaak.components.zaken.tests.factories import (
     ZaakFactory,
     ZaakInformatieObjectFactory,
 )
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 
-@tag("cmis")
+@require_cmis
 @freeze_time("2018-06-27 12:12:12")
 @override_settings(
     CMIS_ENABLED=True, CMIS_URL_MAPPING_ENABLED=True,

--- a/src/openzaak/components/zaken/tests/test_filters_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_filters_cmis.py
@@ -1,18 +1,18 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from rest_framework import status
 from vng_api_common.tests import reverse
 
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ...documenten.tests.factories import EnkelvoudigInformatieObjectFactory
 from ..models import ZaakInformatieObject
 from .factories import ZaakInformatieObjectFactory
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class ZaakInformatieObjectFilterCMISTests(JWTAuthMixin, APICMISTestCase):
     heeft_alle_autorisaties = True

--- a/src/openzaak/components/zaken/tests/test_notifications_send_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_notifications_send_cmis.py
@@ -3,7 +3,7 @@
 from unittest import skip
 
 from django.contrib.sites.models import Site
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from django_db_logger.models import StatusLog
 from freezegun import freeze_time
@@ -18,7 +18,7 @@ from openzaak.components.documenten.tests.factories import (
 )
 from openzaak.notifications.models import FailedNotification
 from openzaak.notifications.tests.mixins import NotificationServiceMixin
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from .factories import ZaakFactory, ZaakInformatieObjectFactory
 from .utils import get_operation_url
@@ -26,7 +26,7 @@ from .utils import get_operation_url
 VERANTWOORDELIJKE_ORGANISATIE = "517439943"
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(NOTIFICATIONS_DISABLED=False, CMIS_ENABLED=True)
 @freeze_time("2019-01-01T12:00:00Z")
 class FailedNotificationCMISTests(

--- a/src/openzaak/components/zaken/tests/test_validation_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_validation_cmis.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
 from django.contrib.sites.models import Site
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from rest_framework import status
 from vng_api_common.constants import (
@@ -21,14 +21,14 @@ from openzaak.components.catalogi.tests.factories import (
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ..models import ZaakInformatieObject
 from .factories import ResultaatFactory, ZaakFactory, ZaakInformatieObjectFactory
 from .utils import isodatetime
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class ZaakInformatieObjectValidationCMISTests(JWTAuthMixin, APICMISTestCase):
 
@@ -82,7 +82,7 @@ class ZaakInformatieObjectValidationCMISTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(validation_error["code"], IsImmutableValidator.code)
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class FilterValidationCMISTests(JWTAuthMixin, APICMISTestCase):
     """
@@ -107,7 +107,7 @@ class FilterValidationCMISTests(JWTAuthMixin, APICMISTestCase):
         self.assertEqual(error["code"], "unknown-parameters")
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class StatusValidationCMISTests(JWTAuthMixin, APICMISTestCase):
     heeft_alle_autorisaties = True

--- a/src/openzaak/components/zaken/tests/test_zaak_archive_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_archive_cmis.py
@@ -5,7 +5,7 @@ Ref: https://github.com/VNG-Realisatie/gemma-zaken/issues/345
 """
 from datetime import date
 
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from rest_framework import status
 from vng_api_common.constants import Archiefnominatie, Archiefstatus
@@ -14,7 +14,7 @@ from vng_api_common.tests import reverse
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from .factories import ZaakFactory, ZaakInformatieObjectFactory
 from .utils import ZAAK_WRITE_KWARGS, get_operation_url
@@ -22,7 +22,7 @@ from .utils import ZAAK_WRITE_KWARGS, get_operation_url
 VERANTWOORDELIJKE_ORGANISATIE = "517439943"
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class US345CMISTestCase(JWTAuthMixin, APICMISTestCase):
 

--- a/src/openzaak/components/zaken/tests/test_zaak_closed_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_closed_cmis.py
@@ -12,7 +12,7 @@ from zgw_consumers.test import mock_service_oas_get
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ...catalogi.tests.factories import ZaakTypeFactory
 from ..api.scopes import (
@@ -25,7 +25,8 @@ from .assertions import CRUDAssertions
 from .factories import ZaakFactory, ZaakInformatieObjectFactory
 
 
-@tag("closed-zaak", "cmis")
+@tag("closed-zaak")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class ClosedZaakRelatedDataNotAllowedCMISTests(
     JWTAuthMixin, CRUDAssertions, APICMISTestCase
@@ -94,7 +95,8 @@ class ClosedZaakRelatedDataNotAllowedCMISTests(
         self.assertDestroyBlocked(zio_url)
 
 
-@tag("closed-zaak", "cmis")
+@tag("closed-zaak")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class ClosedZaakRelatedDataAllowedCMISTests(
     JWTAuthMixin, CRUDAssertions, APICMISTestCase

--- a/src/openzaak/components/zaken/tests/test_zaak_delete_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_delete_cmis.py
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from rest_framework import status
 from vng_api_common.tests import reverse
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.models import Service
 
-from openzaak.tests.utils import APICMISTransactionTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTransactionTestCase, JWTAuthMixin, require_cmis
 
 from ...documenten.tests.factories import EnkelvoudigInformatieObjectFactory
 from ..models import (
@@ -33,7 +33,7 @@ from .factories import (
 from .utils import ZAAK_WRITE_KWARGS, get_operation_url
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class US349TestCase(JWTAuthMixin, APICMISTransactionTestCase):
     heeft_alle_autorisaties = True

--- a/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten_cmis.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2020 Dimpact
 from datetime import datetime
 
-from django.test import override_settings, tag
+from django.test import override_settings
 from django.utils import timezone
 
 from freezegun import freeze_time
@@ -17,14 +17,14 @@ from openzaak.components.catalogi.tests.factories import (
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin
+from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
 
 from ...documenten.models import EnkelvoudigInformatieObject, ObjectInformatieObject
 from ..models import Zaak, ZaakInformatieObject
 from .factories import ZaakFactory, ZaakInformatieObjectFactory
 
 
-@tag("cmis")
+@require_cmis
 @override_settings(CMIS_ENABLED=True)
 class ZaakInformatieObjectCMISAPITests(JWTAuthMixin, APICMISTestCase):
 

--- a/src/openzaak/tests/test_self_signed_certificates.py
+++ b/src/openzaak/tests/test_self_signed_certificates.py
@@ -11,7 +11,6 @@ Note that you should have the CI docker-compose running with the mock endpoints,
 uses the self-signed certificates.
 """
 import os
-import socket
 from unittest import TestCase, skipIf
 
 from django.conf import settings
@@ -19,23 +18,12 @@ from django.conf import settings
 import requests
 
 from openzaak.setup import EXTRA_CERTS_ENVVAR, load_self_signed_certs
+from openzaak.tests.utils.helpers import can_connect
 
 CERTS_DIR = os.path.join(settings.BASE_DIR, "docker", "certs")
 
 HOST = "localhost:9001"
 PUBLIC_INTERNET_HOST = "github.com:443"
-
-
-def can_connect(hostname: str):
-    # adapted from https://stackoverflow.com/a/28752285
-    hostname, port = hostname.split(":")
-    try:
-        host = socket.gethostbyname(hostname)
-        s = socket.create_connection((host, port), 2)
-        s.close()
-        return True
-    except Exception:
-        return False
 
 
 class SelfSignedCertificateTests(TestCase):

--- a/src/openzaak/tests/utils/__init__.py
+++ b/src/openzaak/tests/utils/__init__.py
@@ -3,7 +3,12 @@
 from .admin import AdminTestMixin
 from .auth import JWTAuthMixin, generate_jwt_auth
 from .cache import ClearCachesMixin
-from .cmis import APICMISTestCase, APICMISTransactionTestCase, serialise_eio
+from .cmis import (
+    APICMISTestCase,
+    APICMISTransactionTestCase,
+    require_cmis,
+    serialise_eio,
+)
 from .mocks import (
     MockSchemasMixin,
     get_eio_response,
@@ -34,4 +39,5 @@ __all__ = [
     "APICMISTestCase",
     "APICMISTransactionTestCase",
     "serialise_eio",
+    "require_cmis",
 ]

--- a/src/openzaak/tests/utils/cmis.py
+++ b/src/openzaak/tests/utils/cmis.py
@@ -15,6 +15,8 @@ from rest_framework.test import APITestCase, APITransactionTestCase
 
 from .mocks import MockSchemasMixin, get_eio_response
 
+ALFRESCO_BASE_URL = "http://localhost:8082/alfresco/"
+
 
 class CMISMixin(MockSchemasMixin):
     @classmethod
@@ -29,7 +31,7 @@ class CMISMixin(MockSchemasMixin):
         binding = os.getenv("CMIS_BINDING")
         if binding == "WEBSERVICE":
             config = CMISConfig.get_solo()
-            config.client_url = "http://localhost:8082/alfresco/cmisws"
+            config.client_url = f"{ALFRESCO_BASE_URL}cmisws"
             config.binding = "WEBSERVICE"
             config.other_folder_path = "/DRC/"
             config.zaak_folder_path = "/ZRC/{{ zaaktype }}/{{ zaak }}"
@@ -41,7 +43,9 @@ class CMISMixin(MockSchemasMixin):
             config.save()
         elif binding == "BROWSER":
             config = CMISConfig.get_solo()
-            config.client_url = "http://localhost:8082/alfresco/api/-default-/public/cmis/versions/1.1/browser"
+            config.client_url = (
+                f"{ALFRESCO_BASE_URL}api/-default-/public/cmis/versions/1.1/browser"
+            )
             config.binding = "BROWSER"
             config.other_folder_path = "/DRC/"
             config.zaak_folder_path = "/ZRC/{{ zaaktype }}/{{ zaak }}/"

--- a/src/openzaak/tests/utils/helpers.py
+++ b/src/openzaak/tests/utils/helpers.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2022 Dimpact
+import functools
 import socket
 
 
+@functools.cache
 def can_connect(hostname: str):
     # adapted from https://stackoverflow.com/a/28752285
     hostname, port = hostname.split(":")

--- a/src/openzaak/tests/utils/helpers.py
+++ b/src/openzaak/tests/utils/helpers.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2022 Dimpact
+import socket
+
+
+def can_connect(hostname: str):
+    # adapted from https://stackoverflow.com/a/28752285
+    hostname, port = hostname.split(":")
+    try:
+        host = socket.gethostbyname(hostname)
+        s = socket.create_connection((host, int(port)), 2)
+        s.close()
+        return True
+    except Exception:
+        return False


### PR DESCRIPTION
Test utility/convenience so you can run the entire test-suite without having to exclude the "cmis" tag - if the alfresco test environment is not up, those tests will simply be skipped.

The tests are still tagged, so if you want to run only CMIS tags you can do so: `python src/manage.py test src --tag=cmis`
