### PR TITLE
:green_heart: Use https for referentielijsten in postman tests

### DIFF
--- a/fixtures/fixture.json
+++ b/fixtures/fixture.json
@@ -82,7 +82,7 @@
         "fields":{
             "label":"referentielijsten",
             "api_type":"orc",
-            "api_root":"http://referentielijsten-api.vng.cloud/api/v1/",
+            "api_root":"https://referentielijsten-api.vng.cloud/api/v1/",
             "client_id": "",
             "secret":"",
             "auth_type": "no_auth",


### PR DESCRIPTION
this used to be http, because the new referentielijsten API implementation returned all urls with http, causing issues when trying to fetch a Service for one of those urls (see https://github.com/open-zaak/open-zaak/pull/1378#issuecomment-1538024216). This is now fixed and no longer needed

https://github.com/open-zaak/open-zaak/issues/1359

