### PR TITLE
:bug: [#1273/#1275] Fix publishing zaaktypen with durations

### DIFF
--- a/src/openzaak/components/catalogi/admin/mixins.py
+++ b/src/openzaak/components/catalogi/admin/mixins.py
@@ -15,6 +15,8 @@ from django.utils.html import format_html
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _, ungettext_lazy
 
+from dateutil.relativedelta import relativedelta
+
 from openzaak.utils.admin import ExtraContextAdminMixin
 
 from ..api.viewsets import (
@@ -389,6 +391,9 @@ class ReadOnlyPublishedBaseMixin:
         return super().render_change_form(request, context, add, change, form_url, obj)
 
     def render_readonly(self, field, result_repr, value):
+        if isinstance(value, relativedelta) and not value:
+            return self.get_empty_value_display()
+
         # override method to customize formatting
         return result_repr
 

--- a/src/openzaak/components/catalogi/tests/admin/test_zaaktype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_zaaktype_admin.py
@@ -8,6 +8,7 @@ from django.urls import reverse, reverse_lazy
 from django.utils.translation import gettext, ngettext_lazy, ugettext_lazy as _
 
 import requests_mock
+from dateutil.relativedelta import relativedelta
 from django_webtest import WebTest
 from freezegun import freeze_time
 from vng_api_common.constants import VertrouwelijkheidsAanduiding
@@ -869,3 +870,88 @@ class ZaakTypePublishAdminTests(SelectieLijstMixin, WebTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content_type, "application/zip")
         self.assertEqual(zaaktype.datum_einde_geldigheid, date(2020, 1, 1))
+
+    @tag("gh-1275")
+    @override_settings(NOTIFICATIONS_DISABLED=True)
+    @requests_mock.Mocker()
+    def test_save_published_zaaktype_with_verlenging_mogelijk(self, m):
+        """ Regressiontest where a user is not able to publish a concept-zaaktype with a verlenging """
+
+        mock_selectielijst_oas_get(m)
+        mock_resource_list(m, "procestypen")
+        selectielijst_resultaat = (
+            "https://selectielijst.openzaak.nl/api/v1/"
+            "resultaten/65a0a7ab-0906-49bd-924f-f261f990b50f"
+        )
+        mock_resource_get(m, "resultaten", url=selectielijst_resultaat)
+        procestype = "https://selectielijst.openzaak.nl/api/v1/procestypen/cdb46f05-0750-4d83-8025-31e20408ed21"
+        zaaktype = ZaakTypeFactory.create(
+            concept=True,
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.openbaar,
+            selectielijst_procestype=(procestype),
+            verlenging_mogelijk=True,
+            verlengingstermijn=relativedelta(days=42),
+            doorlooptijd_behandeling=relativedelta(days=42),
+            servicenorm_behandeling=relativedelta(days=42),
+        )
+        StatusTypeFactory.create(zaaktype=zaaktype, statustypevolgnummer=1)
+        StatusTypeFactory.create(zaaktype=zaaktype, statustypevolgnummer=2)
+        ResultaatTypeFactory.create(
+            zaaktype=zaaktype, selectielijstklasse=selectielijst_resultaat
+        )
+        RolTypeFactory.create(zaaktype=zaaktype)
+
+        selectielijst_resultaat = (
+            "https://selectielijst.openzaak.nl/api/v1/"
+            "resultaten/65a0a7ab-0906-49bd-924f-f261f990b50f"
+        )
+        mock_resource_get(m, "procestypen", url=procestype)
+
+        admin_url = reverse("admin:catalogi_zaaktype_change", args=(zaaktype.pk,))
+        change_page = self.app.get(admin_url)
+        response = change_page.form.submit("_publish").follow()
+        zaaktype.refresh_from_db()
+        self.assertNotContains(
+            response,
+            "'verlengingstermijn' must be set if 'verlenging_mogelijk' is set.",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(zaaktype.concept, False)
+
+    @override_settings(NOTIFICATIONS_DISABLED=True)
+    @requests_mock.Mocker()
+    def test_published_zaaktype_with_empty_durations(self, m):
+        """ Regressiontest where a user is not able to publish a concept-zaaktype with a verlenging """
+
+        mock_selectielijst_oas_get(m)
+        mock_resource_list(m, "procestypen")
+        selectielijst_resultaat = (
+            "https://selectielijst.openzaak.nl/api/v1/"
+            "resultaten/65a0a7ab-0906-49bd-924f-f261f990b50f"
+        )
+        mock_resource_get(m, "resultaten", url=selectielijst_resultaat)
+        procestype = "https://selectielijst.openzaak.nl/api/v1/procestypen/cdb46f05-0750-4d83-8025-31e20408ed21"
+        zaaktype = ZaakTypeFactory.create(
+            concept=False,
+            vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.openbaar,
+            selectielijst_procestype=(procestype),
+            doorlooptijd_behandeling=relativedelta(),
+        )
+        StatusTypeFactory.create(zaaktype=zaaktype, statustypevolgnummer=1)
+        StatusTypeFactory.create(zaaktype=zaaktype, statustypevolgnummer=2)
+        ResultaatTypeFactory.create(
+            zaaktype=zaaktype, selectielijstklasse=selectielijst_resultaat
+        )
+        RolTypeFactory.create(zaaktype=zaaktype)
+
+        selectielijst_resultaat = (
+            "https://selectielijst.openzaak.nl/api/v1/"
+            "resultaten/65a0a7ab-0906-49bd-924f-f261f990b50f"
+        )
+        mock_resource_get(m, "procestypen", url=procestype)
+
+        admin_url = reverse("admin:catalogi_zaaktype_change", args=(zaaktype.pk,))
+        change_page = self.app.get(admin_url)
+        self.assertNotContains(change_page, "relativedelta")
+        self.assertEqual(zaaktype.doorlooptijd_behandeling, relativedelta())
+        self.assertEqual(zaaktype.servicenorm_behandeling, None)

--- a/src/openzaak/forms/widgets.py
+++ b/src/openzaak/forms/widgets.py
@@ -39,24 +39,29 @@ class SplitRelativeDeltaWidget(forms.Widget):
         return id_
 
     def value_from_datadict(self, data, files, name) -> str:
-        value_from_datadict = forms.NumberInput().value_from_datadict
+        # In case the value was directly injected into the form data, e.g. if validation
+        # happens on the backend, simply take that value
+        if name in data and isinstance(data[name], relativedelta):
+            duration = data[name]
+        else:
+            value_from_datadict = forms.NumberInput().value_from_datadict
 
-        years = value_from_datadict(data, files, f"{name}_years")
-        months = value_from_datadict(data, files, f"{name}_months")
-        days = value_from_datadict(data, files, f"{name}_days")
-        hours = value_from_datadict(data, files, f"{name}_hours")
-        minutes = value_from_datadict(data, files, f"{name}_minutes")
-        seconds = value_from_datadict(data, files, f"{name}_seconds")
-        microseconds = value_from_datadict(data, files, f"{name}_microseconds")
-        duration = relativedelta(
-            years=int(years or 0),
-            months=int(months or 0),
-            days=int(days or 0),
-            hours=int(hours or 0),
-            minutes=int(minutes or 0),
-            seconds=int(seconds or 0),
-            microseconds=int(microseconds or 0),
-        )
+            years = value_from_datadict(data, files, f"{name}_years")
+            months = value_from_datadict(data, files, f"{name}_months")
+            days = value_from_datadict(data, files, f"{name}_days")
+            hours = value_from_datadict(data, files, f"{name}_hours")
+            minutes = value_from_datadict(data, files, f"{name}_minutes")
+            seconds = value_from_datadict(data, files, f"{name}_seconds")
+            microseconds = value_from_datadict(data, files, f"{name}_microseconds")
+            duration = relativedelta(
+                years=int(years or 0),
+                months=int(months or 0),
+                days=int(days or 0),
+                hours=int(hours or 0),
+                minutes=int(minutes or 0),
+                seconds=int(seconds or 0),
+                microseconds=int(microseconds or 0),
+            )
         return format_relativedelta(duration)
 
     def get_context(self, name, value: Union[relativedelta, str], attrs=None):


### PR DESCRIPTION
Fixes #1273 and fixes #1275 and also fixes rendering of empty durations for published zaaktypen in the admin UI


