### PR TITLE
:heavy_plus_sign: Add factory-boy for generate_data command

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -52,3 +52,6 @@ uwsgi
 sentry_sdk # error monitoring sentry
 flower # task monitoring
 elastic-apm  # Elastic APM integration
+
+# Required for generate_data command
+factory-boy

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -197,8 +197,12 @@ elastic-apm==6.13.2
     # via -r requirements/base.in
 face==20.1.1
     # via glom
+factory-boy==3.2.1
+    # via -r requirements/base.in
 faker==13.3.2
-    # via zgw-consumers
+    # via
+    #   factory-boy
+    #   zgw-consumers
 flower==1.2.0
     # via -r requirements/base.in
 furl==2.1.3

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -256,7 +256,9 @@ face==20.1.1
     #   -r requirements/base.txt
     #   glom
 factory-boy==3.2.1
-    # via -r requirements/test-tools.in
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/test-tools.in
 faker==13.3.2
     # via
     #   -r requirements/base.txt

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -16,6 +16,10 @@ recommonmark
 sphinx-markdown-tables
 sphinx-tabs
 
+# Required for generate_data command
+# Has to be added explicitly to pass CI requirements_check
+factory-boy
+
 # Deployment
 
 -r ../deployment/requirements.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -291,7 +291,9 @@ face==20.1.1
     #   -r requirements/ci.txt
     #   glom
 factory-boy==3.2.1
-    # via -r requirements/ci.txt
+    # via
+    #   -r requirements/ci.txt
+    #   -r requirements/dev.in
 faker==13.3.2
     # via
     #   -r requirements/ci.txt


### PR DESCRIPTION
This library was only included in the dev/ci requirements, which makes it impossible to run currently via Docker.

I think the library should be included in the base requirements, so it can be used in dockerized/k8s environments as well (@sjoerdie is trying to run this command for DH)