### PR TITLE
add middleware to rewrite the request host

### DIFF
--- a/docs/installation/config/env_config.md
+++ b/docs/installation/config/env_config.md
@@ -67,10 +67,20 @@ on Docker, since `localhost` is contained within the container:
 * `DB_CONN_MAX_AGE`: maximum age of a database connection, in seconds. This reduces
   overhead of connecting to the database server for every request. Defaults to `60`.
 
+* `OPENZAAK_DOMAIN`: a `[host]:[port]` or `[host]` value indicating the canonical domain
+  where Open Zaak is hosted/deployed, e.g. `openzaak.example.com:8443`. This value is
+  used (together with `IS_HTTPS`) when fully qualified URLs need to be constructed
+  without HTTP request context available. Defaults to empty string.
+
 * `USE_X_FORWARDED_HOST`: whether to grab the domain/host from the `X-Forwarded-Host`
   header or not. This header is typically set by reverse proxies (such as nginx,
   traefik, Apache...). Default `False` - this is a header that can be spoofed and you
   need to ensure you control it before enabling this.
+
+* `OPENZAAK_REWRITE_HOST`: whether to rewrite the request host of all incoming requests
+  with the value of `OPENZAAK_DOMAIN`, discarding the original `Host` header or headers
+  set by reverse proxies. Useful if you provide the services only via the NLX network,
+  for example. Defaults to `False` and conflicts with `USE_X_FORWARDED_HOST`.
 
 * `NUM_PROXIES`: the number of reverse proxies in front of Open Zaak, as an integer.
   This is used to determine the actual client IP adres. Defaults to 1, however on

--- a/docs/installation/config/openzaak_config.rst
+++ b/docs/installation/config/openzaak_config.rst
@@ -25,6 +25,10 @@ In the admin, under **Configuratie > Websites**, make sure to change the existin
 .. note:: Due to a cache-bug in the underlying framework, you need to restart all
    replicas for this change to take effect everywhere.
 
+.. note:: The deprecation process for this domain configuration has started in favour of
+   the ``OPENZAAK_DOMAIN`` setting. Some libraries still rely on this though, so it
+   still needs to be provided.
+
 .. _installation_configuration_notificaties_api:
 
 Configure Notificaties API

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -67,5 +67,6 @@ Reference
    reference/cli
    reference/logging
    reference/containers
+   reference/fq-urls
    reference/time
    reference/1-5_upgrade

--- a/docs/installation/reference/fq-urls.rst
+++ b/docs/installation/reference/fq-urls.rst
@@ -1,0 +1,79 @@
+.. _installation_reference_fq_urls:
+
+Deploying behind API gateways
+=============================
+
+Open Zaak relies on fully qualified URLs - that is, URLs with scheme, host/domain, and
+path segments - to locate resources, both provided by the Open Zaak instance itself or
+external resource.
+
+API resources are identified by these fully qualified URLs and determine if Open Zaak
+can do a database lookup (because the resource is owned by Open Zaak) or if a network
+call needs to be made to retrieve it (e.g. a reference to a geometric object in the BAG).
+
+This requires that Open Zaak is deployed on "a canonical" domain. Most deployments are
+automatically configured correctly for this, but API gateways tend to complicate this.
+
+This reference documents your configuration options when you are using advanced network
+topology, such as deploying behind an API gateway (like NLX) without also 'publicly'
+exposing the service.
+
+How Open Zaak builds URLs
+-------------------------
+
+Normally Open Zaak builds absolute URIs based on the context of the incoming HTTP
+request by looking at the ``Host`` header. This allows you to expose the service on
+multiple host names (e.g. internal Kubernetes service names and a public host name
+protected with TLS certificates).
+
+Reverse proxies (such as Kubernetes ingresses) typically take the incoming HTTP request
+and relay this information in the ``X-Forwarded-Host`` header which is received by
+Open Zaak.
+
+API gateways
+------------
+
+Not all API gateways correctly rewrite the host or even path information from the
+original incoming request.
+
+Consider the following scenario:
+
+* API gateway is "publicly" accessible at ``gateway.example.com``
+* the Zaken API is exposed at ``https://gateway.example.com/zaken/api/v1/``
+* internally, the Open Zaak service is available on the DNS name
+  ``open-zaak.namespace.svc.cluster.local``
+
+1. The client then makes a request ``GET https://gateway.example.com/zaken/api/v1/``
+2. The API gateway translates this into a
+   ``GET http://open-zaak.namespace.svc.cluster.local:8000``
+3. Open Zaak gets the ``Host: open-zaak.namespace.svc.cluster.local`` header, and will
+   build all response data URLs based on this host.
+
+This is problematic, as the client cannot handle these internal service names and use
+them for follow up API calls.
+
+Additionally, there may be another layer of abstraction where the client hits a
+URL/service that is specific to that client, which is the case with NLX outways.
+
+Forcing host rewrites
+---------------------
+
+To mitigate this, you can force Open Zaak to rewrite the ``Host`` header if this cannot
+be solved at the infrastructure level, by using two settings:
+
+* ``OPENZAAK_DOMAIN``, which specifies the canonical host of your Open Zaak instance.
+  Any incoming HTTP request will then be rewritten as if this was the host requested by
+  the client.
+* ``OPENZAAK_REWRITE_HOST`` must be set to ``True`` for this to take effect, and this
+  setting conflict with the ``USE_X_FORWARDED_HOST`` setting. The latter will tell Open
+  Zaak to trust and use the value set by reverse proxy in front of Open Zaak. It is
+  ignored if you force rewrites with ``OPENZAAK_DOMAIN``
+
+Absolute URLs outside of HTTP requests contexts
+-----------------------------------------------
+
+At times Open Zaak needs to build absolute URLs without an HTTP request context being
+available, such as command-line scripts or certain admin synchronization steps.
+
+If the ``OPENZAAK_DOMAIN`` is not empty, then this value will be used for those URLs,
+otherwise the ``Site`` configuration (from the admin) will be used.

--- a/src/openzaak/components/catalogi/admin/zaaktypen.py
+++ b/src/openzaak/components/catalogi/admin/zaaktypen.py
@@ -71,6 +71,11 @@ class ZaakTypenRelatieAdmin(ReadOnlyPublishedZaaktypeMixin, admin.ModelAdmin):
     )
     raw_id_fields = ("zaaktype",)
 
+    def save_model(self, request, obj, form, change):
+        form.normalize_data(request, obj)
+        # make URL field absolute using the request
+        super().save_model(request, obj, form, change)
+
 
 class StatusTypeInline(EditInlineAdminMixin, admin.TabularInline):
     model = StatusType

--- a/src/openzaak/components/catalogi/management/commands/export.py
+++ b/src/openzaak/components/catalogi/management/commands/export.py
@@ -5,15 +5,16 @@ import json
 import zipfile
 
 from django.apps import apps
-from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand, CommandError
 from django.http import HttpResponse
 from django.utils.translation import ugettext_lazy as _
 
-from rest_framework.test import APIRequestFactory
+from rest_framework.request import Request
 from rest_framework.versioning import URLPathVersioning
 
-from openzaak.components.catalogi.api import serializers
+from openzaak.utils import build_fake_request
+
+from ...api import serializers
 
 
 class Command(BaseCommand):
@@ -59,9 +60,7 @@ class Command(BaseCommand):
                 _("The number of resources supplied does not match the number of IDs")
             )
 
-        factory = APIRequestFactory()
-        server_name = Site.objects.get_current().domain
-        request = factory.get("/", SERVER_NAME=server_name)
+        request = Request(build_fake_request())
         setattr(request, "versioning_scheme", URLPathVersioning())
         setattr(request, "version", "1")
 

--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -446,7 +446,6 @@ SITE_TITLE = "API dashboard"
 
 # if specified, this replaces the host information in the requests, and it is used
 # to build absolute URLs.
-# TODO: add system check that OPENZAAK_DOMAIN is in ALLOWED_HOSTS
 OPENZAAK_DOMAIN = config("OPENZAAK_DOMAIN", "")
 OPENZAAK_REWRITE_HOST = config("OPENZAAK_REWRITE_HOST", False)
 

--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -165,6 +165,7 @@ INSTALLED_APPS = [
 ] + PLUGIN_INSTALLED_APPS
 
 MIDDLEWARE = [
+    "openzaak.utils.middleware.OverrideHostMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "openzaak.utils.middleware.LogHeadersMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -442,6 +443,14 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
 #
 PROJECT_NAME = "Open Zaak"
 SITE_TITLE = "API dashboard"
+
+# if specified, this replaces the host information in the requests, and it is used
+# to build absolute URLs.
+# TODO: add system check to validate the pattern
+# TODO: add system check, as it conflicts with USE_X_FORWARDED_HOST
+# TODO: add system check that OPENZAAK_DOMAIN is in ALLOWED_HOSTS
+OPENZAAK_DOMAIN = config("OPENZAAK_DOMAIN", "")
+OPENZAAK_REWRITE_HOST = config("OPENZAAK_REWRITE_HOST", False)
 
 ENVIRONMENT = config("ENVIRONMENT", "")
 ENVIRONMENT_SHOWN_IN_ADMIN = True

--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -446,7 +446,6 @@ SITE_TITLE = "API dashboard"
 
 # if specified, this replaces the host information in the requests, and it is used
 # to build absolute URLs.
-# TODO: add system check to validate the pattern
 # TODO: add system check, as it conflicts with USE_X_FORWARDED_HOST
 # TODO: add system check that OPENZAAK_DOMAIN is in ALLOWED_HOSTS
 OPENZAAK_DOMAIN = config("OPENZAAK_DOMAIN", "")

--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -446,7 +446,6 @@ SITE_TITLE = "API dashboard"
 
 # if specified, this replaces the host information in the requests, and it is used
 # to build absolute URLs.
-# TODO: add system check, as it conflicts with USE_X_FORWARDED_HOST
 # TODO: add system check that OPENZAAK_DOMAIN is in ALLOWED_HOSTS
 OPENZAAK_DOMAIN = config("OPENZAAK_DOMAIN", "")
 OPENZAAK_REWRITE_HOST = config("OPENZAAK_REWRITE_HOST", False)

--- a/src/openzaak/management/commands/setup_configuration.py
+++ b/src/openzaak/management/commands/setup_configuration.py
@@ -81,11 +81,12 @@ class Command(BaseCommand):
         parser.add_argument(
             "-d",
             "--domain",
-            default="",
+            default=settings.OPENZAAK_DOMAIN,
             type=domain_only_netloc,
             help=(
                 "Domain/host of the Open Zaak instance. E.g. 'open-zaak.example.com:4443', "
-                "without the 'https://...' prefix."
+                "without the 'https://...' prefix. The default value is taken from the "
+                "OPENZAAK_DOMAIN setting."
             ),
         )
 
@@ -234,7 +235,7 @@ class Command(BaseCommand):
             if not domain:
                 self.write_info(
                     "The domain is used to construct fully qualified (resource) URLs "
-                    "to be retrieved by other services."
+                    "to be retrieved by other services if OPENZAAK_DOMAIN is not set."
                 )
                 current_domain = Site.objects.get_current().domain
                 message = f"Domain (leave blank to use '{current_domain}'): "

--- a/src/openzaak/tests/test_rewrite_host.py
+++ b/src/openzaak/tests/test_rewrite_host.py
@@ -3,8 +3,10 @@
 from unittest.mock import patch
 
 from django.http import HttpResponse
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
 from django.urls import path
+
+from openzaak.utils import build_absolute_url
 
 
 def test_view(request):
@@ -42,7 +44,9 @@ class RewriteHostTests(TestCase):
 
         self.assertEqual(response.content, b"testserver")
 
-    @override_settings(OPENZAAK_REWRITE_HOST=False)
+    @override_settings(
+        OPENZAAK_DOMAIN="openzaak.example.com", OPENZAAK_REWRITE_HOST=False
+    )
     def test_setting_not_empty_but_rewrite_disabled(self):
         response = self.client.get("")
 
@@ -66,3 +70,13 @@ class RewriteHostTests(TestCase):
         response = self.client.get("", HTTP_X_FORWARDED_HOST="upstream.proxy")
 
         self.assertEqual(response.content, b"kekw")
+
+
+class BuildAbsoluteUrlTests(SimpleTestCase):
+    @override_settings(
+        OPENZAAK_DOMAIN="oz.example.com", IS_HTTPS=True,
+    )
+    def test_build_absolute_url_uses_setting(self):
+        abs_url = build_absolute_url("/foo")
+
+        self.assertEqual(abs_url, "https://oz.example.com/foo")

--- a/src/openzaak/tests/test_rewrite_host.py
+++ b/src/openzaak/tests/test_rewrite_host.py
@@ -128,3 +128,10 @@ class SystemCheckTests(SimpleTestCase):
                     errors = check_openzaak_domain(None)
 
                     self.assertEqual(len(errors), 0)
+
+    @override_settings(USE_X_FORWARDED_HOST=True)
+    def test_cannot_be_used_with_use_x_forwarded_host(self):
+        errors = check_openzaak_domain(None)
+
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].id, "openzaak.settings.W001")

--- a/src/openzaak/tests/test_rewrite_host.py
+++ b/src/openzaak/tests/test_rewrite_host.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2022 Dimpact
+from unittest.mock import patch
+
+from django.http import HttpResponse
+from django.test import TestCase, override_settings
+from django.urls import path
+
+
+def test_view(request):
+    return HttpResponse(request.get_host())
+
+
+urlpatterns = [path("", test_view)]
+
+
+@override_settings(ROOT_URLCONF=__name__, OPENZAAK_REWRITE_HOST=True)
+class RewriteHostTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        mocker = patch(
+            "openzaak.utils.middleware.get_version_mapping", return_value={"/": "1.0.0"}
+        )
+        mocker.start()
+        self.addCleanup(mocker.stop)
+
+    @override_settings(OPENZAAK_DOMAIN="openzaak.example.com", ALLOWED_HOSTS=["*"])
+    def test_overridden_host(self):
+        response = self.client.get("")
+
+        self.assertEqual(response.content, b"openzaak.example.com")
+
+    @override_settings(OPENZAAK_DOMAIN="openzaak.example.com:8443", ALLOWED_HOSTS=["*"])
+    def test_overridden_host_with_port(self):
+        response = self.client.get("")
+
+        self.assertEqual(response.content, b"openzaak.example.com:8443")
+
+    @override_settings(OPENZAAK_DOMAIN="")
+    def test_setting_empty(self):
+        response = self.client.get("")
+
+        self.assertEqual(response.content, b"testserver")
+
+    @override_settings(OPENZAAK_REWRITE_HOST=False)
+    def test_setting_not_empty_but_rewrite_disabled(self):
+        response = self.client.get("")
+
+        self.assertEqual(response.content, b"testserver")
+
+    def test_setting_default_unset(self):
+        response = self.client.get("")
+
+        self.assertEqual(response.content, b"testserver")
+
+    @override_settings(
+        OPENZAAK_DOMAIN="kekw",
+        ALLOWED_HOSTS=["kekw", "upstream.proxy"],
+        USE_X_FORWARDED_HOST=True,
+    )
+    def test_with_usage_http_forwarded_host(self):
+        """
+        System checks check also prevent USE_X_FORWARDED_HOST and OPENZAAK_DOMAIN
+        combined usage.
+        """
+        response = self.client.get("", HTTP_X_FORWARDED_HOST="upstream.proxy")
+
+        self.assertEqual(response.content, b"kekw")

--- a/src/openzaak/utils/__init__.py
+++ b/src/openzaak/utils/__init__.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
+import warnings
 from datetime import datetime
 from typing import Optional
 
@@ -24,6 +25,11 @@ def build_absolute_url(path: str, request: Optional[HttpRequest] = None) -> str:
     if settings.OPENZAAK_DOMAIN:
         domain = settings.OPENZAAK_DOMAIN
     else:
+        warnings.warn(
+            "Deriving the domain from the Site configuration will soon be deprecated, "
+            "please migrate to the OPENZAAK_DOMAIN setting.",
+            PendingDeprecationWarning,
+        )
         domain = Site.objects.get_current().domain
 
     protocol = "https" if settings.IS_HTTPS else "http"

--- a/src/openzaak/utils/__init__.py
+++ b/src/openzaak/utils/__init__.py
@@ -17,23 +17,43 @@ def parse_isodatetime(val) -> datetime:
     return dateutil.parser.parse(val)
 
 
-def build_absolute_url(path: str, request: Optional[HttpRequest] = None) -> str:
+def get_openzaak_domain() -> str:
+    """
+    Obtain the domain/netloc of Open Zaak according to settings or configuration.
+    """
     from django.contrib.sites.models import Site
 
+    if settings.OPENZAAK_DOMAIN:
+        return settings.OPENZAAK_DOMAIN
+
+    warnings.warn(
+        "Deriving the domain from the Site configuration will soon be deprecated, "
+        "please migrate to the OPENZAAK_DOMAIN setting.",
+        PendingDeprecationWarning,
+    )
+    return Site.objects.get_current().domain
+
+
+def build_absolute_url(path: str, request: Optional[HttpRequest] = None) -> str:
     if request is not None:
         return request.build_absolute_uri(path)
 
-    if settings.OPENZAAK_DOMAIN:
-        domain = settings.OPENZAAK_DOMAIN
-    else:
-        warnings.warn(
-            "Deriving the domain from the Site configuration will soon be deprecated, "
-            "please migrate to the OPENZAAK_DOMAIN setting.",
-            PendingDeprecationWarning,
-        )
-        domain = Site.objects.get_current().domain
-
+    domain = get_openzaak_domain()
     _furl = furl(
         scheme="https" if settings.IS_HTTPS else "http", netloc=domain, path=path,
     )
     return _furl.url
+
+
+def build_fake_request(*, method="get", **kwargs) -> HttpRequest:
+    from rest_framework.test import APIRequestFactory
+
+    request_factory = APIRequestFactory()
+
+    environ = {
+        "wsgi.url_scheme": "https" if settings.IS_HTTPS else "http",
+        "HTTP_HOST": get_openzaak_domain(),
+    }
+    environ.update(kwargs)
+    func = getattr(request_factory, method.lower())
+    return func("/", **environ)

--- a/src/openzaak/utils/__init__.py
+++ b/src/openzaak/utils/__init__.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.http import HttpRequest
 
 import dateutil.parser
+from furl import furl
 
 default_app_config = "openzaak.utils.apps.UtilsConfig"
 
@@ -32,5 +33,7 @@ def build_absolute_url(path: str, request: Optional[HttpRequest] = None) -> str:
         )
         domain = Site.objects.get_current().domain
 
-    protocol = "https" if settings.IS_HTTPS else "http"
-    return f"{protocol}://{domain}{path}"
+    _furl = furl(
+        scheme="https" if settings.IS_HTTPS else "http", netloc=domain, path=path,
+    )
+    return _furl.url

--- a/src/openzaak/utils/__init__.py
+++ b/src/openzaak/utils/__init__.py
@@ -21,6 +21,10 @@ def build_absolute_url(path: str, request: Optional[HttpRequest] = None) -> str:
     if request is not None:
         return request.build_absolute_uri(path)
 
-    domain = Site.objects.get_current().domain
+    if settings.OPENZAAK_DOMAIN:
+        domain = settings.OPENZAAK_DOMAIN
+    else:
+        domain = Site.objects.get_current().domain
+
     protocol = "https" if settings.IS_HTTPS else "http"
     return f"{protocol}://{domain}{path}"

--- a/src/openzaak/utils/checks.py
+++ b/src/openzaak/utils/checks.py
@@ -108,4 +108,14 @@ def check_openzaak_domain(app_configs, **kwargs):
             )
         )
 
+    if settings.OPENZAAK_DOMAIN and settings.USE_X_FORWARDED_HOST:
+        errors.append(
+            Warning(
+                "Setting OPENZAAK_DOMAIN together with USE_X_FORWARDED_HOST causes "
+                "the X-Forwarded-Host header to be ignored.",
+                hint="Disable USE_X_FORWARDED_HOST or OPENZAAK_DOMAIN",
+                id="openzaak.settings.W001",
+            )
+        )
+
     return errors


### PR DESCRIPTION
Fixes #1020

**Changes**

* Rewrite HTTP_HOST at the request level.
* Deprecate `Site.objects.get_current().domain` usage in favour of `OPENZAAK_DOMAIN`
* Use `OPENZAAK_DOMAIN` in `build_absolute_url` if available
* Added system checks to detect bad/ambiguous configurations

