### PR TITLE
Ensure Rol unique representation does not exceed 200 characters

### DIFF
--- a/src/openzaak/components/zaken/models/zaken.py
+++ b/src/openzaak/components/zaken/models/zaken.py
@@ -624,7 +624,7 @@ class Rol(ETagMixin, models.Model):
 
     def unique_representation(self):
         if self.betrokkene == "":
-            return f"({self.zaak.unique_representation()}) - {self.roltoelichting}"
+            return f"({self.zaak.unique_representation()}) - {self.uuid}"
 
         betrokkene = (
             self.betrokkene.rstrip("/")

--- a/src/openzaak/components/zaken/tests/models/test_unique_representation.py
+++ b/src/openzaak/components/zaken/tests/models/test_unique_representation.py
@@ -6,7 +6,7 @@ from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
 
-from ..factories import ZaakInformatieObjectFactory
+from ..factories import RolFactory, ZaakInformatieObjectFactory
 
 
 class UniqueRepresentationTestCase(APITestCase):
@@ -22,3 +22,12 @@ class UniqueRepresentationTestCase(APITestCase):
             zio.unique_representation(),
             "(730924658 - 5d940d52-ff5e-4b18-a769-977af9130c04) - 12345",
         )
+
+    def test_rol_unique_repr_does_not_exceed_200_chars(self):
+        rol = RolFactory.build(
+            zaak__identificatie="foo", roltoelichting="a" * 200, betrokkene="",
+        )
+
+        unique_repr = rol.unique_representation()
+
+        self.assertLessEqual(len(unique_repr), 200)


### PR DESCRIPTION
I ran into this while migrating data from an existing system to Open Zaak.

If it's longer than 200 chars, then the audittrail record saving fails because the representation is a DB column with 200-char limit.