### PR TITLE
Fix zaak zoek ordering parameter

### DIFF
--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -395,14 +395,6 @@ class ZaakZoekSerializer(serializers.Serializer):
         help_text=_("Array of unieke resource identifiers (UUID4)"),
     )
 
-    def validate(self, attrs):
-        validated_attrs = super().validate(attrs)
-        if not validated_attrs:
-            raise serializers.ValidationError(
-                _("Search parameters must be specified"), code="empty_search_body"
-            )
-        return validated_attrs
-
 
 class StatusSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:

--- a/src/openzaak/utils/filters.py
+++ b/src/openzaak/utils/filters.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
 from django_filters import filters
+from rest_framework.filters import OrderingFilter
 from vng_api_common.constants import VertrouwelijkheidsAanduiding
+from vng_api_common.search import is_search_view
 
 
 class MaximaleVertrouwelijkheidaanduidingFilter(filters.ChoiceFilter):
@@ -23,3 +25,23 @@ class MaximaleVertrouwelijkheidaanduidingFilter(filters.ChoiceFilter):
         qs = qs.annotate(**{self.field_name: order_expression})
         numeric_value = VertrouwelijkheidsAanduiding.get_choice(value).order
         return super().filter(qs, numeric_value)
+
+
+class SearchOrderingFilter(OrderingFilter):
+    """
+    Ordering filter compatible with search views.
+
+    The search views have their parameters in the request body, while the default
+    ordering filter only looks up parameters in the query params.
+    """
+
+    def get_ordering(self, request, queryset, view):
+        # for search views, look up the parameters from the body
+        if is_search_view(view):
+            params = request.data.get(self.ordering_param)
+            if params:
+                fields = [param.strip() for param in params.split(",")]
+                ordering = self.remove_invalid_fields(queryset, fields, view, request)
+                if ordering:
+                    return ordering
+        return super().get_ordering(request, queryset, view)


### PR DESCRIPTION
Fixes #1198

**Changes**

* Moved empty search body/parameters validation to view
* Added test for filter backend (search-capable)
* Added regression test for broken ordering
* Fixed looking up ordering parameter in request body

