### PR TITLE
Refactor setup_configuration management command

### DIFF
--- a/docs/installation/config/index.rst
+++ b/docs/installation/config/index.rst
@@ -6,6 +6,7 @@ Configuration
 .. toctree::
    :maxdepth: 1
 
+   openzaak_config_cli
    openzaak_config
    env_config
    cmis

--- a/docs/installation/config/openzaak_config_cli.rst
+++ b/docs/installation/config/openzaak_config_cli.rst
@@ -1,0 +1,107 @@
+.. _installation_configuration_cli:
+
+=============================
+Open Zaak configuration (CLI)
+=============================
+
+After deploying Open Zaak, it needs to be configured to be fully functional. The
+command line tool ``setup_configuration`` assist with this configuration:
+
+* It favours explicit configuration via options - you can integrate this with your
+  infrastructure tooling such as init containers and/or Kubernetes Jobs
+* In interactive mode, you receive prompts to fill out the requested information
+* The command can self-test the configuration to detect problems early on
+
+You can get the full command documentation with:
+
+.. code-block:: bash
+
+    src/manage.py setup_configuration --help
+
+.. note::
+
+    For more explanation/feedback, run the command with increased verbosity:
+
+    .. code-block:: bash
+
+        src/manage.py setup_configuration --verbosity 2
+
+
+.. warning:: This command is declarative - if configuration is manually changed after
+   running the command and you then run the exact same command again, the manual
+   changes will be reverted.
+
+Preparation
+===========
+
+You should prepare the following information:
+
+* organization name, e.g. ``ACME``
+* domain name where Open Zaak is deployed, e.g. ``open-zaak.gemeente.local``
+* Notifications API root, e.g. ``https://notificaties.gemeente.local/api/v1/``
+* A Client ID for Open Zaak to the Notifications API, e.g. ``open-zaak-acme``
+* A Client Secret for Open Zaak to the Notifications API, e.g. ``insecure-nrc-secret``
+* A Client ID for the Notifications API to Open Zaak, e.g. ``notificaties-api-acme``
+* A Client Secret for the Notifications API to Open Zaak, e.g. ``insecure-oz-secret``
+
+.. note:: You can generate these Client IDs and Secrets using any password generation
+   tool, as long as you configure the same values in the Notifications API.
+
+Execution
+=========
+
+Open Zaak configuration
+-----------------------
+
+With the full command invocation, everything is configured at once and immediately
+tested. For all the self-tests to succeed, it's important that the
+:ref:`Notifications API is configured <installation_configuration_notificaties_api>`
+correctly before calling this command.
+
+Alternatively, you can skip the self-tests by using the ``--no-self-test`` flag.
+
+The example command uses the example values from the preparation above:
+
+.. code-block:: bash
+
+    src/manage.py setup_configuration \
+        -v 2 \
+        --organization ACME \
+        --domain open-zaak.gemeente.local \
+        --create-notifications-api-app \
+        --notifications-api-app-client-id notificaties-api-acme \
+        --notifications-api-app-secret insecure-oz-secret \
+        --notifications-api-root https://notificaties.gemeente.local/api/v1/ \
+        --notifications-api-client-id open-zaak-acme \
+        --notifications-api-secret insecure-nrc-secret \
+        --self-test \
+        --send-test-notification
+
+.. note:: Due to a cache-bug in the underlying framework, you need to restart all
+   replicas for part of this change to take effect everywhere.
+
+.. note:: You can output the results as JSON which your configuration management can
+   then pick up and process:
+
+   .. code-block:: bash
+
+      export LOG_LEVEL=CRITICAL
+      src/manage.py setup_configuration \
+        ...\
+        --skip-checks \
+        --json
+
+   The ``LOG_LEVEL`` environment variable ensures your output is not cluttered with
+   logs, while ``--skip-checks`` prevents system check output from appearing.
+
+Register notification channels
+------------------------------
+
+Before notifications can be sent to ``kanalen`` in Open Notificaties, these ``kanalen``
+must first be registered via Open Zaak.
+
+Register the required channels:
+
+.. code-block:: bash
+
+    python src/manage.py register_kanalen

--- a/docs/installation/reference/cli.rst
+++ b/docs/installation/reference/cli.rst
@@ -24,7 +24,11 @@ Available commands
     set up correctly (any of the ``EMAIL_*`` envvars)!
 
 ``setup_configuration``
-    A CLI alternative to the point-and-click configuration in the admin interface.
+    A CLI alternative to the point-and-click
+    :ref:`configuration <installation_configuration>` in the admin interface.
+
+    This command is idempotent and can be run as part of your CI/CD workflow if desired.
+    Please check the command documentation for more details.
 
 ``send_test_notification``
     After configuring the Notificaties API, send a test nofification to verify the

--- a/src/openzaak/config/bootstrap/__init__.py
+++ b/src/openzaak/config/bootstrap/__init__.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2022 Dimpact
+"""
+Implement utilities to bootstrap the configuration.
+
+A fresh Open Zaak installation needs to be configured before it can be used,
+with connections to the Notifications API amongs others.
+
+This module exposes the helpers for every bootstrap part. Every part needs to be
+implement such that it's idempotent and can be run mulitple times, e.g. as part of
+a container orchestration tool.
+
+See also: :ref:`installation_configuration`.
+
+Configuration aspects:
+
+- [x] Configure the canonical domain: sets the current Site options. Note that this
+      should ideally signal other instances (django bug!).
+
+      TODO: include ``settings.ENVIRONMENT`` in the site name once it's configurable
+      from the environment.
+
+- [x] Notifications API
+    - Open Zaak MAY provide the Autorisaties API used by the Notifications API, this
+      requires an application with the appropriate scopes to be configured so that
+      Open Zaak is allowed to publish notifications to the Notifications API.
+
+    - Open Zaak is a client of the notifications API and thus requires credentials.
+      These credentials need to be configured in the Notifications API to be used.
+
+    - Specify the API root of the Notifications API -> must update_or_create the
+      appropriate services with the credentials
+
+    - When Open Zaak provides the Autorisaties API for the Notifications API, an
+      application needs to be created for the Notifications API with the appropriate
+      scopes so that the Notifications API can query the applications/permissions of
+      a given client ID. (SCOPE_AUTORISATIES_LEZEN)
+
+- [ ] Create a demo API token and make a test request?
+
+- [ ] Configure NLX
+"""

--- a/src/openzaak/config/bootstrap/datastructures.py
+++ b/src/openzaak/config/bootstrap/datastructures.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2022 Dimpact
+from dataclasses import dataclass
+
+
+@dataclass
+class Output:
+    id: str  # must be unique!
+    title: str
+    data: dict
+
+    def __str__(self):
+        bits = [f"{self.title} (id: {self.id}):",] + [
+            f"  * {key}: {value}" for key, value in self.data.items()
+        ]
+        return "\n".join(bits)
+
+    def as_json(self) -> dict:
+        return {self.id: {"title": self.title, "data": self.data}}

--- a/src/openzaak/config/bootstrap/exceptions.py
+++ b/src/openzaak/config/bootstrap/exceptions.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2022 Dimpact
+
+
+class SelfTestFailure(Exception):
+    """
+    Raise an error for failed configuration self-tests.
+    """
+
+    pass

--- a/src/openzaak/config/bootstrap/notifications.py
+++ b/src/openzaak/config/bootstrap/notifications.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2022 Dimpact
+from dataclasses import dataclass, field
+from typing import List
+
+from django.urls import reverse
+from django.utils.crypto import get_random_string
+
+import requests
+from notifications_api_common.constants import (
+    SCOPE_NOTIFICATIES_CONSUMEREN_LABEL,
+    SCOPE_NOTIFICATIES_PUBLICEREN_LABEL,
+)
+from notifications_api_common.models import NotificationsConfig
+from vng_api_common.authorizations.models import Applicatie, Autorisatie, ComponentTypes
+from vng_api_common.models import JWTSecret
+from zds_client import ClientAuth, ClientError
+from zgw_consumers.constants import APITypes, AuthTypes
+from zgw_consumers.models import Service
+
+from openzaak.components.autorisaties.api.scopes import SCOPE_AUTORISATIES_LEZEN
+from openzaak.utils import build_absolute_url
+
+from .datastructures import Output
+from .exceptions import SelfTestFailure
+
+
+def generate_jwt_secret(prefix="oz"):
+    random_bit = get_random_string(length=20)
+    return f"{prefix}-{random_bit}"
+
+
+@dataclass
+class AutorisatiesAPIClientConfiguration:
+    """
+    Configure the client for Notifications API to consume Autorisaties API.
+    """
+
+    org_name: str
+    client_id: str
+    secret: str
+    secret_provided: bool = field(init=False)
+
+    def __post_init__(self):
+        self.secret_provided = bool(self.secret)
+
+        if not self.client_id:
+            self.client_id = f"notificaties-api-{self.normalized_org_name}"
+
+        if not self.secret:
+            self.secret = generate_jwt_secret()
+
+    @property
+    def normalized_org_name(self) -> str:
+        return self.org_name.lower().replace(" ", "-") or "ac"
+
+    def configure(self) -> List[Output]:
+        # check if there's an existing application/secret
+        jwt_secret, _ = JWTSecret.objects.get_or_create(
+            identifier=self.client_id, defaults={"secret": self.secret},
+        )
+        if self.secret_provided and jwt_secret.secret != self.secret:
+            jwt_secret.secret = self.secret
+            jwt_secret.save(update_fields=["secret"])
+
+        # check for the application
+        try:
+            applicatie = Applicatie.objects.get(client_ids__contains=[self.client_id])
+        except Applicatie.DoesNotExist:
+            applicatie = Applicatie.objects.create(
+                client_ids=[self.client_id],
+                label=f"Notificaties API {self.org_name}".strip(),
+            )
+
+        # finally, set up the appropriate permission(s)
+        ac_permission, _ = Autorisatie.objects.get_or_create(
+            applicatie=applicatie,
+            component=ComponentTypes.ac,
+            defaults={"scopes": [SCOPE_AUTORISATIES_LEZEN]},
+        )
+        if SCOPE_AUTORISATIES_LEZEN not in ac_permission.scopes:
+            ac_permission.scopes.append(SCOPE_AUTORISATIES_LEZEN)
+            ac_permission.save(update_fields=["scopes"])
+
+        # Notifications API should subscribe to authorizations channel to invalidate
+        # applications/authorization caches
+        required_scopes = {
+            SCOPE_NOTIFICATIES_PUBLICEREN_LABEL,
+            SCOPE_NOTIFICATIES_CONSUMEREN_LABEL,
+        }
+        nrc_permission, _ = Autorisatie.objects.get_or_create(
+            applicatie=applicatie,
+            component=ComponentTypes.nrc,
+            defaults={"scopes": list(required_scopes)},
+        )
+        if not required_scopes.issubset(
+            (existing_scopes := set(nrc_permission.scopes))
+        ):
+            nrc_permission.scopes = sorted(required_scopes.union(existing_scopes))
+            nrc_permission.save(update_fields=["scopes"])
+
+        return [
+            Output(
+                id="autorisatiesAPIClientCredentials",
+                title="Notificaties API credentials for Open Zaak Autorisaties API",
+                data={"client_id": self.client_id, "secret": jwt_secret.secret,},
+            )
+        ]
+
+    def test_configuration(self) -> List[Output]:
+        # self test by listing the applications in the Autorisaties API
+        endpoint = reverse("applicatie-list", kwargs={"version": "1"})
+        full_url = build_absolute_url(endpoint, request=None)
+        auth = ClientAuth(client_id=self.client_id, secret=self.secret)
+
+        try:
+            response = requests.get(
+                full_url, headers={**auth.credentials(), "Accept": "application/json",}
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            raise SelfTestFailure(
+                "Could not list applications from Autorisaties API"
+            ) from exc
+
+        return [
+            Output(
+                id="autorisatiesAPIClientSelfTest",
+                title="Autorisaties API client credentials are valid",
+                data={"success": True},
+            )
+        ]
+
+
+@dataclass
+class NotificationsAPIConfiguration:
+    """
+    Configure the Open Zaak client to publish notifications.
+
+    1. Create application with permissions to publish notifications
+    2. Create service for Notifications API
+    3. Set up configuration to point to this service
+    """
+
+    org_name: str
+    uses_autorisaties_api: bool
+    api_root: str
+    client_id: str
+    client_id_provided: bool = field(init=False)
+    secret: str
+    secret_provided: bool = field(init=False)
+
+    def __post_init__(self):
+        self.secret_provided = bool(self.secret)
+        self.client_id_provided = bool(self.client_id)
+
+        if not self.api_root.endswith("/"):
+            self.api_root = f"{self.api_root}/"
+
+        if not self.client_id:
+            self.client_id = f"open-zaak-{self.normalized_org_name}"
+
+        if not self.secret:
+            self.secret = generate_jwt_secret()
+
+    @property
+    def normalized_org_name(self) -> str:
+        return self.org_name.lower().replace(" ", "-") or "ac"
+
+    def configure(self) -> List[Output]:
+        org_label = f"Open Zaak {self.org_name}".strip()
+
+        # 1. set up application and permission (to be returned by Autorisaties API)
+        if self.uses_autorisaties_api:
+            try:
+                applicatie = Applicatie.objects.get(
+                    client_ids__contains=[self.client_id]
+                )
+            except Applicatie.DoesNotExist:
+                applicatie = Applicatie.objects.create(
+                    client_ids=[self.client_id], label=org_label
+                )
+            required_scopes = {
+                SCOPE_NOTIFICATIES_PUBLICEREN_LABEL,
+                SCOPE_NOTIFICATIES_CONSUMEREN_LABEL,  # TODO: figure out why this is needed!
+            }
+            permission, _ = Autorisatie.objects.get_or_create(
+                applicatie=applicatie,
+                component=ComponentTypes.nrc,
+                defaults={"scopes": list(required_scopes)},
+            )
+            if not required_scopes.issubset(
+                (existing_scopes := set(permission.scopes))
+            ):
+                permission.scopes = sorted(required_scopes.union(existing_scopes))
+                permission.save(update_fields=["scopes"])
+
+        # 2. Set up a service and credentials for the notifications API so Open Zaak
+        #    can consume it (read: publish notifications)
+        service, created = Service.objects.update_or_create(
+            api_root=self.api_root,
+            defaults={
+                "api_type": APITypes.nrc,
+                "oas": f"{self.api_root}schema/openapi.yaml",
+                "auth_type": AuthTypes.zgw,
+            },
+        )
+        if created:
+            # this values should only be set initially, but can be edited in the admin
+            # afterwards without any problems
+            service.label = "Notificaties API"
+            service.secret = self.secret
+            service.client_id = self.client_id
+            service.user_id = self.client_id
+            service.user_representation = org_label
+            service.save()
+        else:
+            update_fields = []
+            if self.client_id_provided and service.client_id != self.client_id:
+                service.client_id = self.client_id
+                update_fields.append("client_id")
+            if self.secret_provided and service.secret != self.secret:
+                service.secret = self.secret
+                update_fields.append("secret")
+            if update_fields:
+                service.save(update_fields=update_fields)
+
+        # 3. Set up configuration
+        config = NotificationsConfig.get_solo()
+        if config.notifications_api_service != service:
+            config.notifications_api_service = service
+            config.save(update_fields=["notifications_api_service"])
+
+        return [
+            Output(
+                id="notificationsAPIConfiguration",
+                title="Notifications API configured",
+                data={"client_id": service.client_id, "secret": service.secret,},
+            )
+        ]
+
+    def test_configuration(self) -> List[Output]:
+        # do self-test - check if we can fetch list of kanalen
+        service = Service.objects.get(api_root=self.api_root)
+        client = service.build_client()
+        try:
+            channels = client.list("kanaal")
+        except (ClientError, requests.RequestException) as exc:
+            raise SelfTestFailure(
+                "Could not retrieve list of kanalen from Notificaties API."
+            ) from exc
+
+        channel_names = [channel["naam"] for channel in channels] or ["(none)"]
+        return [
+            Output(
+                id="notificationsApiChannels",
+                title="Channels present in notifications API",
+                data={"channels": ", ".join(channel_names)},
+            )
+        ]

--- a/src/openzaak/config/bootstrap/site.py
+++ b/src/openzaak/config/bootstrap/site.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2022 Dimpact
+from dataclasses import dataclass
+from typing import List
+
+from django.contrib.sites.models import Site
+from django.urls import reverse
+
+import requests
+
+from openzaak.utils import build_absolute_url
+
+from .datastructures import Output
+from .exceptions import SelfTestFailure
+
+
+@dataclass
+class SiteConfiguration:
+    """
+    Configure the application site/domain.
+
+    From: https://open-zaak.readthedocs.io/en/stable/installation/config/openzaak_config.html#setting-the-domain
+
+    FIXME: perhaps set up pub-sub with redis to flush the process site cache? See
+    open-zaak/open-zaak#598
+    """
+
+    domain: str
+    organization_name: str
+
+    def configure(self) -> List[Output]:
+        site = Site.objects.get_current()
+        # no-op - we only check based on domain
+        if site.domain == self.domain:
+            return []
+
+        # TODO: configure and include settings.ENVIRONMENT (currently hardcoded in settings files)
+        site.domain = self.domain
+        site.name = f"Open Zaak {self.organization_name}".strip()
+        site.save()
+        return []
+
+    def test_configuration(self) -> List[Output]:
+        full_url = build_absolute_url(reverse("home"), request=None)
+        try:
+            response = requests.get(full_url)
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            raise SelfTestFailure(
+                f"Could not access home page at '{full_url}'"
+            ) from exc
+
+        return [
+            Output(
+                id="domainCheck",
+                title="Domain test succeeded",
+                data={"response_status": response.status_code},
+            )
+        ]

--- a/src/openzaak/config/bootstrap/typing.py
+++ b/src/openzaak/config/bootstrap/typing.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2022 Dimpact
+from typing import List, Protocol
+
+from .datastructures import Output
+
+
+class ConfigurationProtocol(Protocol):
+    """
+    Define the base protocol for configuration factories.
+    """
+
+    def configure(self) -> List[Output]:
+        """
+        Make the necessary configuration changes to reach the desired state.
+        """
+        ...
+
+    def test_configuration(self) -> List[Output]:
+        """
+        Test the provided configuration parameters.
+
+        :raises: :class:`openzaak.config.bootstrap.exceptions.SelfTestFailure` if a
+          configuration aspect was found to be faulty.
+        """
+        ...

--- a/src/openzaak/config/tests/bootstrap/__init__.py
+++ b/src/openzaak/config/tests/bootstrap/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2022 Dimpact

--- a/src/openzaak/config/tests/bootstrap/test_notifications_api_configuration.py
+++ b/src/openzaak/config/tests/bootstrap/test_notifications_api_configuration.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2022 Dimpact
+from unittest.mock import patch
+
+from django.test import TestCase
+
+import requests
+import requests_mock
+from notifications_api_common.models import NotificationsConfig
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+from vng_api_common.authorizations.models import Applicatie, Autorisatie
+from zgw_consumers.constants import AuthTypes
+from zgw_consumers.models import Service
+
+from openzaak.notifications.tests import mock_nrc_oas_get
+from openzaak.tests.utils.auth import JWTAuthMixin
+
+from ...bootstrap.exceptions import SelfTestFailure
+from ...bootstrap.notifications import NotificationsAPIConfiguration
+
+
+class NotificationsAPIConfigurationTests(TestCase):
+    @patch(
+        "openzaak.config.bootstrap.notifications.generate_jwt_secret",
+        return_value="not-so-random",
+    )
+    def test_create_missing_configuration(self, mock_generate):
+        configuration = NotificationsAPIConfiguration(
+            org_name="ACME",
+            uses_autorisaties_api=False,
+            api_root="https://notifs.example.com/api/v1",
+            client_id="",
+            secret="",
+        )
+
+        output = configuration.configure()
+
+        service = NotificationsConfig.get_solo().notifications_api_service
+        self.assertIsNotNone(service)
+        self.assertEqual(service.api_root, "https://notifs.example.com/api/v1/")
+        self.assertEqual(service.client_id, "open-zaak-acme")
+        self.assertEqual(service.secret, "not-so-random")
+
+        self.assertEqual(output[0].id, "notificationsAPIConfiguration")
+        self.assertEqual(
+            output[0].data, {"client_id": "open-zaak-acme", "secret": "not-so-random",}
+        )
+
+    def test_create_missing_configuration_explicit_credentials(self):
+        configuration = NotificationsAPIConfiguration(
+            org_name="ACME",
+            uses_autorisaties_api=False,
+            api_root="https://notifs.example.com/api/v1/",
+            client_id="a-client-id",
+            secret="a-secret",
+        )
+
+        output = configuration.configure()
+
+        service = NotificationsConfig.get_solo().notifications_api_service
+        self.assertIsNotNone(service)
+        self.assertEqual(service.api_root, "https://notifs.example.com/api/v1/")
+        self.assertEqual(service.client_id, "a-client-id")
+        self.assertEqual(service.secret, "a-secret")
+
+        self.assertEqual(output[0].id, "notificationsAPIConfiguration")
+        self.assertEqual(
+            output[0].data, {"client_id": "a-client-id", "secret": "a-secret",}
+        )
+
+    def test_update_existing_configuration(self):
+        configuration = NotificationsAPIConfiguration(
+            org_name="ACME",
+            uses_autorisaties_api=False,
+            api_root="https://notifs.example.com/api/v1",
+            client_id="a-client-id",
+            secret="new-secret",
+        )
+        # set up service to be replaced
+        old_service = Service.objects.create(
+            api_root="http://old-notifs.example.com/api/v1", api_type="nrc"
+        )
+        config = NotificationsConfig.get_solo()
+        config.notifications_api_service = old_service
+        config.save()
+
+        output = configuration.configure()
+
+        service = NotificationsConfig.get_solo().notifications_api_service
+        self.assertIsNotNone(service)
+        self.assertNotEqual(service, old_service)
+        self.assertEqual(service.api_root, "https://notifs.example.com/api/v1/")
+        self.assertEqual(service.client_id, "a-client-id")
+        self.assertEqual(service.secret, "new-secret")
+
+        self.assertEqual(output[0].id, "notificationsAPIConfiguration")
+        self.assertEqual(
+            output[0].data, {"client_id": "a-client-id", "secret": "new-secret",}
+        )
+
+    def test_update_existing_configuration_no_new_service(self):
+        configuration = NotificationsAPIConfiguration(
+            org_name="ACME",
+            uses_autorisaties_api=False,
+            api_root="https://notifs.example.com/api/v1",
+            client_id="a-client-id",
+            secret="new-secret",
+        )
+        # set up service to be replaced
+        old_service = Service.objects.create(
+            api_root="https://notifs.example.com/api/v1",
+            api_type="nrc",
+            auth_type=AuthTypes.zgw,
+            client_id="old-client-id",
+            secret="old-secret",
+        )
+        config = NotificationsConfig.get_solo()
+        config.notifications_api_service = old_service
+        config.save()
+
+        output = configuration.configure()
+
+        service = NotificationsConfig.get_solo().notifications_api_service
+        self.assertEqual(service, old_service)
+        self.assertEqual(service.api_root, "https://notifs.example.com/api/v1/")
+        self.assertEqual(service.client_id, "a-client-id")
+        self.assertEqual(service.secret, "new-secret")
+
+        self.assertEqual(output[0].id, "notificationsAPIConfiguration")
+        self.assertEqual(
+            output[0].data, {"client_id": "a-client-id", "secret": "new-secret",}
+        )
+
+    def test_update_no_changes_without_credentials(self):
+        configuration = NotificationsAPIConfiguration(
+            org_name="ACME",
+            uses_autorisaties_api=False,
+            api_root="https://notifs.example.com/api/v1",
+            client_id="a-client-id",
+            secret="a-secret",
+        )
+        configuration.configure()
+
+        configuration2 = NotificationsAPIConfiguration(
+            org_name="",
+            uses_autorisaties_api=False,
+            api_root="https://notifs.example.com/api/v1",
+            client_id="",
+            secret="",
+        )
+        output = configuration2.configure()
+        self.assertEqual(output[0].id, "notificationsAPIConfiguration")
+        self.assertEqual(
+            output[0].data, {"client_id": "a-client-id", "secret": "a-secret",}
+        )
+
+    @requests_mock.Mocker()
+    def test_configuration_check_ok(self, m):
+        configuration = NotificationsAPIConfiguration(
+            org_name="ACME",
+            uses_autorisaties_api=False,
+            api_root="https://notifs.example.com/api/v1",
+            client_id="",
+            secret="",
+        )
+        configuration.configure()
+        mock_nrc_oas_get(m)
+        m.get("https://notifs.example.com/api/v1/kanaal", json=[{"naam": "test"}])
+
+        output = configuration.test_configuration()
+
+        self.assertEqual(output[0].id, "notificationsApiChannels")
+        self.assertEqual(output[0].data, {"channels": "test"})
+
+    @requests_mock.Mocker()
+    def test_configuration_check_failures(self, m):
+        configuration = NotificationsAPIConfiguration(
+            org_name="ACME",
+            uses_autorisaties_api=False,
+            api_root="https://notifs.example.com/api/v1",
+            client_id="",
+            secret="",
+        )
+        configuration.configure()
+        mock_nrc_oas_get(m)
+
+        mock_kwargs = (
+            {"exc": requests.ConnectTimeout},
+            {"exc": requests.ConnectionError},
+            {"status_code": 404},
+            {"status_code": 403},
+            {"status_code": 500},
+        )
+        for mock_config in mock_kwargs:
+            with self.subTest(mock=mock_config):
+                m.get("https://notifs.example.com/api/v1/kanaal", **mock_config)
+
+                with self.assertRaises(SelfTestFailure):
+                    configuration.test_configuration()
+
+
+class APIStateTests(JWTAuthMixin, APITestCase):
+    heeft_alle_autorisaties = True
+
+    def assertApplicationHasPermissions(self, client_id: str):
+        endpoint = reverse("applicatie-consumer", kwargs={"version": "1"})
+
+        response = self.client.get(endpoint, {"client_id": client_id})
+
+        application = response.json()
+        nrc_permissions = next(
+            (
+                perm
+                for perm in application["autorisaties"]
+                if perm["component"] == "nrc"
+            ),
+            None,
+        )
+
+        self.assertIsNotNone(
+            nrc_permissions, "Notificaties API permissions are missing"
+        )
+        self.assertTrue(
+            {"notificaties.consumeren", "notificaties.publiceren"}.issubset(
+                set(nrc_permissions["scopes"])
+            )
+        )
+
+    def test_correct_permissions(self):
+        configuration = NotificationsAPIConfiguration(
+            org_name="ACME",
+            uses_autorisaties_api=True,
+            api_root="https://notifs.example.com/api/v1/",
+            client_id="a-client-id",
+            secret="a-secret",
+        )
+        configuration.configure()
+
+        self.assertApplicationHasPermissions("a-client-id")
+
+    def test_extend_existing_configuration(self):
+        app = Applicatie.objects.create(
+            client_ids=["a-client-id", "another-client-id"], label="A label",
+        )
+        Autorisatie.objects.create(
+            applicatie=app, component="nrc", scopes=["notificaties.consumeren"]
+        )
+
+        configuration = NotificationsAPIConfiguration(
+            org_name="ACME",
+            uses_autorisaties_api=True,
+            api_root="https://notifs.example.com/api/v1/",
+            client_id="a-client-id",
+            secret="a-secret",
+        )
+        configuration.configure()
+
+        self.assertApplicationHasPermissions("a-client-id")

--- a/src/openzaak/config/tests/bootstrap/test_notifications_autorisaties_api_configuration.py
+++ b/src/openzaak/config/tests/bootstrap/test_notifications_autorisaties_api_configuration.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2022 Dimpact
+from unittest.mock import patch
+
+from django.test import TestCase
+
+import requests
+import requests_mock
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+from vng_api_common.authorizations.models import Applicatie, Autorisatie
+from vng_api_common.models import JWTSecret
+
+from openzaak.tests.utils.auth import JWTAuthMixin
+
+from ...bootstrap.exceptions import SelfTestFailure
+from ...bootstrap.notifications import AutorisatiesAPIClientConfiguration
+
+
+class AutorisatiesAPIClientConfigurationTests(TestCase):
+    @patch(
+        "openzaak.config.bootstrap.notifications.generate_jwt_secret",
+        return_value="not-so-random",
+    )
+    def test_create_missing_configuration(self, mock_generate):
+        configuration = AutorisatiesAPIClientConfiguration(
+            org_name="ACME", client_id="", secret=""
+        )
+
+        output = configuration.configure()
+
+        app = Applicatie.objects.get()
+        # client ID generated
+        self.assertEqual(len(app.client_ids), 1)
+        client_id = app.client_ids[0]
+        self.assertTrue(
+            JWTSecret.objects.filter(
+                identifier=client_id, secret="not-so-random"
+            ).exists()
+        )
+
+        self.assertEqual(output[0].id, "autorisatiesAPIClientCredentials")
+        self.assertEqual(
+            output[0].data, {"client_id": client_id, "secret": "not-so-random",}
+        )
+
+    def test_create_missing_configuration_explicit_credentials(self):
+        configuration = AutorisatiesAPIClientConfiguration(
+            org_name="ACME", client_id="a-client-id", secret="a-secret"
+        )
+
+        output = configuration.configure()
+
+        app = Applicatie.objects.get()
+        # client ID generated
+        self.assertEqual(app.client_ids, ["a-client-id"])
+        jwt_secret = JWTSecret.objects.get(identifier="a-client-id")
+        self.assertEqual(jwt_secret.secret, "a-secret")
+        self.assertEqual(output[0].id, "autorisatiesAPIClientCredentials")
+        self.assertEqual(
+            output[0].data, {"client_id": "a-client-id", "secret": "a-secret",}
+        )
+
+    def test_update_existing_configuration(self):
+        app = Applicatie.objects.create(
+            client_ids=["a-client-id", "another-client-id"], label="A label",
+        )
+        jwt_secret = JWTSecret.objects.create(
+            identifier="a-client-id", secret="old-secret"
+        )
+        configuration = AutorisatiesAPIClientConfiguration(
+            org_name="ACME", client_id="a-client-id", secret="new-secret"
+        )
+
+        output = configuration.configure()
+
+        jwt_secret.refresh_from_db()
+        self.assertEqual(jwt_secret.secret, "new-secret")
+        app.refresh_from_db()
+        self.assertEqual(app.label, "A label")
+        self.assertEqual(output[0].id, "autorisatiesAPIClientCredentials")
+        self.assertEqual(
+            output[0].data, {"client_id": "a-client-id", "secret": "new-secret",}
+        )
+
+    @requests_mock.Mocker()
+    @patch(
+        "openzaak.config.bootstrap.notifications.build_absolute_url",
+        return_value="http://testserver/applicaties",
+    )
+    def test_configuration_check_ok(self, m, *mocks):
+        configuration = AutorisatiesAPIClientConfiguration(
+            org_name="ACME", client_id="", secret=""
+        )
+        configuration.configure()
+        m.get("http://testserver/applicaties", json=[])
+
+        output = configuration.test_configuration()
+
+        self.assertEqual(output[0].id, "autorisatiesAPIClientSelfTest")
+        self.assertEqual(output[0].data, {"success": True})
+
+    @requests_mock.Mocker()
+    @patch(
+        "openzaak.config.bootstrap.notifications.build_absolute_url",
+        return_value="http://testserver/applicaties",
+    )
+    def test_configuration_check_failures(self, m, *mocks):
+        configuration = AutorisatiesAPIClientConfiguration(
+            org_name="ACME", client_id="", secret=""
+        )
+        configuration.configure()
+
+        mock_kwargs = (
+            {"exc": requests.ConnectTimeout},
+            {"exc": requests.ConnectionError},
+            {"status_code": 404},
+            {"status_code": 403},
+            {"status_code": 500},
+        )
+        for mock_config in mock_kwargs:
+            with self.subTest(mock=mock_config):
+                m.get("http://testserver/applicaties", **mock_config)
+
+                with self.assertRaises(SelfTestFailure):
+                    configuration.test_configuration()
+
+
+class APIStateTests(JWTAuthMixin, APITestCase):
+    heeft_alle_autorisaties = True
+
+    def assertApplicationHasPermissions(self, client_id: str):
+        endpoint = reverse("applicatie-consumer", kwargs={"version": "1"})
+
+        response = self.client.get(endpoint, {"client_id": client_id})
+
+        application = response.json()
+        ac_permissions = next(
+            (perm for perm in application["autorisaties"] if perm["component"] == "ac"),
+            None,
+        )
+        nrc_permissions = next(
+            (
+                perm
+                for perm in application["autorisaties"]
+                if perm["component"] == "nrc"
+            ),
+            None,
+        )
+
+        self.assertIsNotNone(ac_permissions, "Autorisaties API permissions are missing")
+        self.assertIsNotNone(
+            nrc_permissions, "Notificaties API permissions are missing"
+        )
+
+        self.assertTrue({"autorisaties.lezen"}.issubset(set(ac_permissions["scopes"])))
+        self.assertTrue(
+            {"notificaties.consumeren", "notificaties.publiceren"}.issubset(
+                set(nrc_permissions["scopes"])
+            )
+        )
+
+    def test_correct_permissions(self):
+        configuration = AutorisatiesAPIClientConfiguration(
+            org_name="ACME", client_id="a-client-id", secret="a-secret"
+        )
+        configuration.configure()
+
+        self.assertApplicationHasPermissions("a-client-id")
+
+    def test_extend_existing_configuration(self):
+        app = Applicatie.objects.create(
+            client_ids=["a-client-id", "another-client-id"], label="A label",
+        )
+        Autorisatie.objects.create(applicatie=app, component="ac", scopes=[])
+        Autorisatie.objects.create(
+            applicatie=app, component="nrc", scopes=["notificaties.consumeren"]
+        )
+
+        configuration = AutorisatiesAPIClientConfiguration(
+            org_name="ACME", client_id="a-client-id", secret="a-secret"
+        )
+        configuration.configure()
+
+        self.assertApplicationHasPermissions("a-client-id")

--- a/src/openzaak/config/tests/bootstrap/test_site_configuration.py
+++ b/src/openzaak/config/tests/bootstrap/test_site_configuration.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2022 Dimpact
+from django.contrib.sites.models import Site
+from django.test import TestCase
+
+import requests
+import requests_mock
+
+from ...bootstrap.exceptions import SelfTestFailure
+from ...bootstrap.site import SiteConfiguration
+
+
+class SiteConfigurationTests(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.addCleanup(Site.objects.clear_cache)
+
+    def test_set_domain(self):
+        configuration = SiteConfiguration(
+            domain="localhost:8000", organization_name="ACME"
+        )
+        configuration.configure()
+
+        site = Site.objects.get_current()
+        self.assertEqual(site.domain, "localhost:8000")
+        self.assertEqual(site.name, "Open Zaak ACME")
+
+    def test_noop_current_state(self):
+        site = Site.objects.get_current()
+        site.domain = "testserver"
+        site.name = "Test server"  # explicit name given
+        site.save()
+
+        configuration = SiteConfiguration(domain="testserver", organization_name="ACME")
+        configuration.configure()
+
+        site.refresh_from_db()
+        self.assertEqual(site.name, "Test server")
+
+    @requests_mock.Mocker()
+    def test_configuration_check_ok(self, m):
+        m.get("http://localhost:8000/", status_code=200)
+        configuration = SiteConfiguration(
+            domain="localhost:8000", organization_name="ACME"
+        )
+        configuration.configure()
+
+        output = configuration.test_configuration()
+
+        self.assertEqual(output[0].id, "domainCheck")
+
+    @requests_mock.Mocker()
+    def test_configuration_check_failures(self, m):
+        configuration = SiteConfiguration(
+            domain="localhost:8000", organization_name="ACME"
+        )
+        configuration.configure()
+
+        mock_kwargs = (
+            {"exc": requests.ConnectTimeout},
+            {"exc": requests.ConnectionError},
+            {"status_code": 404},
+            {"status_code": 403},
+            {"status_code": 500},
+        )
+        for mock_config in mock_kwargs:
+            with self.subTest(mock=mock_config):
+                m.get("http://localhost:8000/", **mock_config)
+
+                with self.assertRaises(SelfTestFailure):
+                    configuration.test_configuration()

--- a/src/openzaak/management/commands/setup_configuration.py
+++ b/src/openzaak/management/commands/setup_configuration.py
@@ -1,156 +1,462 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
+import argparse
+import json
 import logging
-from argparse import RawTextHelpFormatter
+import sys
+from dataclasses import dataclass
+from io import StringIO
+from typing import Any, List, Optional
+from urllib.parse import urlparse
 
+from django.conf import settings
 from django.contrib.sites.models import Site
-from django.core.management.base import BaseCommand, CommandError
-from django.db import transaction
-from django.utils.crypto import get_random_string
+from django.core.management import BaseCommand, CommandError, call_command
 
-from notifications_api_common.constants import (
-    SCOPE_NOTIFICATIES_CONSUMEREN_LABEL,
-    SCOPE_NOTIFICATIES_PUBLICEREN_LABEL,
-)
 from notifications_api_common.models import NotificationsConfig
-from vng_api_common.authorizations.models import Applicatie, Autorisatie
-from vng_api_common.constants import ComponentTypes
-from vng_api_common.models import APICredential, JWTSecret
-from zgw_consumers.constants import APITypes, AuthTypes
-from zgw_consumers.models import Service
 
-from openzaak.components.autorisaties.api.scopes import SCOPE_AUTORISATIES_LEZEN
+from openzaak.config.bootstrap.exceptions import SelfTestFailure
+from openzaak.config.bootstrap.notifications import (
+    AutorisatiesAPIClientConfiguration,
+    NotificationsAPIConfiguration,
+)
+from openzaak.config.bootstrap.site import SiteConfiguration
+from openzaak.config.bootstrap.typing import ConfigurationProtocol
 
 logger = logging.getLogger(__name__)
 
 
-class Command(BaseCommand):
-    help = "Setup the initial necessary configuration"
+def domain_only_netloc(value: str) -> str:
+    if "//" in value:
+        parsed = urlparse(value)
+        return f"{parsed.netloc}{parsed.path}"
+    elif ":" in value:
+        host, port = value.split(":", 1)
+        return f"{host}:{port}"
+    return value
 
-    def create_parser(self, *args, **kwargs):
-        parser = super(Command, self).create_parser(*args, **kwargs)
-        parser.formatter_class = RawTextHelpFormatter
-        return parser
+
+def fq_url(value: str) -> str:
+    parsed = urlparse(value)
+    if not parsed.scheme:
+        raise argparse.ArgumentTypeError("URL must include scheme (like 'https://')")
+    if not parsed.netloc:
+        raise argparse.ArgumentTypeError(
+            "URL must include host information (like 'notifications.example.com')"
+        )
+    return value
+
+
+@dataclass
+class ConfigurationStep:
+    configuration: ConfigurationProtocol
+    info_message: str
+    success_message: str
+    self_test_prompt: str
+    do_self_test: Optional[bool] = None
+
+
+class Command(BaseCommand):
+    help = (
+        "Bootstrap the initial Open Zaak configuration. Note that this command is "
+        "interacitve - missing input will be prompted for."
+    )
+    output_transaction = True
+    stealth_options = ("stdin",)
 
     def add_arguments(self, parser):
+        # site meta
         parser.add_argument(
-            "openzaak_domain",
-            help="Specifies the domain for this Open Zaak installation\n"
-            "Used to set the Site.domain\n\n"
-            "Example: open-zaak.utrecht.nl (without https://www.)",
+            "-o",
+            "--org",
+            "--organization",
+            "--organisation",
+            dest="organization",
+            default="",
+            help=(
+                "Name of your organization, e.g. 'ACME'. This is used in labels and "
+                "prefixes of configuration aspects (such as client IDs) if provided."
+            ),
         )
         parser.add_argument(
-            "notifications_api_root",
-            help="Specifies the API root for the Notifications API\n"
-            "Used to create credentials to connect Open Zaak to Notifications API\n\n"
-            "Example: https://open-notificaties.utrecht.nl/api/v1/",
-        )
-        parser.add_argument(
-            "municipality",
-            help="Municipality to which this installation belongs\n"
-            "Used in client IDs for API credentials\n\n"
-            "Example: Utrecht",
-        )
-        parser.add_argument(
-            "openzaak_to_notif_secret",
-            help="Secret used for the Application that allows Open Zaak to retrieve notifications\n\n"
-            "Example: cuohyKZ3lM2R",
-        )
-        parser.add_argument(
-            "notif_to_openzaak_secret",
-            help="Secret used for the Application that allows Notifications API to retrieve authorizations\n\n"
-            "Example: FP6oB8N6cMkr",
+            "-d",
+            "--domain",
+            default="",
+            type=domain_only_netloc,
+            help=(
+                "Domain/host of the Open Zaak instance. E.g. 'open-zaak.example.com:4443', "
+                "without the 'https://...' prefix."
+            ),
         )
 
-    @transaction.atomic
-    def handle(self, *args, **options):
+        # create autorisaties application for notifications API
+        parser.add_argument(
+            "--create-notifications-api-app",
+            dest="notifications_provision_ac_client",
+            action=argparse.BooleanOptionalAction,
+            help=(
+                "Create a client application for the Notifications API in Open Zaak's "
+                "autorisaties API. This application is required if your Notifications "
+                "API uses the Open Zaak autorisaties API to check permissions of "
+                "notification publishers/consumers."
+            ),
+        )
+        parser.add_argument(
+            "--notifications-api-app-client-id",
+            dest="notifications_ac_client_client_id",
+            default="",
+            help=(
+                "Specify a client ID for the Autorisaties API client. If not specified, "
+                "a client ID will be generated. If provided, the existing client will "
+                "be looked up by this value, otherwise the label will be derived from "
+                "the organization name for lookup."
+            ),
+        )
+        parser.add_argument(
+            "--notifications-api-app-secret",
+            dest="notifications_ac_client_secret",
+            default="",
+            help=(
+                "Specify a client secret for the Autorisaties API client. If not "
+                "specified, a value will be generated."
+            ),
+        )
+
+        # notifications API - which notifications API to use
+        parser.add_argument(
+            "--notifications-api-root",
+            type=fq_url,
+            dest="notifications_api_root",
+            help=(
+                "Notifications API root URL, including protocol. E.g. "
+                "'https://notificaties.example.com/api/v1/'. If provided, the "
+                "relevant permissions and service are configured."
+            ),
+        )
+        parser.add_argument(
+            "--notifications-api-client-id",
+            default="",
+            help=(
+                "Specify a client ID for the Notifications API. If not specified, a "
+                "client ID will be generated. Any existing configuration is looked up "
+                "based on this client ID. If not provided, a value is derived from the "
+                "organiation name. Requires the --notifications-api option."
+            ),
+        )
+        parser.add_argument(
+            "--notifications-api-secret",
+            default="",
+            help=(
+                "Specify a client secret for the Notifications API. If not specified, a "
+                "value will be generated. Only when explicitly provided existing "
+                "configuration is updated."
+            ),
+        )
+        parser.add_argument(
+            "--send-test-notification",
+            dest="send_test_notification",
+            action=argparse.BooleanOptionalAction,
+            help="Send a test notification to the configured Notifications API.",
+        )
+
+        # self-test config
+        parser.add_argument(
+            "--self-test",
+            "--selftest",
+            dest="do_self_test",
+            action=argparse.BooleanOptionalAction,
+            help="Skip self-testing the created configuration.",
+        )
+        parser.add_argument(
+            "--noinput",
+            "--no-input",
+            action="store_false",
+            dest="interactive",
+            help=(
+                "Tells Open Zaak to NOT prompt the user for input of any kind. "
+                "Only parameters provided on the command line will be processed."
+            ),
+        )
+        parser.add_argument(
+            "--json",
+            action="store_true",
+            help=(
+                "Outputs results to stdout as JSON. Note that this surpresses any "
+                "other informative output."
+            ),
+        )
+
+    def execute(self, *args, **options):
+        self.stdin = options.get("stdin", sys.stdin)  # Used for testing
+        return super().execute(*args, **options)
+
+    def handle(self, **options):
+        verbosity: int = options["verbosity"]
+        self.as_json = options["json"]
+        self.verbosity = verbosity
+
+        organization = options["organization"]
+        domain = options["domain"]
+
+        # notifications: autorisaties API client
+        notifications_provision_ac_client: Optional[bool] = options[
+            "notifications_provision_ac_client"
+        ]
+        notifications_ac_client_client_id = options["notifications_ac_client_client_id"]
+        notifications_ac_client_secret = options["notifications_ac_client_secret"]
+
+        # notifications API: Open Zaak is client for this service
+        notifications_api_root = options["notifications_api_root"]
+        notifications_api_client_id = options["notifications_api_client_id"]
+        notifications_api_secret = options["notifications_api_secret"]
+        send_test_notification: Optional[bool] = options["send_test_notification"]
+
+        # globally enable/disable self-testing - None if not explicitly provided
+        do_self_test: Optional[bool] = options["do_self_test"]
+
+        # Interactively prompt for missing/empty options.
+        if options["interactive"]:
+            self._check_tty()
+
+            # prompt for organization name
+            if not organization:
+                self.write_info(
+                    "The organization name is used in labels and Client ID suffixes. "
+                    "We recommend setting a proper value."
+                )
+                message = "Organization (leave blank to use 'ACME'): "
+                organization = self._get_input_data(message, default="ACME")
+                if not self.as_json:
+                    self.stdout.write(
+                        f"  Continuing with organization name '{organization}'..."
+                    )
+
+            if not domain:
+                self.write_info(
+                    "The domain is used to construct fully qualified (resource) URLs "
+                    "to be retrieved by other services."
+                )
+                current_domain = Site.objects.get_current().domain
+                message = f"Domain (leave blank to use '{current_domain}'): "
+                domain = self._get_input_data(message, default=current_domain)
+                if not self.as_json:
+                    self.stdout.write(f"  Continuing with domain '{domain}'...")
+
+            # Autorisaties API configuration for Notifications API
+            if notifications_provision_ac_client is None:
+                self.write_info(
+                    "The Notifications API retrieves permission information from an "
+                    "Authorizations API to check whether clients are allowed to "
+                    "produce or consume notifications. If your Notifications API uses "
+                    "the Authorizations API implemented by Open Zaak (which is "
+                    "likely), then the Application record for the Notifications API "
+                    "must be configured."
+                )
+                message = "Create Notifications API application? [Y/n]: "
+                notifications_provision_ac_client = self._bool_prompt(
+                    message, default="Y"
+                )
+                if not notifications_provision_ac_client and not self.as_json:
+                    self.stdout.write(
+                        "  Skipping Notifications API application creation."
+                    )
+
+            if (
+                notifications_provision_ac_client
+                and not notifications_ac_client_client_id
+            ):
+                message = "Notifications app: CLIENT ID (leave blank to generate one): "
+                notifications_ac_client_client_id = self._get_input_data(message)
+                if not notifications_ac_client_client_id and not self.as_json:
+                    self.stdout.write("  A value will be generated.")
+
+            if notifications_provision_ac_client and not notifications_ac_client_secret:
+                message = "Notifications app: SECRET (leave blank to generate one): "
+                notifications_ac_client_secret = self._get_input_data(message)
+                if not notifications_ac_client_secret and not self.as_json:
+                    self.stdout.write("  A value will be generated.")
+
+            if not settings.NOTIFICATIONS_DISABLED:
+                # Notifications API configuration
+                if not notifications_api_root:
+                    self.write_info(
+                        "Open Zaak publishes notifications to the Notifications API. "
+                        "For this, the connection to the Notifications API must be "
+                        "correctly configured.\n\n"
+                        "If credentials are generated, make sure to configure those in "
+                        "your Notifications API too."
+                    )
+
+                    service = NotificationsConfig.get_solo().notifications_api_service
+                    current_api_root = service.api_root if service else "(unset)"
+                    message = f"Notifications API root (leave blank to use '{current_api_root}'): "
+                    notifications_api_root = self._get_input_data(
+                        message, default=current_api_root
+                    )
+                    if not self.as_json:
+                        self.stdout.write(
+                            f"  Continuing with Notifications API at {notifications_api_root}."
+                        )
+
+                if not notifications_api_client_id:
+                    message = (
+                        "Notifications API: CLIENT ID (leave blank to generate one): "
+                    )
+                    notifications_api_client_id = self._get_input_data(message)
+                    if not notifications_api_client_id and not self.as_json:
+                        self.stdout.write("  A value will be generated.")
+
+                if not notifications_api_secret:
+                    message = (
+                        "Notifications API: SECRET (leave blank to generate one): "
+                    )
+                    notifications_api_secret = self._get_input_data(message)
+                    if not notifications_api_secret and not self.as_json:
+                        self.stdout.write("  A value will be generated.")
+
+            elif not self.as_json:
+                self.stdout.write(
+                    self.style.WARNING(
+                        "You currently have notification sending disabled "
+                        "(NOTIFICATIONS_DISABLED). Open Zaak will not be publishing "
+                        "any notifications."
+                    )
+                )
+
+        def _prompt_self_test(msg: str) -> bool:
+            # explicitly provided via flag -> use that global configuration
+            if do_self_test is not None:
+                return do_self_test
+            # in non-interactive mode, we can't prompt, so assume it's unattended
+            # -> no self test by default
+            if not options["interactive"]:
+                return False
+            message = f"{msg} [Y/n]: "
+            return self._bool_prompt(message, default="Y")
+
+        steps: List[ConfigurationStep] = []
+
+        if domain:
+            steps.append(
+                ConfigurationStep(
+                    configuration=SiteConfiguration(domain, organization),
+                    info_message="Configuring site domain...",
+                    success_message="Site (domain) configured.",
+                    self_test_prompt="Test domain configuration by retrieving the homepage?",
+                )
+            )
+
+        if notifications_provision_ac_client:
+            steps.append(
+                ConfigurationStep(
+                    configuration=AutorisatiesAPIClientConfiguration(
+                        org_name=organization,
+                        client_id=notifications_ac_client_client_id,
+                        secret=notifications_ac_client_secret,
+                    ),
+                    info_message="Configuring Autorisaties API credentials...",
+                    success_message="Autorisaties API credentials configured.",
+                    self_test_prompt="Test Autorisaties API credentials?",
+                )
+            )
+
+        if notifications_api_root:
+            steps.append(
+                ConfigurationStep(
+                    configuration=NotificationsAPIConfiguration(
+                        org_name=organization,
+                        uses_autorisaties_api=bool(notifications_provision_ac_client),
+                        api_root=notifications_api_root,
+                        client_id=notifications_api_client_id,
+                        secret=notifications_api_secret,
+                    ),
+                    info_message="Configuring Notifications API...",
+                    success_message="Notifications API configured.",
+                    self_test_prompt="Test Notifications API access?",
+                )
+            )
+
+        # run all the configuration and collect output
+        all_output = []
+        for step in steps:
+            self.report_step(step.info_message)
+            all_output += step.configuration.configure()
+            self.write_success(step.success_message)
+
         try:
-            openzaak_domain = options["openzaak_domain"]
-            notifications_api_root = options["notifications_api_root"]
-            municipality = options["municipality"]
-            openzaak_to_notif_secret = options["openzaak_to_notif_secret"]
-            notif_to_openzaak_secret = options["notif_to_openzaak_secret"]
+            # now prompt for (and run) step self-test
+            for step in steps:
+                run_self_test = _prompt_self_test(step.self_test_prompt)
+                if not run_self_test:
+                    continue
+                all_output += step.configuration.test_configuration()
 
-            # See: https://open-zaak.readthedocs.io/en/latest/installation/configuration.html#setting-the-domain
-            site = Site.objects.get_current()
-            site.domain = openzaak_domain
-            site.name = f"Open Zaak {municipality}"
-            site.save()
+        except SelfTestFailure as failure:
+            error_message = failure.args[0]
+            raise CommandError(error_message) from failure
 
-            # For the steps below, see:
-            # https://open-zaak.readthedocs.io/en/latest/installation/configuration.html#open-zaak
+        if notifications_api_root:
+            if send_test_notification is None:
+                send_test_notification = _prompt_self_test("Send a test notification?")
 
-            # Step 1
-            service = Service.objects.filter(api_type=APITypes.nrc).first()
-            assert service is not None, "Service should have been created by migrations"
-            service.api_root = notifications_api_root
-            service.auth_type = AuthTypes.zgw
-            random_client_id = f"open-zaak-{get_random_string()}"
-            random_secret = get_random_string()
-            service.client_id = random_client_id
-            service.secret = random_secret
-            service.user_id = "open-zaak"
-            service.user_representation = "Open Zaak"
-            service.save()
-
-            # Step 2
-            notif_config = NotificationsConfig.get_solo()
-            notif_config.notifications_api_service = service
-            notif_config.save()
-
-            # Step 3
-            if not APICredential.objects.filter(
-                api_root=notifications_api_root
-            ).exists():
-                APICredential.objects.create(
-                    api_root=notifications_api_root,
-                    label=f"Open Notificaties {municipality}",
-                    client_id=f"open-zaak-{municipality.lower()}",
-                    secret=openzaak_to_notif_secret,
-                    user_id=f"open-zaak-{municipality.lower()}",
-                    user_representation=f"Open Zaak {municipality}",
+            if send_test_notification:
+                stdout = self.stdout if not self.as_json else StringIO()
+                call_command(
+                    "send_test_notification", stdout=stdout, stderr=self.stderr
                 )
 
-            notif_api_jwtsecret_ac = JWTSecret.objects.create(
-                identifier=f"open-notificaties-{municipality.lower()}",
-                secret=notif_to_openzaak_secret,
-            )
-            notif_api_applicatie_ac = Applicatie.objects.create(
-                label=f"Open Notificaties {municipality}",
-                client_ids=[notif_api_jwtsecret_ac.identifier],
-            )
-            Autorisatie.objects.create(
-                applicatie=notif_api_applicatie_ac,
-                component=ComponentTypes.ac,
-                scopes=[SCOPE_AUTORISATIES_LEZEN],
-            )
+        if verbosity >= 1:
 
-            # Step 4
-            openzaak_applicatie_notif = Applicatie.objects.create(
-                label=f"Open Zaak {municipality}",
-                client_ids=[f"open-zaak-{municipality.lower()}"],
-            )
-            Autorisatie.objects.create(
-                applicatie=openzaak_applicatie_notif,
-                component=ComponentTypes.nrc,
-                scopes=[
-                    SCOPE_NOTIFICATIES_CONSUMEREN_LABEL,
-                    SCOPE_NOTIFICATIES_PUBLICEREN_LABEL,
-                ],
-            )
+            if not self.as_json:
+                self.stdout.write(self.style.MIGRATE_LABEL("\nResults summary"))
 
-            self.stdout.write(
-                self.style.SUCCESS(
-                    "Initial configuration for Open Zaak was setup successfully"
+                for output in all_output:
+                    self.stdout.write("\n")
+                    self.stdout.write(str(output))
+
+                self.stdout.write(
+                    self.style.SUCCESS("\nInstance configuration completed.")
                 )
-            )
 
-            self.stdout.write(
-                f"Notificaties API Service configured with client_id {random_client_id} "
-                f"and secret {random_secret}.  Use this to configure your Open Notifications instance."
-            )
-        except Exception as e:
-            logger.warning("Problem with services", exc_info=True)
+            else:
+                json_output = {}
+                for output in all_output:
+                    json_output.update(output.as_json())
+                serialized = json.dumps(json_output)
+                self.stdout.write(serialized)
+
+    def _get_input_data(
+        self, message: str, default: Optional[Any] = None, normalize=lambda x: x
+    ) -> Any:
+        value: str = input(message).strip()
+        if default and value == "":
+            value = default
+        return normalize(value)
+
+    def _bool_prompt(self, message: str, default: str = "N") -> bool:
+        response: str = self._get_input_data(
+            message, default=default, normalize=lambda x: x.lower()
+        )
+        return response in ("y", "yes", "yeah")
+
+    def _check_tty(self):
+        if hasattr(self.stdin, "isatty") and not self.stdin.isatty():
             raise CommandError(
-                f"Something went wrong while setting up initial configuration: {e}"
+                "Cannot prompt for input when not running in a TTY. Either use the "
+                "--noinput flag or run this command in a TTY."
             )
+
+    def write_info(self, msg: str):
+        if self.verbosity <= 1 or self.as_json:
+            return
+        self.stdout.write(self.style.HTTP_INFO(msg))
+
+    def write_success(self, msg: str):
+        if self.verbosity >= 1 or self.as_json:
+            return
+        self.stdout.write(self.style.SUCCESS(msg))
+
+    def report_step(self, msg: str):
+        if self.verbosity <= 1 or self.as_json:
+            return
+        self.stdout.write(self.style.MIGRATE_HEADING(msg))

--- a/src/openzaak/notifications/tests/test_register_kanaal.py
+++ b/src/openzaak/notifications/tests/test_register_kanaal.py
@@ -36,12 +36,14 @@ class RegisterKanaalTests(NotificationsConfigMixin, TestCase):
         cls._configure_notifications(api_root="https://open-notificaties.local/api/v1/")
 
     def test_correct_credentials_used(self):
+        stdout = StringIO()
+
         with requests_mock.Mocker() as m:
             mock_nrc_oas_get(m)
             m.get("https://open-notificaties.local/api/v1/kanaal?naam=zaken", json=[])
             m.post("https://open-notificaties.local/api/v1/kanaal", status_code=201)
 
-            call_command("register_kanalen", kanalen=["zaken"])
+            call_command("register_kanalen", kanalen=["zaken"], stdout=stdout)
 
             # check for auth in the calls
             for request in m.request_history[1:]:

--- a/src/openzaak/tests/management/test_setup_configuration.py
+++ b/src/openzaak/tests/management/test_setup_configuration.py
@@ -1,100 +1,565 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
+import json
+from io import StringIO
+from typing import Dict
+from unittest.mock import patch
+
 from django.contrib.sites.models import Site
-from django.core.management import call_command
-from django.test import TestCase
+from django.core.management import CommandError, call_command
+from django.test import override_settings
 
-from notifications_api_common.constants import (
-    SCOPE_NOTIFICATIES_CONSUMEREN_LABEL,
-    SCOPE_NOTIFICATIES_PUBLICEREN_LABEL,
-)
+import requests
+import requests_mock
+from jwt import decode
 from notifications_api_common.models import NotificationsConfig
-from vng_api_common.authorizations.models import Applicatie, Autorisatie
-from vng_api_common.constants import ComponentTypes
-from vng_api_common.models import APICredential, JWTSecret
-from zgw_consumers.constants import APITypes, AuthTypes
-from zgw_consumers.models import Service
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+from vng_api_common.authorizations.models import Applicatie
+from vng_api_common.models import JWTSecret
+from zds_client import ClientAuth
 
-from openzaak.components.autorisaties.api.scopes import SCOPE_AUTORISATIES_LEZEN
-from openzaak.notifications.tests.mixins import NotificationsConfigMixin
+from openzaak.notifications.tests import mock_notification_send, mock_nrc_oas_get
 
 
-class SetupConfigurationTests(NotificationsConfigMixin, TestCase):
-    def test_setup_configuration(self):
-        openzaak_domain = "open-zaak.utrecht.nl"
-        nrc_root = "https://open-notificaties.utrecht.nl/api/v1/"
-        municipality = "Utrecht"
-        openzaak_to_notif_secret = "12345"
-        notif_to_openzaak_secret = "54321"
+class MockTTY:
+    """
+    A fake stdin object that pretends to be a TTY to be used in conjunction
+    with mock_inputs.
+    """
+
+    def isatty(self):
+        return True
+
+
+def mock_input(prompts: Dict[str, str]):
+    def mocked_input(prompt: str) -> str:
+        answer = prompts.get(prompt, "")
+        return answer
+
+    return patch("builtins.input", side_effect=mocked_input)
+
+
+@override_settings(NOTIFICATIONS_DISABLED=False)
+class SetupConfigurationTests(APITestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.addCleanup(Site.objects.clear_cache)
+
+    @requests_mock.Mocker()
+    def test_non_interactive_without_selftest(self, m):
+        stdout, stderr = StringIO(), StringIO()
 
         call_command(
             "setup_configuration",
-            openzaak_domain,
-            nrc_root,
-            municipality,
-            openzaak_to_notif_secret,
-            notif_to_openzaak_secret,
+            "--no-input",
+            ["-v", "0"],
+            ["-o", "ACME"],
+            ["-d", "open-zaak.example.com"],
+            "--create-notifications-api-app",
+            ["--notifications-api-app-client-id", "notifications-acme"],
+            ["--notifications-api-app-secret", "insecure-oz-secret"],
+            ["--notifications-api-root", "https://notifs.example.com"],
+            ["--notifications-api-client-id", "oz-acme"],
+            ["--notifications-api-secret", "insecure-nrc-secret"],
+            "--no-selftest",
+            "--no-color",
+            stdout=stdout,
+            stderr=stderr,
         )
 
-        site = Site.objects.get_current()
-        self.assertEqual(site.domain, openzaak_domain)
-        self.assertEqual(site.name, f"Open Zaak {municipality}")
+        # minimal output expected
+        with self.subTest("Command output"):
+            command_output = stdout.getvalue().splitlines()
+            expected_output = [
+                "Site (domain) configured.",
+                "Autorisaties API credentials configured.",
+                "Notifications API configured.",
+            ]
+            self.assertEqual(command_output, expected_output)
 
-        service = Service.objects.get(api_type=APITypes.nrc)
-        self.assertEqual(service.api_root, nrc_root)
-        self.assertEqual(service.auth_type, AuthTypes.zgw)
-        self.assertEqual(service.user_id, "open-zaak")
-        self.assertEqual(service.user_representation, "Open Zaak")
+        with self.subTest("Site configured correctly"):
+            site = Site.objects.get_current()
+            self.assertEqual(site.domain, "open-zaak.example.com")
+            self.assertEqual(site.name, "Open Zaak ACME")
 
-        notif_config = NotificationsConfig.get_solo()
-        self.assertEqual(notif_config.notifications_api_service, service)
+        with self.subTest("Notifications API can query Autorisaties API"):
+            auth = ClientAuth("notifications-acme", "insecure-oz-secret")
 
-        api_credential = APICredential.objects.get()
-        self.assertEqual(api_credential.api_root, nrc_root)
+            response = self.client.get(
+                reverse("applicatie-list", kwargs={"version": 1}),
+                HTTP_AUTHORIZATION=auth.credentials()["Authorization"],
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        with self.subTest("Notifications API client configured correctly"):
+            mock_nrc_oas_get(m)
+            mock_notification_send(m)
+            notificaties_client = NotificationsConfig.get_client()
+            self.assertIsNotNone(notificaties_client)
+
+            response_data = notificaties_client.create(
+                "notificaties", data={"foo": "bar"}
+            )
+
+            self.assertEqual(response_data, {"dummy": "json"})
+            create_call = m.last_request
+            self.assertEqual(create_call.url, "https://notifs.example.com/notificaties")
+            self.assertIn("Authorization", create_call.headers)
+            header_jwt = create_call.headers["Authorization"].split(" ")[1]
+            decoded_jwt = decode(header_jwt, options={"verify_signature": False})
+            self.assertEqual(decoded_jwt["client_id"], "oz-acme")
+
+    def test_non_interactive_no_args(self):
+        """
+        Test that non-interactive no-arg commands are no-op.
+        """
+        stdout, stderr = StringIO(), StringIO()
+
+        call_command(
+            "setup_configuration",
+            "--no-selftest",
+            "--no-color",
+            stdout=stdout,
+            stderr=stderr,
+            interactive=False,
+        )
+
+        self.assertEqual(stderr.getvalue(), "")
+        self.assertIn("Instance configuration completed.", stdout.getvalue())
+
+    def test_domain_input_normalization(self):
+        stdout, stderr = StringIO(), StringIO()
+        inputs = (
+            ("http://localhost:8000", "localhost:8000"),
+            ("http://localhost:8000/some-path", "localhost:8000/some-path"),
+            ("example.com", "example.com"),
+            ("example.com/some-path/", "example.com/some-path/"),
+            ("localhost:8000", "localhost:8000"),
+            ("localhost:8000/some-path/", "localhost:8000/some-path/"),
+        )
+
+        for input_domain, expected_output in inputs:
+            with self.subTest(input=input_domain):
+                call_command(
+                    "setup_configuration",
+                    "--no-input",
+                    ["-v", "0"],
+                    ["-o", "ACME"],
+                    ["-d", input_domain],
+                    "--no-create-notifications-api-app",
+                    "--no-selftest",
+                    "--no-color",
+                    interactive=False,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+                site = Site.objects.get_current()
+                self.assertEqual(site.domain, expected_output)
+
+    def test_invalid_notifications_api_root(self):
+        stdout, stderr = StringIO(), StringIO()
+
+        inputs = (
+            ("notifs.example.com", "URL must include scheme (like 'https://')"),
+            (
+                "https:///blah",
+                "URL must include host information (like 'notifications.example.com')",
+            ),
+        )
+
+        for input_host, error_msg in inputs:
+            with self.subTest(input=input_host):
+                expected_error = (
+                    f"Error: argument --notifications-api-root: {error_msg}"
+                )
+                with self.assertRaisesMessage(CommandError, expected_error):
+                    call_command(
+                        "setup_configuration",
+                        "--no-input",
+                        ["--notifications-api-root", input_host],
+                        ["-v", "0"],
+                        ["-o", "ACME"],
+                        "--no-create-notifications-api-app",
+                        "--no-selftest",
+                        "--no-color",
+                        interactive=False,
+                        stdout=stdout,
+                        stderr=stderr,
+                    )
+
+    def test_interactive_without_tty(self):
+        stdout, stderr = StringIO(), StringIO()
+
+        class NoTTY:
+            def isatty(self):
+                return False
+
+        with self.assertRaises(CommandError):
+            call_command(
+                "setup_configuration",
+                interactive=True,
+                stdin=NoTTY(),
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+    @requests_mock.Mocker()
+    def test_interactive_command(self, m):
+        stdout, stderr = StringIO(), StringIO()
+
+        PROMPTS = {
+            "Organization (leave blank to use 'ACME'): ": "My Org",
+            "Domain (leave blank to use 'example.com'): ": "localhost:9000",
+            "Create Notifications API application? [Y/n]: ": "",
+            "Notifications app: CLIENT ID (leave blank to generate one): ": "",
+            "Notifications app: SECRET (leave blank to generate one): ": "",
+            "Notifications API root (leave blank to use '(unset)'): ": "https://notifs.example.com",
+            "Test domain configuration by retrieving the homepage? [Y/n]: ": "n",
+            "Test Autorisaties API credentials? [Y/n]: ": "n",
+            "Test Notifications API access? [Y/n]: ": "N",
+            "Send a test notification? [Y/n]: ": "no",
+        }
+
+        with mock_input(PROMPTS):
+            call_command(
+                "setup_configuration",
+                interactive=True,
+                stdin=MockTTY(),
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+        with self.subTest("Site configured correctly"):
+            site = Site.objects.get_current()
+            self.assertEqual(site.domain, "localhost:9000")
+            self.assertEqual(site.name, "Open Zaak My Org")
+
+        with self.subTest("Notifications API can query Autorisaties API"):
+            # get generated client credentials
+            app = Applicatie.objects.get(label="Notificaties API My Org")
+            client_id = app.client_ids[0]
+            secret = JWTSecret.objects.get(identifier=client_id).secret
+            auth = ClientAuth(client_id, secret)
+
+            response = self.client.get(
+                reverse("applicatie-list", kwargs={"version": 1}),
+                HTTP_AUTHORIZATION=auth.credentials()["Authorization"],
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        with self.subTest("Notifications API client configured correctly"):
+            mock_nrc_oas_get(m)
+            mock_notification_send(m)
+            notificaties_client = NotificationsConfig.get_client()
+            self.assertIsNotNone(notificaties_client)
+
+            response_data = notificaties_client.create(
+                "notificaties", data={"foo": "bar"}
+            )
+
+            self.assertEqual(response_data, {"dummy": "json"})
+            create_call = m.last_request
+            self.assertEqual(create_call.url, "https://notifs.example.com/notificaties")
+            self.assertIn("Authorization", create_call.headers)
+            header_jwt = create_call.headers["Authorization"].split(" ")[1]
+            decoded_jwt = decode(header_jwt, options={"verify_signature": False})
+            self.assertEqual(decoded_jwt["client_id"], "open-zaak-my-org")
+
+    def test_interactive_command_json_output(self):
+        PROMPTS = {
+            "Organization (leave blank to use 'ACME'): ": "My Org",
+            "Domain (leave blank to use 'example.com'): ": "localhost:9000",
+            "Create Notifications API application? [Y/n]: ": "",
+            "Notifications app: CLIENT ID (leave blank to generate one): ": "",
+            "Notifications app: SECRET (leave blank to generate one): ": "",
+            "Notifications API root (leave blank to use '(unset)'): ": "https://notifs.example.com",
+            "Test domain configuration by retrieving the homepage? [Y/n]: ": "n",
+            "Test Autorisaties API credentials? [Y/n]: ": "n",
+            "Test Notifications API access? [Y/n]: ": "N",
+            "Send a test notification? [Y/n]: ": "no",
+        }
+
+        for disabled in (True, False):
+            stdout, stderr = StringIO(), StringIO()
+
+            with self.subTest(NOTIFICATIONS_DISABLED=disabled), override_settings(
+                NOTIFICATIONS_DISABLED=disabled
+            ), mock_input(PROMPTS):
+                call_command(
+                    "setup_configuration",
+                    "--json",
+                    interactive=True,
+                    stdin=MockTTY(),
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+
+            try:
+                json.loads(stdout.getvalue())
+            except Exception:
+                self.fail("Output cannot be parsed as JSON")
+
+    def test_verbose_output_only_missing_info(self):
+        stdout, stderr = StringIO(), StringIO()
+
+        PROMPTS = {
+            "Organization (leave blank to use 'ACME'): ": "",
+            "Send a test notification? [Y/n]: ": "no",
+        }
+
+        with mock_input(PROMPTS):
+            call_command(
+                "setup_configuration",
+                "--no-color",
+                verbosity=2,
+                domain="localhost:8000",
+                notifications_provision_ac_client=False,
+                notifications_api_root="https://notifs.example.com",
+                do_self_test=False,
+                interactive=True,
+                stdin=MockTTY(),
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+        command_output = stdout.getvalue()
+        expected_text = (
+            "The organization name is used in labels and Client ID suffixes. "
+            "We recommend setting a proper value."
+        )
+        self.assertIn(expected_text, command_output)
+
+    def test_interactive_no_promts_if_all_options_given(self):
+        stdout, stderr = StringIO(), StringIO()
+
+        with mock_input({}) as m:
+            call_command(
+                "setup_configuration",
+                "--no-color",
+                verbosity=2,
+                organization="ACME",
+                domain="localhost:8000",
+                notifications_provision_ac_client=False,
+                notifications_api_root="https://notifs.example.com",
+                notifications_api_client_id="foo",
+                notifications_api_secret="bar",
+                do_self_test=False,
+                interactive=True,
+                stdin=MockTTY(),
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+        m.assert_not_called()
+
+    def test_interactive_skip_ac_client(self):
+        stdout, stderr = StringIO(), StringIO()
+
+        PROMPTS = {
+            "Organization (leave blank to use 'ACME'): ": "My Org",
+            "Domain (leave blank to use 'example.com'): ": "localhost:9000",
+            "Create Notifications API application? [Y/n]: ": "n",
+            "Notifications API root (leave blank to use '(unset)'): ": "https://notifs.example.com",
+            "Test domain configuration by retrieving the homepage? [Y/n]: ": "n",
+            "Test Autorisaties API credentials? [Y/n]: ": "n",
+            "Test Notifications API access? [Y/n]: ": "N",
+            "Send a test notification? [Y/n]: ": "no",
+        }
+
+        with mock_input(PROMPTS):
+            call_command(
+                "setup_configuration",
+                interactive=True,
+                stdin=MockTTY(),
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+        with self.subTest("No Autorisaties API client created"):
+            self.assertFalse(Applicatie.objects.exists())
+            self.assertFalse(JWTSecret.objects.exists())
+
+    @override_settings(NOTIFICATIONS_DISABLED=True)
+    def test_no_configure_notificaties_api_when_disabled(self):
+        stdout, stderr = StringIO(), StringIO()
+
+        call_command(
+            "setup_configuration",
+            "--no-color",
+            verbosity=2,
+            organization="ACME",
+            domain="localhost:8000",
+            notifications_provision_ac_client=False,
+            do_self_test=False,
+            interactive=True,
+            stdin=MockTTY(),
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+        config = NotificationsConfig.get_solo()
+        self.assertIsNone(config.notifications_api_service)
+
+    def test_no_prompt_self_test_in_non_interactive_mode(self):
+        stdout, stderr = StringIO(), StringIO()
+
+        with mock_input({}) as mocked_input:
+            call_command(
+                "setup_configuration",
+                "--no-color",
+                organization="ACME",
+                domain="localhost:8000",
+                notifications_provision_ac_client=False,
+                interactive=False,
+                stdin=MockTTY(),
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+        mocked_input.assert_not_called()
+
+    @requests_mock.Mocker()
+    def test_send_test_notification(self, m):
+        stdout, stderr = StringIO(), StringIO()
+
+        # configure instance without check to set up test data
+        call_command(
+            "setup_configuration",
+            ["-v", "0"],
+            ["-o", "ACME"],
+            ["-d", "open-zaak.example.com"],
+            "--no-create-notifications-api-app",
+            ["--notifications-api-root", "https://notifs.example.com"],
+            "--no-send-test-notification",
+            "--no-selftest",
+            stdout=stdout,
+            stderr=stderr,
+            interactive=False,
+        )
+
+        self.assertEqual(len(m.request_history), 0)
+
+        # set up mocks now the instance is configured
+        mock_nrc_oas_get(m)
+        mock_notification_send(m)
+        m.get(
+            "https://notifs.example.com/kanaal?naam=test", json=[{"naam": "test"}],
+        )
+
+        call_command(
+            "setup_configuration",
+            ["-v", "0"],
+            ["--notifications-api-root", "https://notifs.example.com"],
+            "--send-test-notification",
+            stdout=stdout,
+            stderr=stderr,
+            interactive=False,
+        )
+
+        send_notification = m.last_request
+        self.assertEqual(send_notification.method, "POST")
         self.assertEqual(
-            api_credential.label, f"Open Notificaties {municipality}",
-        )
-        self.assertEqual(api_credential.client_id, f"open-zaak-{municipality.lower()}")
-        self.assertEqual(api_credential.secret, openzaak_to_notif_secret)
-        self.assertEqual(api_credential.user_id, f"open-zaak-{municipality.lower()}")
-        self.assertEqual(
-            api_credential.user_representation, f"Open Zaak {municipality}"
+            send_notification.url, "https://notifs.example.com/notificaties"
         )
 
-        notif_api_jwtsecret_ac = JWTSecret.objects.get()
-        self.assertEqual(
-            notif_api_jwtsecret_ac.identifier,
-            f"open-notificaties-{municipality.lower()}",
-        )
-        self.assertEqual(notif_api_jwtsecret_ac.secret, notif_to_openzaak_secret)
+    @override_settings(NOTIFICATIONS_DISABLED=False)
+    def test_no_generate_credentials_from_prompt(self):
+        stdout, stderr = StringIO(), StringIO()
 
-        notif_api_applicatie_ac = Applicatie.objects.get(
-            label=f"Open Notificaties {municipality}"
+        PROMPTS = {
+            "Notifications app: CLIENT ID (leave blank to generate one): ": "oz-client",
+            "Notifications app: SECRET (leave blank to generate one): ": "oz-secret",
+            "Notifications API: CLIENT ID (leave blank to generate one): ": "notifs-client",
+            "Notifications API: SECRET (leave blank to generate one): ": "notifs-secret",
+        }
+
+        with mock_input(PROMPTS):
+            call_command(
+                "setup_configuration",
+                "--json",
+                "--no-color",
+                interactive=True,
+                organization="ACME",
+                domain="testserver",
+                notifications_provision_ac_client=True,
+                notifications_api_root="https://notifs.example.com",
+                do_self_test=False,
+                send_test_notification=False,
+                stdin=MockTTY(),
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+        # assert that the credentials are echoed back in json format (for machine reading)
+        command_output = stdout.getvalue()
+        output = json.loads(command_output)
+
+        self.assertEqual(
+            output["autorisatiesAPIClientCredentials"]["data"],
+            {"client_id": "oz-client", "secret": "oz-secret",},
         )
         self.assertEqual(
-            notif_api_applicatie_ac.client_ids, [notif_api_jwtsecret_ac.identifier]
+            output["notificationsAPIConfiguration"]["data"],
+            {"client_id": "notifs-client", "secret": "notifs-secret",},
         )
 
-        notif_api_autorisatie_ac = Autorisatie.objects.get(
-            applicatie=notif_api_applicatie_ac
-        )
-        self.assertEqual(notif_api_autorisatie_ac.component, ComponentTypes.ac)
-        self.assertEqual(
-            notif_api_autorisatie_ac.scopes, [SCOPE_AUTORISATIES_LEZEN.label]
-        )
+    @requests_mock.Mocker()
+    @override_settings(NOTIFICATIONS_DISABLED=True)
+    def test_self_test_succeeds(self, m):
+        m.get("http://localhost:9000/", status_code=200)
+        stdout, stderr = StringIO(), StringIO()
 
-        openzaak_applicatie_notif = Applicatie.objects.get(
-            label=f"Open Zaak {municipality}"
-        )
-        self.assertEqual(
-            openzaak_applicatie_notif.client_ids, [f"open-zaak-{municipality.lower()}"]
-        )
+        PROMPTS = {
+            "Organization (leave blank to use 'ACME'): ": "My Org",
+            "Domain (leave blank to use 'example.com'): ": "localhost:9000",
+            "Create Notifications API application? [Y/n]: ": "n",
+            "Test domain configuration by retrieving the homepage? [Y/n]: ": "Yes",
+            "Test Autorisaties API credentials? [Y/n]: ": "n",
+            "Test Notifications API access? [Y/n]: ": "N",
+            "Send a test notification? [Y/n]: ": "no",
+        }
 
-        openzaak_autorisatie_notif = Autorisatie.objects.get(
-            applicatie=openzaak_applicatie_notif
-        )
-        self.assertEqual(openzaak_autorisatie_notif.component, ComponentTypes.nrc)
-        self.assertEqual(
-            openzaak_autorisatie_notif.scopes,
-            [SCOPE_NOTIFICATIES_CONSUMEREN_LABEL, SCOPE_NOTIFICATIES_PUBLICEREN_LABEL,],
-        )
+        with mock_input(PROMPTS):
+            call_command(
+                "setup_configuration",
+                interactive=True,
+                stdin=MockTTY(),
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+        self.assertEqual(m.last_request.method, "GET")
+        self.assertEqual(m.last_request.url, "http://localhost:9000/")
+
+    @requests_mock.Mocker()
+    @override_settings(NOTIFICATIONS_DISABLED=True)
+    def test_self_test_fails(self, m):
+        m.get("http://localhost:9000/", exc=requests.ConnectionError)
+        stdout, stderr = StringIO(), StringIO()
+
+        PROMPTS = {
+            "Organization (leave blank to use 'ACME'): ": "My Org",
+            "Domain (leave blank to use 'example.com'): ": "localhost:9000",
+            "Create Notifications API application? [Y/n]: ": "n",
+            "Test domain configuration by retrieving the homepage? [Y/n]: ": "Yes",
+            "Test Autorisaties API credentials? [Y/n]: ": "n",
+            "Test Notifications API access? [Y/n]: ": "N",
+            "Send a test notification? [Y/n]: ": "no",
+        }
+
+        with self.assertRaisesMessage(
+            CommandError, "Could not access home page at 'http://localhost:9000/'"
+        ):
+            with mock_input(PROMPTS):
+                call_command(
+                    "setup_configuration",
+                    interactive=True,
+                    stdin=MockTTY(),
+                    stdout=stdout,
+                    stderr=stderr,
+                )


### PR DESCRIPTION
Fixes #669

This completely reworks the `setup_configuration` management command

**Changes**

* No more positional arguments, only options/flags
* Interactive vs. silent mode - in interactive mode, options not provided during the invocation are prompted for
* Keep generation of client IDs/secrets if no value is provided and report back the values that are used eventually
* Refactored the actual setup into `openforms.config.bootstrap`, which can in the future also be used by a frontend UI/wizard (if we'd like that, but now it's easier to test)
* Added self-test capabilities by hitting the endpoints with the configuration + reporting the outcomes
* Restructured documentation for configuration between admin and CLI variant
* Updated documentation here and there to account for changes introduced by notifications-api-common usage

TODO:

- [x] #1277
- [x] Lots more tests
- [ ] #1020 to factor out `django.contrib.sites` usage


**Example interactive shell transcript**

```
(open-zaak) ➜  open-zaak git:(feature/669-self-test-cli-tools) src/manage.py setup_configuration
Organization (leave blank to use 'ACME'): dev
  Continuing with organization name 'dev'...
Domain (leave blank to use 'localhost:8000'):     
  Continuing with domain 'localhost:8000'...
Create Notifications API application? [Y/n]: 
Notifications app: CLIENT ID (leave blank to generate one): notificaties-api-dev
Notifications app: SECRET (leave blank to generate one): foobar
Notifications API root (leave blank to use 'http://localhost:9000/api/v1/'): 
  Continuing with Notifications API at http://localhost:9000/api/v1/.
Notifications API: CLIENT ID (leave blank to generate one): open-zaak-dev
Notifications API: SECRET (leave blank to generate one): oz-bgz26PB3srwIcAAtybUy
Test domain configuration by retrieving the homepage? [Y/n]: 
Test Autorisaties API credentials? [Y/n]: 
Test Notifications API access? [Y/n]: 
Send a test notification? [Y/n]: 
Notification successfully sent to http://localhost:9000/api/v1/

Results summary

Notificaties API credentials for Open Zaak Autorisaties API (id: autorisatiesAPIClientCredentials):
  * client_id: notificaties-api-dev
  * secret: foobar

Notifications API configured (id: notificationsAPIConfiguration):
  * client_id: open-zaak-dev
  * secret: oz-bgz26PB3srwIcAAtybUy

Domain test succeeded (id: domainCheck):
  * response_status: 200

Autorisaties API client credentials are valid (id: autorisatiesAPIClientSelfTest):
  * success: True

Channels present in notifications API (id: notificationsApiChannels):
  * channels: test

Instance configuration completed.
```