### PR TITLE
[#1354] Ensuring OIO 'verzoek' field can be left empty via the Open Z…

### DIFF
--- a/src/openzaak/components/documenten/models.py
+++ b/src/openzaak/components/documenten/models.py
@@ -785,7 +785,7 @@ class ObjectInformatieObject(CMISETagMixin, models.Model, CMISClientMixin):
         source_field=_object_url,
         allow_write_when=lambda instance: instance.object_type
         == ObjectInformatieObjectTypes.verzoek,
-        blank=True
+        blank=True,
     )
 
     _zaak = models.ForeignKey(

--- a/src/openzaak/components/documenten/models.py
+++ b/src/openzaak/components/documenten/models.py
@@ -785,6 +785,7 @@ class ObjectInformatieObject(CMISETagMixin, models.Model, CMISClientMixin):
         source_field=_object_url,
         allow_write_when=lambda instance: instance.object_type
         == ObjectInformatieObjectTypes.verzoek,
+        blank=True
     )
 
     _zaak = models.ForeignKey(


### PR DESCRIPTION
…aak admin

Fixes #1354 

**Changes**

![image](https://user-images.githubusercontent.com/226839/235922820-5e0f0f74-11c5-4f70-a4bc-dea686badd5a.png)

