### PR TITLE
Don't measure the coverage of tests themselves

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,3 +21,5 @@ exclude = migrations,static,media
 [coverage:run]
 branch = True
 source = src
+omit =
+    */test_*.py


### PR DESCRIPTION
We get some drops in coverage now because some try: except: calls in tests aren't hit (because they are now passing correctly).

Measuring the coverage of the test code by itself already skews the coverage statistics, we only care about the actual application code.