### PR TITLE
Allow providing the ENVIRONMENT via envvar to Sentry

### DIFF
--- a/docs/installation/config/env_config.md
+++ b/docs/installation/config/env_config.md
@@ -33,6 +33,14 @@ on Docker, since `localhost` is contained within the container:
 
 ### Optional
 
+* `ENVIRONMENT`: An identifier for the environment, displayed in the admin depending on
+  the settings module used and included in the error monitoring (see `SENTRY_DSN`).
+  The default is set according to `DJANGO_SETTINGS_MODULE`. Good examples values are:
+
+  * `production`
+  * `test`
+  * `ACME public`
+
 * `SITE_ID`: defaults to `1`. The database ID of the site object. You usually
   won't have to touch this.
 

--- a/src/openzaak/conf/ci.py
+++ b/src/openzaak/conf/ci.py
@@ -13,6 +13,7 @@ from openzaak.notifications.tests.utils import LOGGING_SETTINGS
 os.environ.setdefault("IS_HTTPS", "no")
 os.environ.setdefault("SECRET_KEY", "dummy")
 os.environ.setdefault("NOTIFICATIONS_DISABLED", "yes")
+os.environ.setdefault("ENVIRONMENT", "CI")
 
 from .includes.base import *  # noqa isort:skip
 
@@ -28,8 +29,6 @@ CACHES = {
 }
 
 LOGGING = LOGGING_SETTINGS  # Minimally required logging is nice
-
-ENVIRONMENT = "CI"
 
 #
 # Django-axes

--- a/src/openzaak/conf/dev.py
+++ b/src/openzaak/conf/dev.py
@@ -15,6 +15,7 @@ os.environ.setdefault(
 )
 os.environ.setdefault("IS_HTTPS", "no")
 os.environ.setdefault("RELEASE", "dev")
+os.environ.setdefault("ENVIRONMENT", "development")
 
 os.environ.setdefault("DB_NAME", "openzaak")
 os.environ.setdefault("DB_USER", "openzaak")
@@ -49,11 +50,6 @@ LOGGING["loggers"].update(
 
 if not LOG_QUERIES:
     LOGGING["loggers"]["django.db.backends"]["handlers"] = ["django"]
-
-#
-# Custom settings
-#
-ENVIRONMENT = "development"
 
 #
 # Library settings

--- a/src/openzaak/conf/docker.py
+++ b/src/openzaak/conf/docker.py
@@ -8,12 +8,7 @@ os.environ.setdefault("DB_USER", "postgres")
 os.environ.setdefault("DB_PASSWORD", "")
 os.environ.setdefault("DB_CONN_MAX_AGE", "60")
 
+os.environ.setdefault("ENVIRONMENT", "docker")
 os.environ.setdefault("LOG_STDOUT", "yes")
 
 from .production import *  # noqa isort:skip
-
-#
-# Custom settings
-#
-
-ENVIRONMENT = "docker"

--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -442,7 +442,7 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
 PROJECT_NAME = "Open Zaak"
 SITE_TITLE = "API dashboard"
 
-ENVIRONMENT = None
+ENVIRONMENT = config("ENVIRONMENT", "")
 ENVIRONMENT_SHOWN_IN_ADMIN = True
 
 # settings for uploading large files
@@ -617,6 +617,7 @@ if SENTRY_DSN:
     SENTRY_CONFIG = {
         "dsn": SENTRY_DSN,
         "release": RELEASE or "RELEASE not set",
+        "environment": ENVIRONMENT,
     }
 
     sentry_sdk.init(

--- a/src/openzaak/conf/production.py
+++ b/src/openzaak/conf/production.py
@@ -6,9 +6,13 @@ Production environment settings module.
 Tweaks the base settings so that caching mechanisms are used where possible,
 and HTTPS is leveraged where possible to further secure things.
 """
+import os
+
+os.environ.setdefault("ENVIRONMENT", "production")
+
 from .includes.base import *  # noqa
-from .includes.base import _django_handlers
-from .includes.environ import config
+from .includes.base import _django_handlers  # noqa
+from .includes.environ import config  # noqa
 
 conn_max_age = config("DB_CONN_MAX_AGE", cast=float, default=None)
 for db_config in DATABASES.values():
@@ -51,5 +55,4 @@ if subpath and subpath != "/":
 #
 # Custom settings overrides
 #
-ENVIRONMENT = "production"
 ENVIRONMENT_SHOWN_IN_ADMIN = False

--- a/src/openzaak/conf/staging.py
+++ b/src/openzaak/conf/staging.py
@@ -5,8 +5,8 @@ Staging environment settings module.
 
 This *should* be nearly identical to production.
 """
+import os
+
+os.environ.setdefault("ENVIRONMENT", "staging")
 
 from .production import *  # noqa
-
-# Show active environment in admin.
-ENVIRONMENT = "staging"


### PR DESCRIPTION
Fixes #1280

* You can now specify the environment at deploy-time
* The environment is now configured in the Sentry SDK and sent along with error reports.