### PR TITLE
Reduce outgoing network IO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ docs/_build
 /docker/volumes/
 !/docker/volumes/.gitkeep
 
+/cache/
+!/cache/README.md
+
 # Coverage reports
 /reports/
 /htmlcov/

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,9 +98,14 @@ LABEL org.label-schema.vcs-ref=$COMMIT_HASH \
       org.label-schema.version=$RELEASE \
       org.label-schema.name="Open Zaak"
 
-# Run collectstatic, so the result is already included in the image
+# Run management commands:
+# * collectstatic -> bake the static assets into the image
+# * compilemessages -> ensure the translation catalog binaries are present
+# * warm_cache -> writes to the filesystem cache so that orgs don't need to open the
+#   firewall to github
 RUN python src/manage.py collectstatic --noinput \
-    && python src/manage.py compilemessages
+    && python src/manage.py compilemessages \
+    && python src/manage.py warm_cache
 
 EXPOSE 8000
 CMD ["/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
+COPY ./cache /app/cache
 COPY ./bin/docker_start.sh /start.sh
 COPY ./bin/reset_migrations.sh /app/bin/reset_migrations.sh
 COPY ./bin/uninstall_adfs.sh ./bin/uninstall_django_auth_adfs_db.sql /app/bin/

--- a/cache/README.md
+++ b/cache/README.md
@@ -1,0 +1,12 @@
+# Open Zaak cache directory
+
+The files in this directory (except for this `README.md`) are used to cache certain
+resources.
+
+This cache is populated by running the `src/manage.py warm_cache` management command,
+which is executed as part of the docker image build.
+
+## Do not mount this directory as a volume
+
+You should _not_ mount a volume on this directory, as the image build will contain
+the (cached) resources that are only generated at build time.

--- a/docs/development/roadmap.rst
+++ b/docs/development/roadmap.rst
@@ -156,22 +156,6 @@ manual for day-to-day administrators managing the content of catalogi.
 Technical debt / clean-up / codebase quality
 --------------------------------------------
 
-**Inclusion of API specs for validation**
-
-Currently, OAS specs are linked to (raw.github.com) for validation of remote resources.
-Instead of requiring an open internet connection to github, we should fetch these specs
-at build time and include them as static files in the Docker image. This is good for
-performance, security and reliability.
-
-See https://github.com/open-zaak/open-zaak/issues/644
-
-*Impact*
-
-- affects system/network administrators
-- allows firewalls to (stay or) be more strict
-- small performance improvement
-- sizing: small
-
 **Check if we can change the API timezone to UTC and interface TZ to Europe/Amsterdam**
 
 This would display the correct local times for users browsing in the admin interface,

--- a/fixtures_notificaties/fixture_nrc.json
+++ b/fixtures_notificaties/fixture_nrc.json
@@ -10,6 +10,66 @@
         }
     },
     {
+        "model": "datamodel.kanaal",
+        "pk": 2,
+        "fields": {
+            "uuid": "7cc1195e-1856-48ef-b4e6-329b26d0d24d",
+            "naam": "zaken",
+            "documentatie_link": "",
+            "filters": "[\"bronorganisatie\",\"zaaktype\",\"vertrouwelijkheidaanduiding\"]"
+        }
+    },
+    {
+        "model": "datamodel.kanaal",
+        "pk": 3,
+        "fields": {
+            "uuid": "ff2612de-de98-4a1a-8084-451a628acce7",
+            "naam": "documenten",
+            "documentatie_link": "",
+            "filters": "[\"bronorganisatie\",\"informatieobjecttype\",\"vertrouwelijkheidaanduiding\"]"
+        }
+    },
+    {
+        "model": "datamodel.kanaal",
+        "pk": 4,
+        "fields": {
+            "uuid": "4f28f1af-a4c3-4ca4-a073-7e565bf69723",
+            "naam": "besluiten",
+            "documentatie_link": "",
+            "filters": "[\"verantwoordelijke_organisatie\",\"besluittype\"]"
+        }
+    },
+    {
+        "model": "datamodel.kanaal",
+        "pk": 5,
+        "fields": {
+            "uuid": "59c6ae28-3c39-42a0-8347-03ed9d1466e2",
+            "naam": "zaaktypen",
+            "documentatie_link": "",
+            "filters": "[]"
+        }
+    },
+    {
+        "model": "datamodel.kanaal",
+        "pk": 6,
+        "fields": {
+            "uuid": "299db45f-65ee-41aa-9d5f-a530fcbfdbf1",
+            "naam": "informatieobjecttypen",
+            "documentatie_link": "",
+            "filters": "[]"
+        }
+    },
+    {
+        "model": "datamodel.kanaal",
+        "pk": 7,
+        "fields": {
+            "uuid": "c460c669-25c6-4479-b062-c32c1743df88",
+            "naam": "besluittypen",
+            "documentatie_link": "",
+            "filters": "[]"
+        }
+    },
+    {
         "model": "authorizations.authorizationsconfig",
         "pk": 1,
         "fields": {

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -260,7 +260,7 @@ python-decouple==3.6
     #   drc-cmis
 python-dotenv==0.19.2
     # via -r requirements/base.in
-pytz==2021.3
+pytz==2022.6
     # via django
 pyyaml==6.0
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -372,7 +372,7 @@ python-decouple==3.6
     #   drc-cmis
 python-dotenv==0.19.2
     # via -r requirements/base.txt
-pytz==2021.3
+pytz==2022.6
     # via
     #   -r requirements/base.txt
     #   django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -466,7 +466,7 @@ python-dotenv==0.19.2
     # via -r requirements/ci.txt
 python-string-utils==1.0.0
     # via openshift
-pytz==2021.3
+pytz==2022.6
     # via
     #   -r requirements/ci.txt
     #   babel

--- a/src/openzaak/api_standards.py
+++ b/src/openzaak/api_standards.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2019 - 2020 Dimpact
+"""
+Utilities to deal with OpenAPI 3 specifications.
+
+.. warning:: this module is import at settings load-time and CANNOT use Django models
+   or anything else that requires django to be configured first.
+"""
+from dataclasses import dataclass
+from typing import Callable
+
+__all__ = ["SPECIFICATIONS", "APIStandard"]
+
+SPECIFICATIONS = {}
+
+
+@dataclass
+class APIStandard:
+    alias: str  # unique alias
+    oas_url: str  # URL to download the API spec from if it doesn't exist in cache
+
+    def __post_init__(self):
+        self._register()
+
+    def _register(self) -> None:
+        """
+        Register itself with the global specifications registry.
+        """
+        if self.alias in SPECIFICATIONS:
+            raise ValueError(f"Non-unique alias '{self.alias}' given.")
+        SPECIFICATIONS[self.alias] = self
+
+    @property
+    def schema(self):
+        """
+        Download the cached schema.
+        """
+        raise NotImplementedError()
+
+    def download_schema(self, fetch: Callable[[str], dict]) -> dict:
+        return fetch(self.oas_url)

--- a/src/openzaak/api_standards.py
+++ b/src/openzaak/api_standards.py
@@ -8,12 +8,14 @@ Utilities to deal with OpenAPI 3 specifications.
 """
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Dict
 
+import requests
 import yaml
 
 __all__ = ["SPECIFICATIONS", "APIStandard"]
 
-SPECIFICATIONS = {}
+SPECIFICATIONS: Dict[str, "APIStandard"] = {}
 
 
 @dataclass
@@ -41,6 +43,15 @@ class APIStandard:
 
         cache_dir = Path(settings.BASE_DIR) / "cache"
         return cache_dir / f"{self.alias}.yaml"
+
+    def write_cache(self) -> None:
+        """
+        Retrieve the API specs and write to the cache path.
+        """
+        response = requests.get(self.oas_url)
+        response.raise_for_status()
+        cache_path = self._get_cache_path()
+        cache_path.write_bytes(response.content)
 
     @property
     def schema(self) -> dict:

--- a/src/openzaak/api_standards.py
+++ b/src/openzaak/api_standards.py
@@ -7,7 +7,6 @@ Utilities to deal with OpenAPI 3 specifications.
    or anything else that requires django to be configured first.
 """
 from dataclasses import dataclass
-from typing import Callable
 
 __all__ = ["SPECIFICATIONS", "APIStandard"]
 
@@ -35,11 +34,13 @@ class APIStandard:
         SPECIFICATIONS[self.alias] = self
 
     @property
-    def schema(self):
+    def schema(self) -> dict:
         """
-        Download the cached schema.
+        Download the (cached) schema.
         """
-        raise NotImplementedError()
+        return self.download_schema()
 
-    def download_schema(self, fetch: Callable[[str], dict]) -> dict:
-        return fetch(self.oas_url)
+    def download_schema(self) -> dict:
+        from vng_api_common.oas import fetcher
+
+        return fetcher.fetch(self.oas_url)

--- a/src/openzaak/api_standards.py
+++ b/src/openzaak/api_standards.py
@@ -18,6 +18,10 @@ SPECIFICATIONS = {}
 class APIStandard:
     alias: str  # unique alias
     oas_url: str  # URL to download the API spec from if it doesn't exist in cache
+    is_standardized: bool = True
+    """
+    Track whether an API "standard" is actually an official VNG standard.
+    """
 
     def __post_init__(self):
         self._register()

--- a/src/openzaak/components/autorisaties/forms.py
+++ b/src/openzaak/components/autorisaties/forms.py
@@ -18,7 +18,6 @@ from vng_api_common.authorizations.models import Applicatie, Autorisatie
 from vng_api_common.constants import ComponentTypes, VertrouwelijkheidsAanduiding
 from vng_api_common.models import JWTSecret
 from vng_api_common.scopes import SCOPE_REGISTRY
-from vng_api_common.validators import ResourceValidator
 
 from openzaak.components.catalogi.models import (
     BesluitType,
@@ -26,6 +25,7 @@ from openzaak.components.catalogi.models import (
     ZaakType,
 )
 from openzaak.utils.auth import get_auth
+from openzaak.utils.validators import ResourceValidator
 
 from .constants import RelatedTypeSelectionMethods
 from .utils import (
@@ -313,7 +313,7 @@ class AutorisatieForm(forms.Form):
             return
 
         validator = ResourceValidator(
-            _field_info["resource_name"], settings.ZTC_API_SPEC, get_auth=get_auth
+            _field_info["resource_name"], settings.ZTC_API_STANDARD, get_auth=get_auth
         )
         for _type in external_typen:
             try:

--- a/src/openzaak/components/autorisaties/tests/admin/test_autorisaties_admin.py
+++ b/src/openzaak/components/autorisaties/tests/admin/test_autorisaties_admin.py
@@ -18,6 +18,7 @@ from django_webtest import WebTest
 from furl import furl
 from vng_api_common.authorizations.models import Autorisatie
 from vng_api_common.constants import ComponentTypes, VertrouwelijkheidsAanduiding
+from zgw_consumers.test import generate_oas_component
 
 from openzaak.accounts.tests.factories import UserFactory
 from openzaak.components.catalogi.models.informatieobjecttype import (
@@ -29,7 +30,7 @@ from openzaak.components.catalogi.tests.factories import (
     ZaakTypeFactory,
 )
 from openzaak.notifications.tests.mixins import NotificationsConfigMixin
-from openzaak.tests.utils import mock_nrc_oas_get
+from openzaak.tests.utils import mock_nrc_oas_get, mock_ztc_oas_get
 from openzaak.utils import build_absolute_url
 
 from ...constants import RelatedTypeSelectionMethods
@@ -655,10 +656,14 @@ class ManageAutorisatiesAdmin(NotificationsConfigMixin, TestCase):
         }
         self.assertEqual(body, expected)
 
-    @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
-    def test_add_autorisatie_external_zaaktypen(self, *mocks):
+    @requests_mock.Mocker()
+    def test_add_autorisatie_external_zaaktypen(self, m):
+        mock_ztc_oas_get(m)
+        zt1 = generate_oas_component("ztc", "schemas/ZaakType", url=ZAAKTYPE1)
+        zt2 = generate_oas_component("ztc", "schemas/ZaakType", url=ZAAKTYPE2)
+        m.get(ZAAKTYPE1, json=zt1)
+        m.get(ZAAKTYPE2, json=zt2)
+
         data = {
             # management form
             "form-TOTAL_FORMS": 1,
@@ -682,10 +687,18 @@ class ManageAutorisatiesAdmin(NotificationsConfigMixin, TestCase):
         self.assertEqual(autorisatie1.zaaktype, ZAAKTYPE1)
         self.assertEqual(autorisatie2.zaaktype, ZAAKTYPE2)
 
-    @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
-    def test_add_autorisatie_external_iotypen(self, *mocks):
+    @requests_mock.Mocker()
+    def test_add_autorisatie_external_iotypen(self, m):
+        mock_ztc_oas_get(m)
+        iot1 = generate_oas_component(
+            "ztc", "schemas/InformatieObjectType", url=IOTYPE1
+        )
+        iot2 = generate_oas_component(
+            "ztc", "schemas/InformatieObjectType", url=IOTYPE2
+        )
+        m.get(IOTYPE1, json=iot1)
+        m.get(IOTYPE2, json=iot2)
+
         data = {
             # management form
             "form-TOTAL_FORMS": 1,
@@ -709,10 +722,14 @@ class ManageAutorisatiesAdmin(NotificationsConfigMixin, TestCase):
         self.assertEqual(autorisatie1.informatieobjecttype, IOTYPE1)
         self.assertEqual(autorisatie2.informatieobjecttype, IOTYPE2)
 
-    @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
-    def test_add_autorisatie_external_besluittypen(self, *mocks):
+    @requests_mock.Mocker()
+    def test_add_autorisatie_external_besluittypen(self, m):
+        mock_ztc_oas_get(m)
+        bt1 = generate_oas_component("ztc", "schemas/BesluitType", url=BESLUITTYPE1)
+        bt2 = generate_oas_component("ztc", "schemas/BesluitType", url=BESLUITTYPE2)
+        m.get(BESLUITTYPE1, json=bt1)
+        m.get(BESLUITTYPE2, json=bt2)
+
         data = {
             # management form
             "form-TOTAL_FORMS": 1,

--- a/src/openzaak/components/besluiten/api/serializers.py
+++ b/src/openzaak/components/besluiten/api/serializers.py
@@ -171,7 +171,7 @@ class BesluitInformatieObjectSerializer(serializers.HyperlinkedModelSerializer):
         validators=[
             LooseFkIsImmutableValidator(instance_path="canonical"),
             LooseFkResourceValidator(
-                "EnkelvoudigInformatieObject", settings.DRC_API_SPEC
+                "EnkelvoudigInformatieObject", settings.DRC_API_STANDARD
             ),
         ],
         max_length=1000,

--- a/src/openzaak/components/besluiten/api/serializers.py
+++ b/src/openzaak/components/besluiten/api/serializers.py
@@ -66,7 +66,7 @@ class BesluitSerializer(ConvertNoneMixin, serializers.HyperlinkedModelSerializer
                 "max_length": 200,
                 "min_length": 1,
                 "validators": [
-                    LooseFkResourceValidator("BesluitType", settings.ZTC_API_SPEC),
+                    LooseFkResourceValidator("BesluitType", settings.ZTC_API_STANDARD),
                     LooseFkIsImmutableValidator(),
                     PublishValidator(),
                 ],

--- a/src/openzaak/components/catalogi/admin/forms.py
+++ b/src/openzaak/components/catalogi/admin/forms.py
@@ -308,7 +308,7 @@ class ResultaatTypeForm(forms.ModelForm):
             err = forms.ValidationError(msg, code="invalid")
             raise forms.ValidationError({"selectielijstklasse": err}) from exc
 
-        validator = ResourceValidator("Resultaat", settings.VRL_API_SPEC)
+        validator = ResourceValidator("Resultaat", settings.SELECTIELIJST_API_STANDARD)
         try:
             # Check whether the url points to a Resultaat
             validator(selectielijstklasse)

--- a/src/openzaak/components/catalogi/admin/forms.py
+++ b/src/openzaak/components/catalogi/admin/forms.py
@@ -18,7 +18,6 @@ from vng_api_common.constants import (
     BrondatumArchiefprocedureAfleidingswijze as Afleidingswijze,
 )
 from vng_api_common.tests import reverse as _reverse
-from vng_api_common.validators import ResourceValidator
 from zds_client import ClientError
 from zgw_consumers.models import Service
 
@@ -26,6 +25,7 @@ from openzaak.forms.widgets import BooleanRadio
 from openzaak.selectielijst.admin_fields import get_selectielijst_resultaat_choices
 from openzaak.selectielijst.models import ReferentieLijstConfig
 from openzaak.utils import build_absolute_url
+from openzaak.utils.validators import ResourceValidator
 
 from ..constants import SelectielijstKlasseProcestermijn as Procestermijn
 from ..models import (

--- a/src/openzaak/components/catalogi/api/serializers/resultaattype.py
+++ b/src/openzaak/components/catalogi/api/serializers/resultaattype.py
@@ -92,7 +92,7 @@ class ResultaatTypeSerializer(
             "zaaktype": {"lookup_field": "uuid", "label": _("is van")},
             "selectielijstklasse": {
                 "validators": [
-                    ResourceValidator("Resultaat", settings.REFERENTIELIJSTEN_API_SPEC)
+                    ResourceValidator("Resultaat", settings.SELECTIELIJST_API_STANDARD)
                 ]
             },
         }

--- a/src/openzaak/components/catalogi/api/serializers/resultaattype.py
+++ b/src/openzaak/components/catalogi/api/serializers/resultaattype.py
@@ -14,9 +14,8 @@ from vng_api_common.serializers import (
     NestedGegevensGroepMixin,
     add_choice_values_help_text,
 )
-from vng_api_common.validators import ResourceValidator
 
-from openzaak.utils.validators import UniqueTogetherValidator
+from openzaak.utils.validators import ResourceValidator, UniqueTogetherValidator
 
 from ...models import ResultaatType
 from ..validators import (

--- a/src/openzaak/components/catalogi/api/serializers/resultaattype.py
+++ b/src/openzaak/components/catalogi/api/serializers/resultaattype.py
@@ -79,7 +79,7 @@ class ResultaatTypeSerializer(
                 "validators": [
                     ResourceValidator(
                         "ResultaattypeOmschrijvingGeneriek",
-                        settings.REFERENTIELIJSTEN_API_SPEC,
+                        settings.SELECTIELIJST_API_STANDARD,
                     )
                 ]
             },

--- a/src/openzaak/components/catalogi/api/serializers/resultaattype.py
+++ b/src/openzaak/components/catalogi/api/serializers/resultaattype.py
@@ -79,7 +79,7 @@ class ResultaatTypeSerializer(
                 "validators": [
                     ResourceValidator(
                         "ResultaattypeOmschrijvingGeneriek",
-                        settings.SELECTIELIJST_API_STANDARD,
+                        settings.REFERENTIELIJSTEN_API_STANDARD,
                     )
                 ]
             },

--- a/src/openzaak/components/catalogi/api/serializers/zaaktype.py
+++ b/src/openzaak/components/catalogi/api/serializers/zaaktype.py
@@ -184,7 +184,7 @@ class ZaakTypeSerializer(
             "producten_of_diensten": {"required": True},
             "selectielijst_procestype": {
                 "validators": [
-                    ResourceValidator("ProcesType", settings.REFERENTIELIJSTEN_API_SPEC)
+                    ResourceValidator("ProcesType", settings.SELECTIELIJST_API_STANDARD)
                 ]
             },
             "deelzaaktypen": {"lookup_field": "uuid"},

--- a/src/openzaak/components/catalogi/api/serializers/zaaktype.py
+++ b/src/openzaak/components/catalogi/api/serializers/zaaktype.py
@@ -15,7 +15,8 @@ from vng_api_common.serializers import (
     NestedGegevensGroepMixin,
     add_choice_values_help_text,
 )
-from vng_api_common.validators import ResourceValidator
+
+from openzaak.utils.validators import ResourceValidator
 
 from ...constants import AardRelatieChoices, RichtingChoices
 from ...models import BesluitType, ZaakType, ZaakTypenRelatie

--- a/src/openzaak/components/catalogi/tests/admin/test_import_export_catalogus.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_import_export_catalogus.py
@@ -15,6 +15,7 @@ from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.models import Service
 
 from openzaak.accounts.tests.factories import SuperUserFactory, UserFactory
+from openzaak.tests.utils import patch_resource_validator
 
 from ...models import (
     BesluitType,
@@ -67,8 +68,7 @@ class CatalogusAdminImportExportTests(MockSelectielijst, WebTest):
         self.app.set_user(self.user)
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher")
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_export_import_catalogus_relations_generate_new_uuids(self, *mocks):
         catalogus = CatalogusFactory.create(rsin="000000000", domein="TEST")
         zaaktype = ZaakTypeFactory.create(
@@ -202,8 +202,7 @@ class CatalogusAdminImportExportTests(MockSelectielijst, WebTest):
         self.assertNotEqual(eigenschap.uuid, eigenschap_uuid)
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher")
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_export_import_catalogus_relations_use_existing_uuids(self, *mocks):
         catalogus = CatalogusFactory.create(rsin="000000000", domein="TEST")
         zaaktype = ZaakTypeFactory.create(

--- a/src/openzaak/components/catalogi/tests/admin/test_import_export_catalogus.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_import_export_catalogus.py
@@ -67,8 +67,8 @@ class CatalogusAdminImportExportTests(MockSelectielijst, WebTest):
         self.app.set_user(self.user)
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_export_import_catalogus_relations_generate_new_uuids(self, *mocks):
         catalogus = CatalogusFactory.create(rsin="000000000", domein="TEST")
         zaaktype = ZaakTypeFactory.create(
@@ -202,8 +202,8 @@ class CatalogusAdminImportExportTests(MockSelectielijst, WebTest):
         self.assertNotEqual(eigenschap.uuid, eigenschap_uuid)
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_export_import_catalogus_relations_use_existing_uuids(self, *mocks):
         catalogus = CatalogusFactory.create(rsin="000000000", domein="TEST")
         zaaktype = ZaakTypeFactory.create(

--- a/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
@@ -94,8 +94,8 @@ class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
         self.app.set_user(self.user)
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_export_import_zaaktype_with_relations(self, *mocks):
         catalogus = CatalogusFactory.create(rsin="000000000", domein="TEST")
         zaaktype = ZaakTypeFactory.create(
@@ -214,8 +214,8 @@ class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
         self.assertEqual(eigenschap.zaaktype, zaaktype)
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_export_import_zaaktype_to_different_catalogus(self, *mocks):
         catalogus = CatalogusFactory.create(rsin="000000000", domein="TEST")
         zaaktype = ZaakTypeFactory.create(

--- a/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
@@ -19,6 +19,7 @@ from openzaak.accounts.tests.factories import SuperUserFactory, UserFactory
 from openzaak.selectielijst.models import ReferentieLijstConfig
 from openzaak.selectielijst.tests import mock_resource_get
 from openzaak.selectielijst.tests.mixins import SelectieLijstMixin
+from openzaak.tests.utils import patch_resource_validator
 
 from ...models import (
     BesluitType,
@@ -94,8 +95,7 @@ class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
         self.app.set_user(self.user)
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher")
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_export_import_zaaktype_with_relations(self, *mocks):
         catalogus = CatalogusFactory.create(rsin="000000000", domein="TEST")
         zaaktype = ZaakTypeFactory.create(
@@ -214,8 +214,7 @@ class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
         self.assertEqual(eigenschap.zaaktype, zaaktype)
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher")
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_export_import_zaaktype_to_different_catalogus(self, *mocks):
         catalogus = CatalogusFactory.create(rsin="000000000", domein="TEST")
         zaaktype = ZaakTypeFactory.create(

--- a/src/openzaak/components/catalogi/tests/management/test_import_export.py
+++ b/src/openzaak/components/catalogi/tests/management/test_import_export.py
@@ -272,8 +272,8 @@ class ImportCatalogiTests(ImportExportMixin, TestCase):
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
     @requests_mock.Mocker()
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_import_catalogus_with_relations(self, m, *mocks):
         catalogus = CatalogusFactory.create(rsin="000000000")
         zaaktype = ZaakTypeFactory.create(
@@ -414,8 +414,8 @@ class ImportCatalogiTests(ImportExportMixin, TestCase):
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
     @requests_mock.Mocker()
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_import_request_caching(self, m, *mocks):
         """
         Assert that when running imports, external requests are cached to improve import performance

--- a/src/openzaak/components/catalogi/tests/management/test_import_export.py
+++ b/src/openzaak/components/catalogi/tests/management/test_import_export.py
@@ -16,6 +16,7 @@ from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.models import Service
 
 from openzaak.selectielijst.tests import mock_resource_get, mock_selectielijst_oas_get
+from openzaak.tests.utils import patch_resource_validator
 
 from ...models import (
     BesluitType,
@@ -272,8 +273,7 @@ class ImportCatalogiTests(ImportExportMixin, TestCase):
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
     @requests_mock.Mocker()
-    @patch("openzaak.utils.validators.fetcher")
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_import_catalogus_with_relations(self, m, *mocks):
         catalogus = CatalogusFactory.create(rsin="000000000")
         zaaktype = ZaakTypeFactory.create(
@@ -414,8 +414,7 @@ class ImportCatalogiTests(ImportExportMixin, TestCase):
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
     @requests_mock.Mocker()
-    @patch("openzaak.utils.validators.fetcher")
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_import_request_caching(self, m, *mocks):
         """
         Assert that when running imports, external requests are cached to improve import performance

--- a/src/openzaak/components/catalogi/tests/models/test_resultaattype_validation.py
+++ b/src/openzaak/components/catalogi/tests/models/test_resultaattype_validation.py
@@ -26,8 +26,8 @@ PROCESTYPE_URL = "https://selectielijst.openzaak.nl/api/v1/procestypen/{uuid}"
 
 
 @tag("resultaattype")
-@patch("vng_api_common.validators.fetcher")
-@patch("vng_api_common.validators.obj_has_shape", return_value=True)
+@patch("openzaak.utils.validators.fetcher")
+@patch("openzaak.utils.validators.obj_has_shape", return_value=True)
 class ResultaattypeSelectielijstlasseValidationTests(SelectieLijstMixin, TestCase):
     """
     Test the validation on Resultaattype.selectielijstklasse.
@@ -159,8 +159,8 @@ class ResultaattypeSelectielijstlasseValidationTests(SelectieLijstMixin, TestCas
 
 
 @tag("resultaattype")
-@patch("vng_api_common.validators.fetcher")
-@patch("vng_api_common.validators.obj_has_shape", return_value=True)
+@patch("openzaak.utils.validators.fetcher")
+@patch("openzaak.utils.validators.obj_has_shape", return_value=True)
 class ResultaattypeAfleidingswijzeSelectielijstValidationTests(
     SelectieLijstMixin, TestCase
 ):
@@ -372,8 +372,8 @@ class ResultaattypeAfleidingswijzeSelectielijstValidationTests(
 
 
 @tag("resultaattype")
-@patch("vng_api_common.validators.fetcher")
-@patch("vng_api_common.validators.obj_has_shape", return_value=True)
+@patch("openzaak.utils.validators.fetcher")
+@patch("openzaak.utils.validators.obj_has_shape", return_value=True)
 class ResultaattypeAfleidingswijzeAndParameterFieldsValidationTests(
     SelectieLijstMixin, TestCase
 ):

--- a/src/openzaak/components/catalogi/tests/models/test_resultaattype_validation.py
+++ b/src/openzaak/components/catalogi/tests/models/test_resultaattype_validation.py
@@ -112,6 +112,7 @@ class ResultaattypeSelectielijstlasseValidationTests(SelectieLijstMixin, TestCas
     def test_selectielijstklasse_url_pointing_to_incorrect_resource_raises_error(
         self, mock_has_shape, mock_fetcher
     ):
+        mock_has_shape.return_value = False
         procestype = PROCESTYPE_URL.format(uuid="e1b73b12-b2f6-4c4e-8929-94f84dd2a57d")
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=procestype)
 

--- a/src/openzaak/components/catalogi/tests/models/test_resultaattype_validation.py
+++ b/src/openzaak/components/catalogi/tests/models/test_resultaattype_validation.py
@@ -16,6 +16,7 @@ from vng_api_common.constants import (
 )
 
 from openzaak.selectielijst.tests.mixins import SelectieLijstMixin
+from openzaak.tests.utils import patch_resource_validator
 
 from ...admin.forms import ResultaatTypeForm
 from ...constants import SelectielijstKlasseProcestermijn as Procestermijn
@@ -26,8 +27,7 @@ PROCESTYPE_URL = "https://selectielijst.openzaak.nl/api/v1/procestypen/{uuid}"
 
 
 @tag("resultaattype")
-@patch("openzaak.utils.validators.fetcher")
-@patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+@patch_resource_validator
 class ResultaattypeSelectielijstlasseValidationTests(SelectieLijstMixin, TestCase):
     """
     Test the validation on Resultaattype.selectielijstklasse.
@@ -160,8 +160,7 @@ class ResultaattypeSelectielijstlasseValidationTests(SelectieLijstMixin, TestCas
 
 
 @tag("resultaattype")
-@patch("openzaak.utils.validators.fetcher")
-@patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+@patch_resource_validator
 class ResultaattypeAfleidingswijzeSelectielijstValidationTests(
     SelectieLijstMixin, TestCase
 ):
@@ -373,8 +372,7 @@ class ResultaattypeAfleidingswijzeSelectielijstValidationTests(
 
 
 @tag("resultaattype")
-@patch("openzaak.utils.validators.fetcher")
-@patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+@patch_resource_validator
 class ResultaattypeAfleidingswijzeAndParameterFieldsValidationTests(
     SelectieLijstMixin, TestCase
 ):

--- a/src/openzaak/components/catalogi/tests/test_resultaattype.py
+++ b/src/openzaak/components/catalogi/tests/test_resultaattype.py
@@ -22,6 +22,7 @@ from zgw_consumers.models import Service
 
 from openzaak.selectielijst.models import ReferentieLijstConfig
 from openzaak.selectielijst.tests import mock_selectielijst_oas_get
+from openzaak.tests.utils import patch_resource_validator
 
 from ..api.scopes import SCOPE_CATALOGI_READ, SCOPE_CATALOGI_WRITE
 from ..api.validators import ZaakTypeConceptValidator
@@ -174,8 +175,7 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(brondatumArchiefprocedure["procestermijn"], "P5Y")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     @requests_mock.Mocker()
     def test_create_resultaattype(self, mock_shape, mock_fetch, m):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
@@ -222,8 +222,7 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         )
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     @requests_mock.Mocker()
     def test_create_resultaattype_brondatum_archiefprocedure_null(
         self, mock_shape, mock_fetch, m
@@ -279,8 +278,7 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         )
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     @requests_mock.Mocker()
     def test_create_resultaattype_brondatum_archiefprocedure_null_with_vernietigen(
         self, mock_shape, mock_fetch, m
@@ -337,8 +335,7 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         )
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     @requests_mock.Mocker()
     def test_create_resultaattype_fail_not_concept_zaaktype(
         self, mock_shape, mock_fetch, m
@@ -406,8 +403,7 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(error["code"], ZaakTypeConceptValidator.code)
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_derive_archiefactiedatum_from_selectielijstklasse(self, *mocks):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
         zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})
@@ -446,8 +442,7 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(response.data["archiefactietermijn"], "P5Y")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_update_resultaattype(self, *mocks):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
         zaaktype_url = reverse(zaaktype)
@@ -489,8 +484,7 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(response.data["omschrijving"], "aangepast")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_update_resultaattype_fail_not_concept_zaaktype(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=False
@@ -536,8 +530,7 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(error["code"], "non-concept-zaaktype")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_update_resultaattype_add_relation_to_non_concept_zaaktype_fails(
         self, *mocks
     ):
@@ -622,8 +615,7 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(error["code"], "non-concept-zaaktype")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_partial_update_resultaattype_add_relation_to_non_concept_zaaktype_fails(
         self, *mocks
     ):
@@ -652,8 +644,7 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(error["code"], "non-concept-zaaktype")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_update_resultaattype_omschrijving_generiek(self, *mocks):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
         zaaktype_url = reverse(zaaktype)
@@ -857,7 +848,7 @@ class ResultaatTypeValidationTests(APITestCase):
             selectielijstklasse = SELECTIELIJSTKLASSE_URL
         return selectielijstklasse
 
-    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
+    @patch("openzaak.utils.validators.ResourceValidatorMixin._resolve_schema")
     @patch("openzaak.utils.validators.obj_has_shape", return_value=False)
     def test_validate_wrong_resultaattypeomschrijving(self, mock_shape, mock_fetch):
         zaaktype = ZaakTypeFactory.create(concept=False)
@@ -1013,8 +1004,7 @@ class ResultaatTypeValidationTests(APITestCase):
         self.assertEqual(error["code"], "invalid-afleidingswijze-for-procestermijn")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher")
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_procestermijn_empty_and_afleidingswijze_afgehandeld(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1098,8 +1088,7 @@ class ResultaatTypeValidationTests(APITestCase):
         self.assertEqual(error["code"], "invalid-afleidingswijze-for-procestermijn")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher")
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_procestermijn_empty_and_afleidingswijze_niet_termijn(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1139,8 +1128,7 @@ class ResultaatTypeValidationTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher")
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_value_for_datumkenmerk(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1185,8 +1173,7 @@ class ResultaatTypeValidationTests(APITestCase):
                     self.assertEqual(error["code"], "must-be-empty")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher")
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_datumkenmerk_empty(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1231,8 +1218,7 @@ class ResultaatTypeValidationTests(APITestCase):
                     ResultaatType.objects.get().delete()
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher")
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_einddatum_bekend_true(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1276,8 +1262,7 @@ class ResultaatTypeValidationTests(APITestCase):
                     ResultaatType.objects.get().delete()
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher")
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_einddatum_bekend_false(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1310,8 +1295,7 @@ class ResultaatTypeValidationTests(APITestCase):
                 ResultaatType.objects.get().delete()
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher")
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_value_for_objecttype(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1355,8 +1339,7 @@ class ResultaatTypeValidationTests(APITestCase):
                     self.assertEqual(error["code"], "must-be-empty")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher")
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_objecttype_empty(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1400,8 +1383,7 @@ class ResultaatTypeValidationTests(APITestCase):
                     ResultaatType.objects.get().delete()
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher")
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_value_for_registratie(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1442,8 +1424,7 @@ class ResultaatTypeValidationTests(APITestCase):
                     self.assertEqual(error["code"], "must-be-empty")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher")
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_registratie_empty(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1484,8 +1465,7 @@ class ResultaatTypeValidationTests(APITestCase):
                     ResultaatType.objects.get().delete()
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher")
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_value_for_procestermijn(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1526,8 +1506,7 @@ class ResultaatTypeValidationTests(APITestCase):
                     self.assertEqual(error["code"], "must-be-empty")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("openzaak.utils.validators.fetcher")
-    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    @patch_resource_validator
     def test_procestermijn_null(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True

--- a/src/openzaak/components/catalogi/tests/test_resultaattype.py
+++ b/src/openzaak/components/catalogi/tests/test_resultaattype.py
@@ -174,8 +174,8 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(brondatumArchiefprocedure["procestermijn"], "P5Y")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.oas.fetcher.fetch", return_value={})
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     @requests_mock.Mocker()
     def test_create_resultaattype(self, mock_shape, mock_fetch, m):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
@@ -222,8 +222,8 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         )
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.oas.fetcher.fetch", return_value={})
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     @requests_mock.Mocker()
     def test_create_resultaattype_brondatum_archiefprocedure_null(
         self, mock_shape, mock_fetch, m
@@ -279,8 +279,8 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         )
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.oas.fetcher.fetch", return_value={})
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     @requests_mock.Mocker()
     def test_create_resultaattype_brondatum_archiefprocedure_null_with_vernietigen(
         self, mock_shape, mock_fetch, m
@@ -337,8 +337,8 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         )
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.oas.fetcher.fetch", return_value={})
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     @requests_mock.Mocker()
     def test_create_resultaattype_fail_not_concept_zaaktype(
         self, mock_shape, mock_fetch, m
@@ -406,8 +406,8 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(error["code"], ZaakTypeConceptValidator.code)
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.oas.fetcher.fetch", return_value={})
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_derive_archiefactiedatum_from_selectielijstklasse(self, *mocks):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
         zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})
@@ -446,8 +446,8 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(response.data["archiefactietermijn"], "P5Y")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.oas.fetcher.fetch", return_value={})
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_update_resultaattype(self, *mocks):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
         zaaktype_url = reverse(zaaktype)
@@ -489,8 +489,8 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(response.data["omschrijving"], "aangepast")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.oas.fetcher.fetch", return_value={})
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_update_resultaattype_fail_not_concept_zaaktype(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=False
@@ -536,8 +536,8 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(error["code"], "non-concept-zaaktype")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.oas.fetcher.fetch", return_value={})
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_update_resultaattype_add_relation_to_non_concept_zaaktype_fails(
         self, *mocks
     ):
@@ -622,8 +622,8 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(error["code"], "non-concept-zaaktype")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.oas.fetcher.fetch", return_value={})
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_partial_update_resultaattype_add_relation_to_non_concept_zaaktype_fails(
         self, *mocks
     ):
@@ -652,8 +652,8 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(error["code"], "non-concept-zaaktype")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.oas.fetcher.fetch", return_value={})
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_update_resultaattype_omschrijving_generiek(self, *mocks):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
         zaaktype_url = reverse(zaaktype)
@@ -857,8 +857,8 @@ class ResultaatTypeValidationTests(APITestCase):
             selectielijstklasse = SELECTIELIJSTKLASSE_URL
         return selectielijstklasse
 
-    @patch("vng_api_common.oas.fetcher.fetch", return_value={})
-    @patch("vng_api_common.validators.obj_has_shape", return_value=False)
+    @patch("openzaak.utils.validators.fetcher.fetch", return_value={})
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=False)
     def test_validate_wrong_resultaattypeomschrijving(self, mock_shape, mock_fetch):
         zaaktype = ZaakTypeFactory.create(concept=False)
         zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})
@@ -925,7 +925,7 @@ class ResultaatTypeValidationTests(APITestCase):
         self.assertEqual(error["code"], "invalid-resource")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_selectielijstklasse_procestype_no_match_with_zaaktype_procestype(
         self, *mocks
     ):
@@ -970,7 +970,7 @@ class ResultaatTypeValidationTests(APITestCase):
         self.assertEqual(error["code"], "procestype-mismatch")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_procestermijn_nihil_and_afleidingswijze_niet_afgehandeld_fails(
         self, *mocks
     ):
@@ -1013,8 +1013,8 @@ class ResultaatTypeValidationTests(APITestCase):
         self.assertEqual(error["code"], "invalid-afleidingswijze-for-procestermijn")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_procestermijn_empty_and_afleidingswijze_afgehandeld(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1054,7 +1054,7 @@ class ResultaatTypeValidationTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_procestermijn_ingeschatte_bestaansduur_procesobject_and_afleidingswijze_niet_termijn_fails(
         self, *mocks
     ):
@@ -1098,8 +1098,8 @@ class ResultaatTypeValidationTests(APITestCase):
         self.assertEqual(error["code"], "invalid-afleidingswijze-for-procestermijn")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_procestermijn_empty_and_afleidingswijze_niet_termijn(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1139,8 +1139,8 @@ class ResultaatTypeValidationTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_value_for_datumkenmerk(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1185,8 +1185,8 @@ class ResultaatTypeValidationTests(APITestCase):
                     self.assertEqual(error["code"], "must-be-empty")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_datumkenmerk_empty(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1231,8 +1231,8 @@ class ResultaatTypeValidationTests(APITestCase):
                     ResultaatType.objects.get().delete()
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_einddatum_bekend_true(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1276,8 +1276,8 @@ class ResultaatTypeValidationTests(APITestCase):
                     ResultaatType.objects.get().delete()
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_einddatum_bekend_false(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1310,8 +1310,8 @@ class ResultaatTypeValidationTests(APITestCase):
                 ResultaatType.objects.get().delete()
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_value_for_objecttype(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1355,8 +1355,8 @@ class ResultaatTypeValidationTests(APITestCase):
                     self.assertEqual(error["code"], "must-be-empty")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_objecttype_empty(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1400,8 +1400,8 @@ class ResultaatTypeValidationTests(APITestCase):
                     ResultaatType.objects.get().delete()
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_value_for_registratie(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1442,8 +1442,8 @@ class ResultaatTypeValidationTests(APITestCase):
                     self.assertEqual(error["code"], "must-be-empty")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_registratie_empty(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1484,8 +1484,8 @@ class ResultaatTypeValidationTests(APITestCase):
                     ResultaatType.objects.get().delete()
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_value_for_procestermijn(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True
@@ -1526,8 +1526,8 @@ class ResultaatTypeValidationTests(APITestCase):
                     self.assertEqual(error["code"], "must-be-empty")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-    @patch("vng_api_common.validators.fetcher")
-    @patch("vng_api_common.validators.obj_has_shape", return_value=True)
+    @patch("openzaak.utils.validators.fetcher")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
     def test_procestermijn_null(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
             selectielijst_procestype=PROCESTYPE_URL, concept=True

--- a/src/openzaak/components/documenten/api/serializers.py
+++ b/src/openzaak/components/documenten/api/serializers.py
@@ -31,6 +31,7 @@ from vng_api_common.serializers import (
 )
 from vng_api_common.utils import get_help_text
 
+from openzaak.contrib.verzoeken.validators import verzoek_validator
 from openzaak.utils.serializer_fields import LengthHyperlinkedRelatedField
 from openzaak.utils.serializers import get_from_serializer_data_or_instance
 from openzaak.utils.validators import (
@@ -38,7 +39,6 @@ from openzaak.utils.validators import (
     LooseFkIsImmutableValidator,
     LooseFkResourceValidator,
     PublishValidator,
-    ResourceValidator,
 )
 
 from ..constants import (
@@ -904,9 +904,7 @@ class ObjectInformatieObjectSerializer(serializers.HyperlinkedModelSerializer):
             )
         elif object_type == ObjectInformatieObjectTypes.verzoek:
             object_field.source = "verzoek"
-            object_field.validators.append(
-                ResourceValidator("Verzoek", settings.VRC_API_STANDARD)
-            )
+            object_field.validators.append(verzoek_validator)
 
     def to_internal_value(self, data):
         object_type = data["object_type"]

--- a/src/openzaak/components/documenten/api/serializers.py
+++ b/src/openzaak/components/documenten/api/serializers.py
@@ -290,7 +290,7 @@ class EnkelvoudigInformatieObjectSerializer(serializers.HyperlinkedModelSerializ
             "URL-referentie naar het INFORMATIEOBJECTTYPE (in de Catalogi API)."
         ),
         validators=[
-            LooseFkResourceValidator("InformatieObjectType", settings.ZTC_API_SPEC),
+            LooseFkResourceValidator("InformatieObjectType", settings.ZTC_API_STANDARD),
             LooseFkIsImmutableValidator(),
             PublishValidator(),
         ],
@@ -355,7 +355,7 @@ class EnkelvoudigInformatieObjectSerializer(serializers.HyperlinkedModelSerializ
                 "min_length": 1,
                 "validators": [
                     LooseFkResourceValidator(
-                        "InformatieObjectType", settings.ZTC_API_SPEC
+                        "InformatieObjectType", settings.ZTC_API_STANDARD
                     ),
                     LooseFkIsImmutableValidator(),
                     PublishValidator(),

--- a/src/openzaak/components/documenten/api/serializers.py
+++ b/src/openzaak/components/documenten/api/serializers.py
@@ -895,7 +895,7 @@ class ObjectInformatieObjectSerializer(serializers.HyperlinkedModelSerializer):
         if object_type == ObjectInformatieObjectTypes.besluit:
             object_field.source = "besluit"
             object_field.validators.append(
-                LooseFkResourceValidator("Besluit", settings.BRC_API_SPEC)
+                LooseFkResourceValidator("Besluit", settings.BRC_API_STANDARD)
             )
         elif object_type == ObjectInformatieObjectTypes.zaak:
             object_field.source = "zaak"

--- a/src/openzaak/components/documenten/api/serializers.py
+++ b/src/openzaak/components/documenten/api/serializers.py
@@ -900,7 +900,7 @@ class ObjectInformatieObjectSerializer(serializers.HyperlinkedModelSerializer):
         elif object_type == ObjectInformatieObjectTypes.zaak:
             object_field.source = "zaak"
             object_field.validators.append(
-                LooseFkResourceValidator("Zaak", settings.ZRC_API_SPEC)
+                LooseFkResourceValidator("Zaak", settings.ZRC_API_STANDARD)
             )
         elif object_type == ObjectInformatieObjectTypes.verzoek:
             object_field.source = "verzoek"

--- a/src/openzaak/components/documenten/api/serializers.py
+++ b/src/openzaak/components/documenten/api/serializers.py
@@ -30,7 +30,6 @@ from vng_api_common.serializers import (
     add_choice_values_help_text,
 )
 from vng_api_common.utils import get_help_text
-from vng_api_common.validators import ResourceValidator
 
 from openzaak.utils.serializer_fields import LengthHyperlinkedRelatedField
 from openzaak.utils.serializers import get_from_serializer_data_or_instance
@@ -39,6 +38,7 @@ from openzaak.utils.validators import (
     LooseFkIsImmutableValidator,
     LooseFkResourceValidator,
     PublishValidator,
+    ResourceValidator,
 )
 
 from ..constants import (
@@ -905,7 +905,7 @@ class ObjectInformatieObjectSerializer(serializers.HyperlinkedModelSerializer):
         elif object_type == ObjectInformatieObjectTypes.verzoek:
             object_field.source = "verzoek"
             object_field.validators.append(
-                ResourceValidator("Verzoek", settings.VRC_API_SPEC)
+                ResourceValidator("Verzoek", settings.VRC_API_STANDARD)
             )
 
     def to_internal_value(self, data):

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -846,7 +846,7 @@ class ZaakContactMomentSerializer(serializers.HyperlinkedModelSerializer):
             "contactmoment": {
                 "validators": [
                     ResourceValidator(
-                        "ContactMoment", settings.CMC_API_SPEC, get_auth=get_auth
+                        "ContactMoment", settings.CMC_API_STANDARD, get_auth=get_auth
                     )
                 ]
             },

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -265,7 +265,7 @@ class ZaakSerializer(
                 "max_length": 1000,
                 "min_length": 1,
                 "validators": [
-                    LooseFkResourceValidator("ZaakType", settings.ZTC_API_SPEC),
+                    LooseFkResourceValidator("ZaakType", settings.ZTC_API_STANDARD),
                     LooseFkIsImmutableValidator(),
                     PublishValidator(),
                 ],
@@ -422,7 +422,7 @@ class StatusSerializer(serializers.HyperlinkedModelSerializer):
                 "max_length": 1000,
                 "min_length": 1,
                 "validators": [
-                    LooseFkResourceValidator("StatusType", settings.ZTC_API_SPEC),
+                    LooseFkResourceValidator("StatusType", settings.ZTC_API_STANDARD),
                 ],
             },
         }
@@ -649,7 +649,7 @@ class ZaakEigenschapSerializer(NestedHyperlinkedModelSerializer):
                 "max_length": 1000,
                 "min_length": 1,
                 "validators": [
-                    LooseFkResourceValidator("Eigenschap", settings.ZTC_API_SPEC),
+                    LooseFkResourceValidator("Eigenschap", settings.ZTC_API_STANDARD),
                     LooseFkIsImmutableValidator(),
                 ],
             },
@@ -733,7 +733,7 @@ class RolSerializer(PolymorphicSerializer):
                 "max_length": 1000,
                 "min_length": 1,
                 "validators": [
-                    LooseFkResourceValidator("RolType", settings.ZTC_API_SPEC),
+                    LooseFkResourceValidator("RolType", settings.ZTC_API_STANDARD),
                     LooseFkIsImmutableValidator(),
                 ],
                 "help_text": get_help_text("zaken.Rol", "roltype"),
@@ -795,7 +795,9 @@ class ResultaatSerializer(serializers.HyperlinkedModelSerializer):
                 "max_length": 1000,
                 "min_length": 1,
                 "validators": [
-                    LooseFkResourceValidator("ResultaatType", settings.ZTC_API_SPEC),
+                    LooseFkResourceValidator(
+                        "ResultaatType", settings.ZTC_API_STANDARD
+                    ),
                     LooseFkIsImmutableValidator(),
                 ],
             },

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -31,6 +31,7 @@ from vng_api_common.utils import get_help_text
 from vng_api_common.validators import IsImmutableValidator, UntilNowValidator
 
 from openzaak.components.documenten.api.fields import EnkelvoudigInformatieObjectField
+from openzaak.contrib.verzoeken.validators import verzoek_validator
 from openzaak.utils.api import (
     create_remote_objectcontactmoment,
     create_remote_objectverzoek,
@@ -897,13 +898,7 @@ class ZaakVerzoekSerializer(serializers.HyperlinkedModelSerializer):
             "url": {"lookup_field": "uuid"},
             "uuid": {"read_only": True},
             "zaak": {"lookup_field": "uuid"},
-            "verzoek": {
-                "validators": [
-                    ResourceValidator(
-                        "Verzoek", settings.VRC_API_STANDARD, get_auth=get_auth
-                    )
-                ]
-            },
+            "verzoek": {"validators": [verzoek_validator]},
         }
 
     def create(self, validated_data):

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -538,7 +538,7 @@ class ZaakInformatieObjectSerializer(serializers.HyperlinkedModelSerializer):
         validators=[
             LooseFkIsImmutableValidator(instance_path="canonical"),
             LooseFkResourceValidator(
-                "EnkelvoudigInformatieObject", settings.DRC_API_SPEC
+                "EnkelvoudigInformatieObject", settings.DRC_API_STANDARD
             ),
         ],
         max_length=1000,

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -900,7 +900,7 @@ class ZaakVerzoekSerializer(serializers.HyperlinkedModelSerializer):
             "verzoek": {
                 "validators": [
                     ResourceValidator(
-                        "Verzoek", settings.VRC_API_SPEC, get_auth=get_auth
+                        "Verzoek", settings.VRC_API_STANDARD, get_auth=get_auth
                     )
                 ]
             },

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -825,7 +825,7 @@ class ZaakBesluitSerializer(NestedHyperlinkedModelSerializer):
                 "max_length": 1000,
                 "min_length": 1,
                 "validators": [
-                    LooseFkResourceValidator("Besluit", settings.BRC_API_SPEC),
+                    LooseFkResourceValidator("Besluit", settings.BRC_API_STANDARD),
                 ],
             },
         }

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -125,7 +125,9 @@ class RelevanteZaakSerializer(serializers.HyperlinkedModelSerializer):
                 "lookup_field": "uuid",
                 "max_length": 1000,
                 "min_length": 1,
-                "validators": [LooseFkResourceValidator("Zaak", settings.ZRC_API_SPEC)],
+                "validators": [
+                    LooseFkResourceValidator("Zaak", settings.ZRC_API_STANDARD)
+                ],
             },
         }
 

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -28,11 +28,7 @@ from vng_api_common.serializers import (
     add_choice_values_help_text,
 )
 from vng_api_common.utils import get_help_text
-from vng_api_common.validators import (
-    IsImmutableValidator,
-    ResourceValidator,
-    UntilNowValidator,
-)
+from vng_api_common.validators import IsImmutableValidator, UntilNowValidator
 
 from openzaak.components.documenten.api.fields import EnkelvoudigInformatieObjectField
 from openzaak.utils.api import (
@@ -47,6 +43,7 @@ from openzaak.utils.validators import (
     LooseFkResourceValidator,
     ObjecttypeInformatieobjecttypeRelationValidator,
     PublishValidator,
+    ResourceValidator,
     UniqueTogetherValidator,
 )
 
@@ -281,7 +278,7 @@ class ZaakSerializer(
             "communicatiekanaal": {
                 "validators": [
                     ResourceValidator(
-                        "CommunicatieKanaal", settings.REFERENTIELIJSTEN_API_SPEC
+                        "CommunicatieKanaal", settings.REFERENTIELIJSTEN_API_STANDARD
                     )
                 ]
             },
@@ -299,7 +296,7 @@ class ZaakSerializer(
                 "validators": [
                     ResourceValidator(
                         "Resultaat",
-                        settings.REFERENTIELIJSTEN_API_SPEC,
+                        settings.SELECTIELIJST_API_STANDARD,
                         get_auth=get_auth,
                     )
                 ]

--- a/src/openzaak/components/zaken/tests/test_zaakcontactmoment.py
+++ b/src/openzaak/components/zaken/tests/test_zaakcontactmoment.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2022 Dimpact
-from unittest.mock import patch
-
 from django.test import override_settings
 
 import requests_mock
@@ -11,6 +9,8 @@ from vng_api_common.tests import JWTAuthMixin, get_validation_errors, reverse
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.models import Service
 from zgw_consumers.test import mock_service_oas_get
+
+from openzaak.tests.utils import patch_resource_validator
 
 from ..models import ZaakContactMoment
 from .factories import ZaakContactMomentFactory, ZaakFactory
@@ -24,8 +24,7 @@ def mock_contactmomenten_oas_get(m, base: str):
 
 
 @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-@patch("openzaak.utils.validators.fetcher")
-@patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+@patch_resource_validator
 class ZaakContactMomentTests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
 

--- a/src/openzaak/components/zaken/tests/test_zaakcontactmoment.py
+++ b/src/openzaak/components/zaken/tests/test_zaakcontactmoment.py
@@ -24,8 +24,8 @@ def mock_contactmomenten_oas_get(m, base: str):
 
 
 @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-@patch("vng_api_common.validators.fetcher")
-@patch("vng_api_common.validators.obj_has_shape", return_value=True)
+@patch("openzaak.utils.validators.fetcher")
+@patch("openzaak.utils.validators.obj_has_shape", return_value=True)
 class ZaakContactMomentTests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
 

--- a/src/openzaak/components/zaken/tests/test_zaakverzoek.py
+++ b/src/openzaak/components/zaken/tests/test_zaakverzoek.py
@@ -24,8 +24,8 @@ def mock_verzoeken_oas_get(m, base):
 
 
 @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-@patch("vng_api_common.validators.fetcher")
-@patch("vng_api_common.validators.obj_has_shape", return_value=True)
+@patch("openzaak.utils.validators.fetcher")
+@patch("openzaak.utils.validators.obj_has_shape", return_value=True)
 class ZaakVerzoekTests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
 

--- a/src/openzaak/components/zaken/tests/test_zaakverzoek.py
+++ b/src/openzaak/components/zaken/tests/test_zaakverzoek.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2022 Dimpact
-from unittest.mock import patch
-
 from django.test import override_settings
 
 import requests_mock
@@ -14,6 +12,7 @@ from zgw_consumers.test import mock_service_oas_get
 
 from openzaak.components.zaken.models import ZaakVerzoek
 from openzaak.components.zaken.tests.factories import ZaakFactory, ZaakVerzoekFactory
+from openzaak.tests.utils import patch_resource_validator
 
 VERZOEKEN_BASE = "https://verzoeken.nl/api/v1/"
 VERZOEK = f"{VERZOEKEN_BASE}verzoeken/1234"
@@ -24,8 +23,7 @@ def mock_verzoeken_oas_get(m, base):
 
 
 @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
-@patch("openzaak.utils.validators.fetcher")
-@patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+@patch_resource_validator
 class ZaakVerzoekTests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
 

--- a/src/openzaak/conf/includes/api.py
+++ b/src/openzaak/conf/includes/api.py
@@ -64,11 +64,13 @@ GEMMA_URL_INFORMATIEMODEL_VERSIE = "1.0"
 #
 
 # TODO: deduplicate
-repo = "vng-Realisatie/vng-referentielijsten"
-commit = "4533cc71dcd17e997fce9e31445db852b7540321"
+vrl_ref = "4533cc71dcd17e997fce9e31445db852b7540321"
 REFERENTIELIJSTEN_API_STANDARD = APIStandard(
-    alias=f"vrl-{commit}",
-    oas_url=f"https://raw.githubusercontent.com/{repo}/{commit}/src/openapi.yaml",
+    alias="vrl-0.5.6",
+    oas_url=(
+        "https://raw.githubusercontent.com/"
+        f"vng-Realisatie/vng-referentielijsten/{vrl_ref}/src/openapi.yaml"
+    ),
     is_standardized=False,
 )
 

--- a/src/openzaak/conf/includes/api.py
+++ b/src/openzaak/conf/includes/api.py
@@ -66,15 +66,16 @@ GEMMA_URL_INFORMATIEMODEL_VERSIE = "1.0"
 # TODO: deduplicate
 repo = "vng-Realisatie/vng-referentielijsten"
 commit = "4533cc71dcd17e997fce9e31445db852b7540321"
-REFERENTIELIJSTEN_API_SPEC = (
-    f"https://raw.githubusercontent.com/{repo}/{commit}/src/openapi.yaml"
+REFERENTIELIJSTEN_API_STANDARD = APIStandard(
+    alias=f"vrl-{commit}",
+    oas_url=f"https://raw.githubusercontent.com/{repo}/{commit}/src/openapi.yaml",
+    is_standardized=False,
 )
-
-VRL_API_SPEC = "https://selectielijst.openzaak.nl/api/v1/schema/openapi.yaml?v=3"
 
 SELECTIELIJST_API_STANDARD = APIStandard(
     alias="selectielijst-1.0.0",
     oas_url="https://selectielijst.openzaak.nl/api/v1/schema/openapi.yaml",
+    is_standardized=False,
 )
 
 ztc_repo = "vng-Realisatie/catalogi-api"

--- a/src/openzaak/conf/includes/api.py
+++ b/src/openzaak/conf/includes/api.py
@@ -124,9 +124,15 @@ CMC_API_STANDARD = APIStandard(
     is_standardized=False,
 )
 
-vrc_repo = "VNG-Realisatie/verzoeken-api"
-vrc_commit = "57c83f6799df482f5c7fc70813d59264b9979619"
-VRC_API_SPEC = f"https://raw.githubusercontent.com/{vrc_repo}/{vrc_commit}/src/openapi.yaml"  # noqa
+vrc_ref = "57c83f6799df482f5c7fc70813d59264b9979619"
+VRC_API_STANDARD = APIStandard(
+    alias="verzoeken-2021-06-21",
+    oas_url=(
+        "https://raw.githubusercontent.com/"
+        f"vng-Realisatie/verzoeken-api/{vrc_ref}/src/openapi.yaml"
+    ),
+    is_standardized=False,
+)
 
 SPEC_CACHE_TIMEOUT = 60 * 60 * 24  # 24 hours
 

--- a/src/openzaak/conf/includes/api.py
+++ b/src/openzaak/conf/includes/api.py
@@ -114,9 +114,15 @@ BRC_API_STANDARD = APIStandard(
     ),
 )
 
-cmc_repo = "VNG-Realisatie/contactmomenten-api"
-cmc_commit = "20f149a66163047b6ae3719709a600285fbb1c36"
-CMC_API_SPEC = f"https://raw.githubusercontent.com/{cmc_repo}/{cmc_commit}/src/openapi.yaml"  # noqa
+cmc_ref = "20f149a66163047b6ae3719709a600285fbb1c36"
+CMC_API_STANDARD = APIStandard(
+    alias="contactmomenten-2021-09-13",
+    oas_url=(
+        "https://raw.githubusercontent.com/"
+        f"vng-Realisatie/contactmomenten-api/{cmc_ref}/src/openapi.yaml"
+    ),
+    is_standardized=False,
+)
 
 vrc_repo = "VNG-Realisatie/verzoeken-api"
 vrc_commit = "57c83f6799df482f5c7fc70813d59264b9979619"

--- a/src/openzaak/conf/includes/api.py
+++ b/src/openzaak/conf/includes/api.py
@@ -87,10 +87,13 @@ ZTC_API_STANDARD = APIStandard(
     ),
 )
 
-drc_repo = "vng-Realisatie/documenten-api"
-drc_commit = "1.0.1.post1"
-DRC_API_SPEC = (
-    f"https://raw.githubusercontent.com/{drc_repo}/{drc_commit}/src/openapi.yaml"
+drc_ref = "1.0.1.post1"
+DRC_API_STANDARD = APIStandard(
+    alias=f"documenten-{drc_ref}",
+    oas_url=(
+        "https://raw.githubusercontent.com/"
+        f"vng-Realisatie/documenten-api/{drc_ref}/src/openapi.yaml"
+    ),
 )
 
 zrc_repo = "vng-Realisatie/zaken-api"

--- a/src/openzaak/conf/includes/api.py
+++ b/src/openzaak/conf/includes/api.py
@@ -96,10 +96,13 @@ DRC_API_STANDARD = APIStandard(
     ),
 )
 
-zrc_repo = "vng-Realisatie/zaken-api"
-zrc_commit = "1.0.3"
-ZRC_API_SPEC = (
-    f"https://raw.githubusercontent.com/{zrc_repo}/{zrc_commit}/src/openapi.yaml"
+zrc_ref = "1.0.3"
+ZRC_API_STANDARD = APIStandard(
+    alias=f"zaken-{zrc_ref}",
+    oas_url=(
+        "https://raw.githubusercontent.com/"
+        f"vng-Realisatie/zaken-api/{zrc_ref}/src/openapi.yaml"
+    ),
 )
 
 brc_repo = "vng-Realisatie/besluiten-api"

--- a/src/openzaak/conf/includes/api.py
+++ b/src/openzaak/conf/includes/api.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2019 - 2022 Dimpact
 from vng_api_common.conf.api import *  # noqa - imports white-listed
 
+from openzaak.api_standards import APIStandard
+
 # Remove the reference - we don't have a single API version.
 del API_VERSION  # noqa
 
@@ -56,13 +58,24 @@ SWAGGER_SETTINGS.update(
 
 GEMMA_URL_INFORMATIEMODEL_VERSIE = "1.0"
 
+#
+# API's Open Zaak interacts with that have a defined standard (or community-accepted
+# one when there's no official standard)
+#
+
 # TODO: deduplicate
 repo = "vng-Realisatie/vng-referentielijsten"
 commit = "4533cc71dcd17e997fce9e31445db852b7540321"
 REFERENTIELIJSTEN_API_SPEC = (
     f"https://raw.githubusercontent.com/{repo}/{commit}/src/openapi.yaml"
 )
+
 VRL_API_SPEC = "https://selectielijst.openzaak.nl/api/v1/schema/openapi.yaml?v=3"
+
+SELECTIELIJST_API_STANDARD = APIStandard(
+    alias="selectielijst-1.0.0",
+    oas_url="https://selectielijst.openzaak.nl/api/v1/schema/openapi.yaml",
+)
 
 ztc_repo = "vng-Realisatie/catalogi-api"
 ztc_commit = "1.0.0.post5"

--- a/src/openzaak/conf/includes/api.py
+++ b/src/openzaak/conf/includes/api.py
@@ -78,10 +78,13 @@ SELECTIELIJST_API_STANDARD = APIStandard(
     is_standardized=False,
 )
 
-ztc_repo = "vng-Realisatie/catalogi-api"
-ztc_commit = "1.0.0.post5"
-ZTC_API_SPEC = (
-    f"https://raw.githubusercontent.com/{ztc_repo}/{ztc_commit}/src/openapi.yaml"
+ztc_ref = "1.0.1"
+ZTC_API_STANDARD = APIStandard(
+    alias=f"catalogi-{ztc_ref}",
+    oas_url=(
+        "https://raw.githubusercontent.com/"
+        f"vng-Realisatie/catalogi-api/{ztc_ref}/src/openapi.yaml"
+    ),
 )
 
 drc_repo = "vng-Realisatie/documenten-api"

--- a/src/openzaak/conf/includes/api.py
+++ b/src/openzaak/conf/includes/api.py
@@ -105,10 +105,13 @@ ZRC_API_STANDARD = APIStandard(
     ),
 )
 
-brc_repo = "vng-Realisatie/besluiten-api"
-brc_commit = "1.0.1.post0"
-BRC_API_SPEC = (
-    f"https://raw.githubusercontent.com/{brc_repo}/{brc_commit}/src/openapi.yaml"
+brc_ref = "1.0.1.post0"
+BRC_API_STANDARD = APIStandard(
+    alias=f"besluiten-{brc_ref}",
+    oas_url=(
+        "https://raw.githubusercontent.com/"
+        f"vng-Realisatie/besluiten-api/{brc_ref}/src/openapi.yaml"
+    ),
 )
 
 cmc_repo = "VNG-Realisatie/contactmomenten-api"

--- a/src/openzaak/contrib/verzoeken/validators.py
+++ b/src/openzaak/contrib/verzoeken/validators.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2022 Dimpact
+from django.conf import settings
+
+from openzaak.utils.auth import get_auth
+from openzaak.utils.validators import ResourceValidator
+
+verzoek_validator = ResourceValidator(
+    "Verzoek", settings.VRC_API_STANDARD, get_auth=get_auth,
+)

--- a/src/openzaak/management/commands/warm_cache.py
+++ b/src/openzaak/management/commands/warm_cache.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2022 Dimpact
+from django.core.management import BaseCommand
+
+from openzaak.api_standards import SPECIFICATIONS
+
+
+class Command(BaseCommand):
+    help = "Populate any and all Open Zaak caches"
+
+    def handle(self, **options):
+        verbosity = options["verbosity"]
+
+        # populating api spec caches
+        if verbosity > 0:
+            self.stdout.write("Populating OpenAPI specs cache...")
+        for standard in SPECIFICATIONS.values():
+            try:
+                standard.write_cache()
+            except Exception:
+                self.stderr.write(
+                    f"Failed populating the API spec cache for '{standard.alias}'."
+                )
+            else:
+                if verbosity > 0:
+                    self.stdout.write(
+                        self.style.SUCCESS(f"API spec for '{standard.alias}' written.")
+                    )

--- a/src/openzaak/selectielijst/tests/__init__.py
+++ b/src/openzaak/selectielijst/tests/__init__.py
@@ -24,7 +24,10 @@ def mock_selectielijst_oas_get(m: Mocker) -> None:
     base_url = _get_base_url()
     mock_service_oas_get(m, url=base_url, service="selectielijst")
     mock_service_oas_get(
-        m, url="", service="selectielijst", oas_url=settings.REFERENTIELIJSTEN_API_SPEC
+        m,
+        url="",
+        service="selectielijst",
+        oas_url=settings.REFERENTIELIJSTEN_API_STANDARD.oas_url,
     )
     mock_service_oas_get(
         m,

--- a/src/openzaak/selectielijst/tests/__init__.py
+++ b/src/openzaak/selectielijst/tests/__init__.py
@@ -26,6 +26,12 @@ def mock_selectielijst_oas_get(m: Mocker) -> None:
     mock_service_oas_get(
         m, url="", service="selectielijst", oas_url=settings.REFERENTIELIJSTEN_API_SPEC
     )
+    mock_service_oas_get(
+        m,
+        url="",
+        service="selectielijst",
+        oas_url=settings.SELECTIELIJST_API_STANDARD.oas_url,
+    )
 
 
 def mock_resource_list(

--- a/src/openzaak/tests/management/test_cache_warming.py
+++ b/src/openzaak/tests/management/test_cache_warming.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2022 Dimpact
+import shutil
+from io import StringIO
+from pathlib import Path
+
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+import requests_mock
+from vng_api_common.oas import fetcher
+
+from openzaak.selectielijst.tests import mock_selectielijst_oas_get
+
+from ..utils import (
+    ClearCachesMixin,
+    mock_brc_oas_get,
+    mock_cmc_oas_get,
+    mock_drc_oas_get,
+    mock_vrc_oas_get,
+    mock_zrc_oas_get,
+    mock_ztc_oas_get,
+)
+
+SCHEMAS = Path(__file__).parent.parent
+CACHE_DIR = SCHEMAS / "cache"
+
+
+@override_settings(BASE_DIR=str(SCHEMAS))
+@requests_mock.Mocker()
+class WarmCacheCommandTests(ClearCachesMixin, TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        super().setUp()
+
+        self.addCleanup(lambda: shutil.rmtree(CACHE_DIR, ignore_errors=True))
+        self.addCleanup(fetcher.cache.clear)
+
+    def _install_mocks(self, m):
+        mock_brc_oas_get(m)
+        mock_drc_oas_get(m)
+        mock_zrc_oas_get(m)
+        mock_ztc_oas_get(m)
+        mock_vrc_oas_get(m)
+        mock_cmc_oas_get(m)
+        mock_selectielijst_oas_get(m)
+
+    def test_successful_cache_warming(self, m):
+        CACHE_DIR.mkdir(parents=True)
+        self._install_mocks(m)
+        stdout, stderr = StringIO(), StringIO()
+
+        call_command(
+            "warm_cache", stdout=stdout, stderr=stderr, verbosity=1, no_color=True
+        )
+
+        output = stdout.getvalue().splitlines()
+        expected_output = [
+            "Populating OpenAPI specs cache...",
+            "API spec for 'vrl-4533cc71dcd17e997fce9e31445db852b7540321' written.",
+            "API spec for 'selectielijst-1.0.0' written.",
+            "API spec for 'catalogi-1.0.1' written.",
+            "API spec for 'documenten-1.0.1.post1' written.",
+            "API spec for 'zaken-1.0.3' written.",
+            "API spec for 'besluiten-1.0.1.post0' written.",
+            "API spec for 'contactmomenten-2021-09-13' written.",
+            "API spec for 'verzoeken-2021-06-21' written.",
+        ]
+        self.assertEqual(output, expected_output)
+
+        self.assertEqual(stderr.getvalue(), "")
+
+    def test_successful_silent_output(self, m):
+        CACHE_DIR.mkdir(parents=True)
+        self._install_mocks(m)
+        stdout, stderr = StringIO(), StringIO()
+
+        call_command(
+            "warm_cache", stdout=stdout, stderr=stderr, verbosity=0, no_color=True
+        )
+
+        output = stdout.getvalue().splitlines()
+        expected_output = []
+        self.assertEqual(output, expected_output)
+
+        self.assertEqual(stderr.getvalue(), "")
+
+    def test_some_errored_some_ok(self, m):
+        CACHE_DIR.mkdir(parents=True)
+        mock_brc_oas_get(m)
+        mock_drc_oas_get(m)
+        mock_zrc_oas_get(m)
+        stdout, stderr = StringIO(), StringIO()
+
+        call_command(
+            "warm_cache", stdout=stdout, stderr=stderr, verbosity=1, no_color=True
+        )
+
+        with self.subTest("stdout output"):
+            output = stdout.getvalue().splitlines()
+            expected_output = [
+                "Populating OpenAPI specs cache...",
+                "API spec for 'documenten-1.0.1.post1' written.",
+                "API spec for 'zaken-1.0.3' written.",
+                "API spec for 'besluiten-1.0.1.post0' written.",
+            ]
+            self.assertEqual(output, expected_output)
+
+        with self.subTest("stderr output"):
+            err = stderr.getvalue().splitlines()
+            expected_errors = [
+                "Failed populating the API spec cache for 'vrl-4533cc71dcd17e997fce9e31445db852b7540321'.",
+                "Failed populating the API spec cache for 'selectielijst-1.0.0'.",
+                "Failed populating the API spec cache for 'catalogi-1.0.1'.",
+                "Failed populating the API spec cache for 'contactmomenten-2021-09-13'.",
+                "Failed populating the API spec cache for 'verzoeken-2021-06-21'.",
+            ]
+            self.assertEqual(err, expected_errors)

--- a/src/openzaak/tests/test_api_standard.py
+++ b/src/openzaak/tests/test_api_standard.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2022 Dimpact
+import shutil
+from copy import deepcopy
+from pathlib import Path
+
+from django.test import SimpleTestCase, override_settings
+
+import requests_mock
+from vng_api_common.oas import fetcher
+from zgw_consumers.test import mock_service_oas_get, read_schema
+
+from openzaak.api_standards import SPECIFICATIONS, APIStandard
+
+from .utils import ClearCachesMixin
+
+ORIGINAL_SPECIFICATIONS = deepcopy(SPECIFICATIONS)
+
+SCHEMAS = Path(__file__).parent
+CACHE_DIR = SCHEMAS / "cache"
+
+
+def reset_spec_registry():
+    SPECIFICATIONS.clear()
+    SPECIFICATIONS.update(ORIGINAL_SPECIFICATIONS)
+
+
+@override_settings(BASE_DIR=str(SCHEMAS))
+@requests_mock.Mocker()
+class APIStandardTests(ClearCachesMixin, SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        self.addCleanup(reset_spec_registry)
+        self.addCleanup(lambda: shutil.rmtree(CACHE_DIR, ignore_errors=True))
+        self.addCleanup(fetcher.cache.clear)
+
+    def test_aliases_must_be_unique(self, m):
+        # ok
+        APIStandard(alias="empty", oas_url="https://example.com/api/")
+
+        # duplicate - not ok
+        with self.assertRaises(ValueError):
+            APIStandard(alias="empty", oas_url="https://example.com/api/")
+
+    def test_empty_cache_fetch_network(self, m):
+        api_standard = APIStandard(alias="empty", oas_url="https://example.com/api/")
+        mock_service_oas_get(m, url="", service="empty", oas_url=api_standard.oas_url)
+
+        schema = api_standard.schema
+
+        self.assertEqual(
+            schema,
+            {
+                "openapi": "3.0.0",
+                "info": {
+                    "title": "Empty schema for mocking purposes",
+                    "description": "",
+                },
+                "paths": {},
+                "components": {},
+            },
+        )
+
+        with self.subTest("Network call made as fallback"):
+            self.assertEqual(len(m.request_history), 1)
+            self.assertEqual(m.last_request.url, "https://example.com/api/")
+
+        with self.subTest("Network call result is cached on subsequent access"):
+            schema = api_standard.schema
+
+            self.assertEqual(len(m.request_history), 1)
+
+    def test_file_not_read_if_already_present_in_cache(self, m):
+        api_standard = APIStandard(alias="empty", oas_url="https://example.com/api/")
+        mock_service_oas_get(m, url="", service="empty", oas_url=api_standard.oas_url)
+        with self.subTest("initial setup"):
+            schema = api_standard.schema
+            self.assertEqual(len(m.request_history), 1)
+            m.reset()
+
+        # file does not exist
+        schema = api_standard.schema
+
+        self.assertEqual(
+            schema,
+            {
+                "openapi": "3.0.0",
+                "info": {
+                    "title": "Empty schema for mocking purposes",
+                    "description": "",
+                },
+                "paths": {},
+                "components": {},
+            },
+        )
+        self.assertEqual(len(m.request_history), 0)
+
+    def test_file_exists_in_cache(self, m):
+        # create the cache directory and file
+        CACHE_DIR.mkdir(parents=True)
+        schema: bytes = read_schema("empty")
+        (CACHE_DIR / "empty.yaml").write_bytes(schema)
+        api_standard = APIStandard(alias="empty", oas_url="https://example.com/api/")
+
+        schema = api_standard.schema
+
+        self.assertEqual(
+            schema,
+            {
+                "openapi": "3.0.0",
+                "info": {
+                    "title": "Empty schema for mocking purposes",
+                    "description": "",
+                },
+                "paths": {},
+                "components": {},
+            },
+        )
+        self.assertEqual(len(m.request_history), 0)

--- a/src/openzaak/tests/utils/__init__.py
+++ b/src/openzaak/tests/utils/__init__.py
@@ -15,6 +15,7 @@ from .mocks import (
     MockSchemasMixin,
     get_eio_response,
     mock_brc_oas_get,
+    mock_cmc_oas_get,
     mock_drc_oas_get,
     mock_nrc_oas_get,
     mock_vrc_oas_get,
@@ -27,6 +28,7 @@ from .oas import get_spec
 __all__ = [
     # mocks
     "mock_brc_oas_get",
+    "mock_cmc_oas_get",
     "mock_drc_oas_get",
     "mock_zrc_oas_get",
     "mock_ztc_oas_get",

--- a/src/openzaak/tests/utils/__init__.py
+++ b/src/openzaak/tests/utils/__init__.py
@@ -20,6 +20,7 @@ from .mocks import (
     mock_vrc_oas_get,
     mock_zrc_oas_get,
     mock_ztc_oas_get,
+    patch_resource_validator,
 )
 from .oas import get_spec
 
@@ -33,6 +34,7 @@ __all__ = [
     "mock_nrc_oas_get",
     "MockSchemasMixin",
     "get_eio_response",
+    "patch_resource_validator",
     # auth
     "JWTAuthMixin",
     "generate_jwt_auth",

--- a/src/openzaak/tests/utils/mocks.py
+++ b/src/openzaak/tests/utils/mocks.py
@@ -14,7 +14,10 @@ mock_brc_oas_get = partial(
     mock_service_oas_get, url="", service="brc", oas_url=settings.BRC_API_SPEC
 )
 mock_drc_oas_get = partial(
-    mock_service_oas_get, url="", service="drc", oas_url=settings.DRC_API_SPEC
+    mock_service_oas_get,
+    url="",
+    service="drc",
+    oas_url=settings.DRC_API_STANDARD.oas_url,
 )
 mock_zrc_oas_get = partial(
     mock_service_oas_get, url="", service="zrc", oas_url=settings.ZRC_API_SPEC

--- a/src/openzaak/tests/utils/mocks.py
+++ b/src/openzaak/tests/utils/mocks.py
@@ -20,7 +20,10 @@ mock_zrc_oas_get = partial(
     mock_service_oas_get, url="", service="zrc", oas_url=settings.ZRC_API_SPEC
 )
 mock_ztc_oas_get = partial(
-    mock_service_oas_get, url="", service="ztc", oas_url=settings.ZTC_API_SPEC
+    mock_service_oas_get,
+    url="",
+    service="ztc",
+    oas_url=settings.ZTC_API_STANDARD.oas_url,
 )
 mock_vrc_oas_get = partial(
     mock_service_oas_get, url="", service="vrc", oas_url=settings.VRC_API_SPEC

--- a/src/openzaak/tests/utils/mocks.py
+++ b/src/openzaak/tests/utils/mocks.py
@@ -35,7 +35,10 @@ mock_ztc_oas_get = partial(
     oas_url=settings.ZTC_API_STANDARD.oas_url,
 )
 mock_vrc_oas_get = partial(
-    mock_service_oas_get, url="", service="vrc", oas_url=settings.VRC_API_SPEC
+    mock_service_oas_get,
+    url="",
+    service="vrc",
+    oas_url=settings.VRC_API_STANDARD.oas_url,
 )
 
 

--- a/src/openzaak/tests/utils/mocks.py
+++ b/src/openzaak/tests/utils/mocks.py
@@ -20,7 +20,10 @@ mock_drc_oas_get = partial(
     oas_url=settings.DRC_API_STANDARD.oas_url,
 )
 mock_zrc_oas_get = partial(
-    mock_service_oas_get, url="", service="zrc", oas_url=settings.ZRC_API_SPEC
+    mock_service_oas_get,
+    url="",
+    service="zrc",
+    oas_url=settings.ZRC_API_STANDARD.oas_url,
 )
 mock_ztc_oas_get = partial(
     mock_service_oas_get,

--- a/src/openzaak/tests/utils/mocks.py
+++ b/src/openzaak/tests/utils/mocks.py
@@ -11,7 +11,10 @@ from requests_mock import Mocker
 from zgw_consumers.test import mock_service_oas_get
 
 mock_brc_oas_get = partial(
-    mock_service_oas_get, url="", service="brc", oas_url=settings.BRC_API_SPEC
+    mock_service_oas_get,
+    url="",
+    service="brc",
+    oas_url=settings.BRC_API_STANDARD.oas_url,
 )
 mock_drc_oas_get = partial(
     mock_service_oas_get,

--- a/src/openzaak/tests/utils/mocks.py
+++ b/src/openzaak/tests/utils/mocks.py
@@ -41,6 +41,12 @@ mock_vrc_oas_get = partial(
     service="vrc",
     oas_url=settings.VRC_API_STANDARD.oas_url,
 )
+mock_cmc_oas_get = partial(
+    mock_service_oas_get,
+    url="",
+    service="contactmomenten",
+    oas_url=settings.CMC_API_STANDARD.oas_url,
+)
 
 
 def mock_nrc_oas_get(m: Mocker) -> None:

--- a/src/openzaak/tests/utils/mocks.py
+++ b/src/openzaak/tests/utils/mocks.py
@@ -3,6 +3,7 @@
 import uuid
 from datetime import date
 from functools import partial
+from unittest.mock import patch
 
 from django.conf import settings
 from django.utils import timezone
@@ -101,3 +102,9 @@ def get_eio_response(url, **overrides):
         eio["informatieobjecttype"] = overrides.get("_informatieobjecttype_url")
 
     return eio
+
+
+def patch_resource_validator(func):
+    patch1 = patch("openzaak.utils.validators.ResourceValidatorMixin._resolve_schema")
+    patch2 = patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    return patch1(patch2(func))

--- a/src/openzaak/utils/validators.py
+++ b/src/openzaak/utils/validators.py
@@ -2,7 +2,6 @@
 # Copyright (C) 2019 - 2020 Dimpact
 import json
 import logging
-from typing import Union
 from urllib.parse import urlparse
 
 from django.conf import settings
@@ -14,7 +13,7 @@ from rest_framework.utils.representation import smart_repr
 from rest_framework.validators import (
     UniqueTogetherValidator as _UniqueTogetherValidator,
 )
-from vng_api_common.oas import fetcher, obj_has_shape
+from vng_api_common.oas import obj_has_shape
 from vng_api_common.utils import get_resource_for_path, get_uuid_from_path
 from vng_api_common.validators import IsImmutableValidator, URLValidator
 
@@ -113,19 +112,13 @@ class LooseFkIsImmutableValidator(FKOrServiceUrlValidator):
 
 
 class ResourceValidatorMixin:
-    def __init__(
-        self, resource: str, api_standard: Union[str, APIStandard], *args, **kwargs
-    ):
+    def __init__(self, resource: str, api_standard: APIStandard, *args, **kwargs):
         self.resource = resource
         self.api_standard = api_standard
         super().__init__(*args, **kwargs)
 
     def _resolve_schema(self) -> dict:
-        if isinstance(self.api_standard, str):
-            schema = fetcher.fetch(self.api_standard)
-        else:
-            schema = self.api_standard.download_schema(fetcher.fetch)
-        return schema
+        return self.api_standard.schema
 
 
 class LooseFkResourceValidator(ResourceValidatorMixin, FKOrServiceUrlValidator):


### PR DESCRIPTION
Fixes #621
Fixes #644 

**Changes**

* Uses OOP approach to pointing to API Standards (and their specs)
* Resource validators now understand these `APIStandard` instances and fetch the schema from them
* `APIStandard` prefers the local cache, then the filesystem cache and finally hits the network to obtain the API specs
* Docker image build warms the cache by downloading these specs at build-time and bakes them into the docker image

