### PR TITLE
Gemeente den haag feature/zaken rol identificaties filters

### DIFF
--- a/src/openzaak/components/zaken/api/filters.py
+++ b/src/openzaak/components/zaken/api/filters.py
@@ -41,6 +41,38 @@ class ZaakFilter(FilterSet):
             "zaken.NatuurlijkPersoon", "inp_bsn", "max_length"
         ),
     )
+    rol__betrokkene_identificatie__natuurlijk_persoon__anp_identificatie = filters.CharFilter(
+        field_name="rol__natuurlijkpersoon__anp_identificatie",
+        help_text=get_help_text("zaken.NatuurlijkPersoon", "anp_identificatie"),
+        max_length=get_field_attribute(
+            "zaken.NatuurlijkPersoon", "anp_identificatie", "max_length"
+        ),
+    )
+    rol__betrokkene_identificatie__natuurlijk_persoon__inp_a_nummer = filters.CharFilter(
+        field_name="rol__natuurlijkpersoon__inp_a_nummer",
+        help_text=get_help_text("zaken.NatuurlijkPersoon", "inp_a_nummer"),
+        max_length=get_field_attribute(
+            "zaken.NatuurlijkPersoon", "inp_a_nummer", "max_length"
+        ),
+    )
+    rol__betrokkene_identificatie__niet_natuurlijk_persoon__inn_nnp_id = filters.CharFilter(
+        field_name="rol__nietnatuurlijkpersoon__inn_nnp_id",
+        help_text=get_help_text("zaken.NietNatuurlijkPersoon", "inn_nnp_id"),
+    )
+    rol__betrokkene_identificatie__niet_natuurlijk_persoon__ann_identificatie = filters.CharFilter(
+        field_name="rol__nietnatuurlijkpersoon__ann_identificatie",
+        help_text=get_help_text("zaken.NietNatuurlijkPersoon", "ann_identificatie"),
+        max_length=get_field_attribute(
+            "zaken.NietNatuurlijkPersoon", "ann_identificatie", "max_length"
+        ),
+    )
+    rol__betrokkene_identificatie__vestiging__vestigings_nummer = filters.CharFilter(
+        field_name="rol__vestiging__vestigings_nummer",
+        help_text=get_help_text("zaken.Vestiging", "vestigings_nummer"),
+        max_length=get_field_attribute(
+            "zaken.Vestiging", "vestigings_nummer", "max_length"
+        ),
+    )
     rol__betrokkene_identificatie__medewerker__identificatie = filters.CharFilter(
         field_name="rol__medewerker__identificatie",
         help_text=get_help_text("zaken.Medewerker", "identificatie"),

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -2899,6 +2899,43 @@ paths:
         schema:
           type: string
           maxLength: 9
+      - name: rol__betrokkeneIdentificatie__natuurlijkPersoon__anpIdentificatie
+        in: query
+        description: Het door de gemeente uitgegeven unieke nummer voor een ANDER
+          NATUURLIJK PERSOON
+        required: false
+        schema:
+          type: string
+          maxLength: 17
+      - name: rol__betrokkeneIdentificatie__natuurlijkPersoon__inpA_nummer
+        in: query
+        description: Het administratienummer van de persoon, bedoeld in de Wet BRP
+        required: false
+        schema:
+          type: string
+          maxLength: 10
+      - name: rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__innNnpId
+        in: query
+        description: Het door een kamer toegekend uniek nummer voor de INGESCHREVEN
+          NIET-NATUURLIJK PERSOON
+        required: false
+        schema:
+          type: string
+      - name: rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie
+        in: query
+        description: Het door de gemeente uitgegeven unieke nummer voor een ANDER
+          NIET-NATUURLIJK PERSOON
+        required: false
+        schema:
+          type: string
+          maxLength: 17
+      - name: rol__betrokkeneIdentificatie__vestiging__vestigingsNummer
+        in: query
+        description: Een korte unieke aanduiding van de Vestiging.
+        required: false
+        schema:
+          type: string
+          maxLength: 24
       - name: rol__betrokkeneIdentificatie__medewerker__identificatie
         in: query
         description: Een korte unieke aanduiding van de MEDEWERKER.
@@ -7339,6 +7376,34 @@ components:
           title: Rol  betrokkeneidentificatie  natuurlijkpersoon  inpbsn
           description: Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet
             algemene bepalingen burgerservicenummer.
+          type: string
+          minLength: 1
+        rol__betrokkeneIdentificatie__natuurlijkPersoon__anpIdentificatie:
+          title: Rol  betrokkeneidentificatie  natuurlijkpersoon  anpidentificatie
+          description: Het door de gemeente uitgegeven unieke nummer voor een ANDER
+            NATUURLIJK PERSOON
+          type: string
+          minLength: 1
+        rol__betrokkeneIdentificatie__natuurlijkPersoon__inpA_nummer:
+          title: Rol  betrokkeneidentificatie  natuurlijkpersoon  inpa nummer
+          description: Het administratienummer van de persoon, bedoeld in de Wet BRP
+          type: string
+          minLength: 1
+        rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__innNnpId:
+          title: Rol  betrokkeneidentificatie  nietnatuurlijkpersoon  innnnpid
+          description: Het door een kamer toegekend uniek nummer voor de INGESCHREVEN
+            NIET-NATUURLIJK PERSOON
+          type: string
+          minLength: 1
+        rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie:
+          title: Rol  betrokkeneidentificatie  nietnatuurlijkpersoon  annidentificatie
+          description: Het door de gemeente uitgegeven unieke nummer voor een ANDER
+            NIET-NATUURLIJK PERSOON
+          type: string
+          minLength: 1
+        rol__betrokkeneIdentificatie__vestiging__vestigingsNummer:
+          title: Rol  betrokkeneidentificatie  vestiging  vestigingsnummer
+          description: Een korte unieke aanduiding van de Vestiging.
           type: string
           minLength: 1
         rol__betrokkeneIdentificatie__medewerker__identificatie:

--- a/src/openzaak/components/zaken/swagger2.0.json
+++ b/src/openzaak/components/zaken/swagger2.0.json
@@ -3916,6 +3916,45 @@
                         "maxLength": 9
                     },
                     {
+                        "name": "rol__betrokkeneIdentificatie__natuurlijkPersoon__anpIdentificatie",
+                        "in": "query",
+                        "description": "Het door de gemeente uitgegeven unieke nummer voor een ANDER NATUURLIJK PERSOON",
+                        "required": false,
+                        "type": "string",
+                        "maxLength": 17
+                    },
+                    {
+                        "name": "rol__betrokkeneIdentificatie__natuurlijkPersoon__inpA_nummer",
+                        "in": "query",
+                        "description": "Het administratienummer van de persoon, bedoeld in de Wet BRP",
+                        "required": false,
+                        "type": "string",
+                        "maxLength": 10
+                    },
+                    {
+                        "name": "rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__innNnpId",
+                        "in": "query",
+                        "description": "Het door een kamer toegekend uniek nummer voor de INGESCHREVEN NIET-NATUURLIJK PERSOON",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie",
+                        "in": "query",
+                        "description": "Het door de gemeente uitgegeven unieke nummer voor een ANDER NIET-NATUURLIJK PERSOON",
+                        "required": false,
+                        "type": "string",
+                        "maxLength": 17
+                    },
+                    {
+                        "name": "rol__betrokkeneIdentificatie__vestiging__vestigingsNummer",
+                        "in": "query",
+                        "description": "Een korte unieke aanduiding van de Vestiging.",
+                        "required": false,
+                        "type": "string",
+                        "maxLength": 24
+                    },
+                    {
                         "name": "rol__betrokkeneIdentificatie__medewerker__identificatie",
                         "in": "query",
                         "description": "Een korte unieke aanduiding van de MEDEWERKER.",
@@ -9027,6 +9066,36 @@
                 "rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn": {
                     "title": "Rol  betrokkeneidentificatie  natuurlijkpersoon  inpbsn",
                     "description": "Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet algemene bepalingen burgerservicenummer.",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "rol__betrokkeneIdentificatie__natuurlijkPersoon__anpIdentificatie": {
+                    "title": "Rol  betrokkeneidentificatie  natuurlijkpersoon  anpidentificatie",
+                    "description": "Het door de gemeente uitgegeven unieke nummer voor een ANDER NATUURLIJK PERSOON",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "rol__betrokkeneIdentificatie__natuurlijkPersoon__inpA_nummer": {
+                    "title": "Rol  betrokkeneidentificatie  natuurlijkpersoon  inpa nummer",
+                    "description": "Het administratienummer van de persoon, bedoeld in de Wet BRP",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__innNnpId": {
+                    "title": "Rol  betrokkeneidentificatie  nietnatuurlijkpersoon  innnnpid",
+                    "description": "Het door een kamer toegekend uniek nummer voor de INGESCHREVEN NIET-NATUURLIJK PERSOON",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie": {
+                    "title": "Rol  betrokkeneidentificatie  nietnatuurlijkpersoon  annidentificatie",
+                    "description": "Het door de gemeente uitgegeven unieke nummer voor een ANDER NIET-NATUURLIJK PERSOON",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "rol__betrokkeneIdentificatie__vestiging__vestigingsNummer": {
+                    "title": "Rol  betrokkeneidentificatie  vestiging  vestigingsnummer",
+                    "description": "Een korte unieke aanduiding van de Vestiging.",
                     "type": "string",
                     "minLength": 1
                 },

--- a/src/openzaak/components/zaken/tests/test_zaken.py
+++ b/src/openzaak/components/zaken/tests/test_zaken.py
@@ -39,7 +39,14 @@ from ..api.scopes import (
     SCOPEN_ZAKEN_HEROPENEN,
 )
 from ..constants import BetalingsIndicatie
-from ..models import Medewerker, NatuurlijkPersoon, OrganisatorischeEenheid, Zaak
+from ..models import (
+    Medewerker,
+    NatuurlijkPersoon,
+    NietNatuurlijkPersoon,
+    OrganisatorischeEenheid,
+    Vestiging,
+    Zaak,
+)
 from .constants import POLYGON_AMSTERDAM_CENTRUM
 from .factories import ResultaatFactory, RolFactory, StatusFactory, ZaakFactory
 from .utils import (
@@ -573,6 +580,168 @@ class ZakenTests(JWTAuthMixin, APITestCase):
         self.assertEqual(
             response.json()["verlenging"], {"reden": "Een reden", "duur": "P5D"}
         )
+
+
+class ZakenFilterTests(JWTAuthMixin, APITestCase):
+    heeft_alle_autorisaties = True
+
+    def test_rol_nnp_id(self):
+        url = reverse(Zaak)
+        rol = RolFactory.create(
+            betrokkene_type=RolTypes.niet_natuurlijk_persoon,
+            omschrijving_generiek=RolOmschrijving.initiator,
+        )
+        NietNatuurlijkPersoon.objects.create(rol=rol, inn_nnp_id="129117729")
+
+        with self.subTest(expected="no-match"):
+            response = self.client.get(
+                url,
+                {
+                    "rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__innNnpId": "000000000"
+                },
+                **ZAAK_READ_KWARGS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 0)
+
+        with self.subTest(expected="match"):
+            response = self.client.get(
+                url,
+                {
+                    "rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__innNnpId": "129117729"
+                },
+                **ZAAK_READ_KWARGS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 1)
+
+    def test_rol_nnp_ann_identificatie(self):
+        url = reverse(Zaak)
+        rol = RolFactory.create(
+            betrokkene_type=RolTypes.niet_natuurlijk_persoon,
+            omschrijving_generiek=RolOmschrijving.initiator,
+        )
+        NietNatuurlijkPersoon.objects.create(rol=rol, ann_identificatie="12345")
+
+        with self.subTest(expected="no-match"):
+            response = self.client.get(
+                url,
+                {
+                    "rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie": "000000000"
+                },
+                **ZAAK_READ_KWARGS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 0)
+
+        with self.subTest(expected="match"):
+            response = self.client.get(
+                url,
+                {
+                    "rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie": "12345"
+                },
+                **ZAAK_READ_KWARGS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 1)
+
+    def test_rol_np_anp_identificatie(self):
+        url = reverse(Zaak)
+        rol = RolFactory.create(
+            betrokkene_type=RolTypes.natuurlijk_persoon,
+            omschrijving_generiek=RolOmschrijving.initiator,
+        )
+        NatuurlijkPersoon.objects.create(rol=rol, anp_identificatie="12345")
+
+        with self.subTest(expected="no-match"):
+            response = self.client.get(
+                url,
+                {
+                    "rol__betrokkeneIdentificatie__natuurlijkPersoon__anpIdentificatie": "000000000"
+                },
+                **ZAAK_READ_KWARGS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 0)
+
+        with self.subTest(expected="match"):
+            response = self.client.get(
+                url,
+                {
+                    "rol__betrokkeneIdentificatie__natuurlijkPersoon__anpIdentificatie": "12345"
+                },
+                **ZAAK_READ_KWARGS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 1)
+
+    def test_rol_np_inp_a_nummer(self):
+        url = reverse(Zaak)
+        rol = RolFactory.create(
+            betrokkene_type=RolTypes.natuurlijk_persoon,
+            omschrijving_generiek=RolOmschrijving.initiator,
+        )
+        NatuurlijkPersoon.objects.create(rol=rol, inp_a_nummer="12345")
+
+        with self.subTest(expected="no-match"):
+            response = self.client.get(
+                url,
+                {
+                    "rol__betrokkeneIdentificatie__natuurlijkPersoon__inpA_nummer": "000000000"
+                },
+                **ZAAK_READ_KWARGS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 0)
+
+        with self.subTest(expected="match"):
+            response = self.client.get(
+                url,
+                {
+                    "rol__betrokkeneIdentificatie__natuurlijkPersoon__inpA_nummer": "12345"
+                },
+                **ZAAK_READ_KWARGS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 1)
+
+    def test_rol_vestiging_vestigings_nummer(self):
+        url = reverse(Zaak)
+        rol = RolFactory.create(
+            betrokkene_type=RolTypes.vestiging,
+            omschrijving_generiek=RolOmschrijving.initiator,
+        )
+        Vestiging.objects.create(rol=rol, vestigings_nummer="12345")
+
+        with self.subTest(expected="no-match"):
+            response = self.client.get(
+                url,
+                {
+                    "rol__betrokkeneIdentificatie__vestiging__vestigingsNummer": "000000000"
+                },
+                **ZAAK_READ_KWARGS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 0)
+
+        with self.subTest(expected="match"):
+            response = self.client.get(
+                url,
+                {"rol__betrokkeneIdentificatie__vestiging__vestigingsNummer": "12345"},
+                **ZAAK_READ_KWARGS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["count"], 1)
 
 
 class ZaakArchivingTests(JWTAuthMixin, APITestCase):


### PR DESCRIPTION
Fixes #1075

This PR was created to replace #1076 PR since the previous PR was made in the fork and can't be rebased 

PR in upstream has been merged: https://github.com/VNG-Realisatie/zaken-api/pull/208

**Changes**
* Added five extra filters for Zaken endpoint:
  * rol__betrokkeneIdentificatie__natuurlijkPersoon__anpIdentificatie
  * rol__betrokkeneIdentificatie__natuurlijkPersoon__inpA_nummer
  * rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__innNnpId
  * rol__betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie
  * rol__betrokkeneIdentificatie__vestiging__vestigingsNummer
