### PR TITLE
:arrow_up: [#1374] Bump commonground-api-common to 1.10.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -56,7 +56,7 @@ click-repl==0.2.0
     # via celery
 cmislib-maykin==0.7.4
     # via drc-cmis
-commonground-api-common==1.10.1
+commonground-api-common==1.10.2
     # via
     #   -r requirements/base.in
     #   drc-cmis
@@ -250,7 +250,7 @@ mozilla-django-oidc==2.0.0
     # via mozilla-django-oidc-db
 mozilla-django-oidc-db==0.11.0
     # via -r requirements/base.in
-notifications-api-common==0.2.1
+notifications-api-common==0.2.2
     # via
     #   -r requirements/base.in
     #   commonground-api-common

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -89,7 +89,7 @@ cmislib-maykin==0.7.4
     # via
     #   -r requirements/base.txt
     #   drc-cmis
-commonground-api-common==1.10.1
+commonground-api-common==1.10.2
     # via
     #   -r requirements/base.txt
     #   drc-cmis
@@ -351,7 +351,7 @@ mozilla-django-oidc==2.0.0
     #   mozilla-django-oidc-db
 mozilla-django-oidc-db==0.11.0
     # via -r requirements/base.txt
-notifications-api-common==0.2.1
+notifications-api-common==0.2.2
     # via
     #   -r requirements/base.txt
     #   commonground-api-common

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -106,7 +106,7 @@ cmislib-maykin==0.7.4
     # via
     #   -r requirements/ci.txt
     #   drc-cmis
-commonground-api-common==1.10.1
+commonground-api-common==1.10.2
     # via
     #   -r requirements/ci.txt
     #   drc-cmis
@@ -411,7 +411,7 @@ mozilla-django-oidc==2.0.0
     #   mozilla-django-oidc-db
 mozilla-django-oidc-db==0.11.0
     # via -r requirements/ci.txt
-notifications-api-common==0.2.1
+notifications-api-common==0.2.2
     # via
     #   -r requirements/ci.txt
     #   commonground-api-common


### PR DESCRIPTION
Fixes #1374 

**Changes**

* Bump commonground-api-common to 1.10.2 to benefit from improved identificatie generation

