### PR TITLE
:sparkles:[#1531] Add ability to import zaaktype under different iden…

### DIFF
--- a/src/openzaak/components/catalogi/admin/admin_views.py
+++ b/src/openzaak/components/catalogi/admin/admin_views.py
@@ -40,7 +40,9 @@ class CatalogusZaakTypeImportUploadView(
             import_file = form.cleaned_data["file"]
             request.session["file_content"] = import_file.read()
 
-            request.session["identificatie"] = request.POST.get("identificatie")
+            request.session["identificatie_prefix"] = request.POST.get(
+                "identificatie_prefix"
+            )
 
             iotypen = retrieve_iotypen(catalogus_pk, request.session["file_content"])
             request.session["iotypen"] = (
@@ -67,7 +69,7 @@ class CatalogusZaakTypeImportUploadView(
                 try:
                     with transaction.atomic():
                         import_zaaktype_for_catalogus(
-                            request.session["identificatie"],
+                            request.session["identificatie_prefix"],
                             catalogus_pk,
                             request.session["file_content"],
                             {},
@@ -201,7 +203,7 @@ class CatalogusZaakTypeImportSelectView(
                         )
 
                 import_zaaktype_for_catalogus(
-                    request.session["identificatie"],
+                    request.session["identificatie_prefix"],
                     kwargs["catalogus_pk"],
                     request.session["file_content"],
                     iotypen_uuid_mapping,

--- a/src/openzaak/components/catalogi/admin/admin_views.py
+++ b/src/openzaak/components/catalogi/admin/admin_views.py
@@ -40,6 +40,8 @@ class CatalogusZaakTypeImportUploadView(
             import_file = form.cleaned_data["file"]
             request.session["file_content"] = import_file.read()
 
+            request.session["identificatie"] = request.POST.get("identificatie")
+
             iotypen = retrieve_iotypen(catalogus_pk, request.session["file_content"])
             request.session["iotypen"] = (
                 sorted(iotypen, key=lambda x: x["omschrijving"]) if iotypen else iotypen
@@ -65,7 +67,11 @@ class CatalogusZaakTypeImportUploadView(
                 try:
                     with transaction.atomic():
                         import_zaaktype_for_catalogus(
-                            catalogus_pk, request.session["file_content"], {}, {}
+                            request.session["identificatie"],
+                            catalogus_pk,
+                            request.session["file_content"],
+                            {},
+                            {},
                         )
 
                     messages.add_message(
@@ -195,6 +201,7 @@ class CatalogusZaakTypeImportSelectView(
                         )
 
                 import_zaaktype_for_catalogus(
+                    request.session["identificatie"],
                     kwargs["catalogus_pk"],
                     request.session["file_content"],
                     iotypen_uuid_mapping,

--- a/src/openzaak/components/catalogi/admin/admin_views.py
+++ b/src/openzaak/components/catalogi/admin/admin_views.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2019 - 2020 Dimpact
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.core.exceptions import ValidationError
 from django.core.management import CommandError
 from django.db import transaction
 from django.db.utils import IntegrityError
@@ -214,7 +215,7 @@ class CatalogusZaakTypeImportSelectView(
                 request, messages.SUCCESS, _("ZaakType successfully imported")
             )
             return HttpResponseRedirect(reverse("admin:catalogi_catalogus_changelist"))
-        except (CommandError, IntegrityError) as exc:
+        except (CommandError, IntegrityError, ValidationError) as exc:
             messages.add_message(request, messages.ERROR, exc)
 
         return TemplateResponse(request, self.template_name, context)

--- a/src/openzaak/components/catalogi/admin/forms.py
+++ b/src/openzaak/components/catalogi/admin/forms.py
@@ -487,10 +487,10 @@ class CatalogusImportForm(forms.Form):
 
 class ZaakTypeImportForm(forms.Form):
 
-    identificatie = forms.CharField(
-        label=_("identificatie"),
+    identificatie_prefix = forms.CharField(
+        label=_("identificatie prefix"),
         required=False,
-        help_text=_("Zaaktype name. Leave blank to use imported."),
+        help_text=_("Zaaktype identification prefix. Leave blank to use imported."),
         validators=[alphanumeric_excluding_diacritic,],
     )
 

--- a/src/openzaak/components/catalogi/admin/forms.py
+++ b/src/openzaak/components/catalogi/admin/forms.py
@@ -18,6 +18,7 @@ from vng_api_common.constants import (
     BrondatumArchiefprocedureAfleidingswijze as Afleidingswijze,
 )
 from vng_api_common.tests import reverse as _reverse
+from vng_api_common.validators import alphanumeric_excluding_diacritic
 from zds_client import ClientError
 from zgw_consumers.models import Service
 
@@ -485,6 +486,14 @@ class CatalogusImportForm(forms.Form):
 
 
 class ZaakTypeImportForm(forms.Form):
+
+    identificatie = forms.CharField(
+        label=_("identificatie"),
+        required=False,
+        help_text=_("Zaaktype name. Leave blank to use imported."),
+        validators=[alphanumeric_excluding_diacritic,],
+    )
+
     file = forms.FileField(
         label=_("bestand"),
         required=True,

--- a/src/openzaak/components/catalogi/admin/utils.py
+++ b/src/openzaak/components/catalogi/admin/utils.py
@@ -164,7 +164,7 @@ def construct_besluittypen(
 
 @requests_cache_enabled("import", backend=DjangoRequestsCache())
 def import_zaaktype_for_catalogus(
-    identificatie,
+    identificatie_prefix,
     catalogus_pk,
     import_file_content,
     iotypen_uuid_mapping,
@@ -205,7 +205,10 @@ def import_zaaktype_for_catalogus(
 
                 for entry in data:
                     if resource == "ZaakType":
-                        entry["identificatie"] = identificatie or entry["identificatie"]
+                        if identificatie_prefix:
+                            entry[
+                                "identificatie"
+                            ] = f"{identificatie_prefix}_{entry['identificatie']}"
                         entry["informatieobjecttypen"] = []
                         old_catalogus_uuid = entry["catalogus"].split("/")[-1]
                         entry["catalogus"] = entry["catalogus"].replace(

--- a/src/openzaak/components/catalogi/admin/utils.py
+++ b/src/openzaak/components/catalogi/admin/utils.py
@@ -164,7 +164,11 @@ def construct_besluittypen(
 
 @requests_cache_enabled("import", backend=DjangoRequestsCache())
 def import_zaaktype_for_catalogus(
-    catalogus_pk, import_file_content, iotypen_uuid_mapping, besluittypen_uuid_mapping
+    identificatie,
+    catalogus_pk,
+    import_file_content,
+    iotypen_uuid_mapping,
+    besluittypen_uuid_mapping,
 ):
     catalogus = Catalogus.objects.get(pk=catalogus_pk)
     catalogus_uuid = str(catalogus.uuid)
@@ -201,6 +205,7 @@ def import_zaaktype_for_catalogus(
 
                 for entry in data:
                     if resource == "ZaakType":
+                        entry["identificatie"] = identificatie or entry["identificatie"]
                         entry["informatieobjecttypen"] = []
                         old_catalogus_uuid = entry["catalogus"].split("/")[-1]
                         entry["catalogus"] = entry["catalogus"].replace(

--- a/src/openzaak/components/catalogi/admin/utils.py
+++ b/src/openzaak/components/catalogi/admin/utils.py
@@ -4,6 +4,7 @@ import io
 import json
 import zipfile
 
+from django.core.exceptions import ValidationError
 from django.core.management import CommandError
 from django.utils.translation import ngettext, ugettext_lazy as _
 
@@ -206,9 +207,20 @@ def import_zaaktype_for_catalogus(
                 for entry in data:
                     if resource == "ZaakType":
                         if identificatie_prefix:
-                            entry[
-                                "identificatie"
-                            ] = f"{identificatie_prefix}_{entry['identificatie']}"[:50]
+
+                            new_identification = (
+                                f"{identificatie_prefix}_{entry['identificatie']}"
+                            )
+
+                            if len(new_identification) > 50:
+                                raise ValidationError(
+                                    _(
+                                        "Identification {} is too long with prefix. Max 50 characters."
+                                    ).format(new_identification)
+                                )
+
+                            entry["identificatie"] = new_identification
+
                         entry["informatieobjecttypen"] = []
                         old_catalogus_uuid = entry["catalogus"].split("/")[-1]
                         entry["catalogus"] = entry["catalogus"].replace(

--- a/src/openzaak/components/catalogi/admin/utils.py
+++ b/src/openzaak/components/catalogi/admin/utils.py
@@ -208,7 +208,7 @@ def import_zaaktype_for_catalogus(
                         if identificatie_prefix:
                             entry[
                                 "identificatie"
-                            ] = f"{identificatie_prefix}_{entry['identificatie']}"
+                            ] = f"{identificatie_prefix}_{entry['identificatie']}"[:50]
                         entry["informatieobjecttypen"] = []
                         old_catalogus_uuid = entry["catalogus"].split("/")[-1]
                         entry["catalogus"] = entry["catalogus"].replace(

--- a/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
@@ -1424,7 +1424,7 @@ class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
             "test.zip",
             f.read(),
         )
-        form["identificatie"] = ""
+        form["identificatie_prefix"] = ""
 
         zaaktype.delete()
         self.assertFalse(ZaakType.objects.filter(identificatie="ZAAKTYPE_1").exists())
@@ -1494,14 +1494,16 @@ class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
             "test.zip",
             f.read(),
         )
-        form["identificatie"] = "ZAAKTYPE_2"
+        form["identificatie_prefix"] = "PREFIX"
         response = form.submit("_import_zaaktype").follow()
 
         response = response.form.submit("_select")
         # succeeds as it is imported under a different name
         self.assertEqual(response.status_code, 302)
         self.assertEqual(ZaakType.objects.all().count(), 2)
-        self.assertTrue(ZaakType.objects.filter(identificatie="ZAAKTYPE_2").exists())
+        self.assertTrue(
+            ZaakType.objects.filter(identificatie="PREFIX_ZAAKTYPE_1").exists()
+        )
 
 
 @patch(

--- a/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
@@ -1379,6 +1379,74 @@ class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
 
         self.assertEqual(response.status_code, 302)
 
+    def test_import_zaaktype_with_different_name(self, *mocks):
+        catalogus = CatalogusFactory.create(rsin="000000000", domein="TEST")
+        zaaktype = ZaakTypeFactory.create(
+            catalogus=catalogus,
+            identificatie="ZAAKTYPE_1",
+            vertrouwelijkheidaanduiding="openbaar",
+            zaaktype_omschrijving="bla",
+            datum_begin_geldigheid="2023-01-01",
+        )
+
+        InformatieObjectTypeFactory.create(
+            catalogus=catalogus,
+            vertrouwelijkheidaanduiding="openbaar",
+            omschrijving="Alpha",
+            zaaktypen__zaaktype=zaaktype,
+            datum_begin_geldigheid="2023-01-01",
+            datum_einde_geldigheid="2023-03-31",
+        )
+
+        BesluitTypeFactory.create(
+            catalogus=catalogus,
+            omschrijving="Apple",
+            zaaktypen=[zaaktype],
+            datum_begin_geldigheid="2023-01-01",
+            datum_einde_geldigheid="2023-03-31",
+        )
+
+        # create zip
+        url = reverse("admin:catalogi_zaaktype_change", args=(zaaktype.pk,))
+        response = self.app.get(url)
+        form = response.forms["zaaktype_form"]
+        response = form.submit("_export")
+        data = response.content
+
+        url = reverse("admin:catalogi_catalogus_import_zaaktype", args=(catalogus.pk,))
+        response = self.app.get(url)
+
+        form = response.form
+        f = io.BytesIO(data)
+        f.name = "test.zip"
+        f.seek(0)
+        form["file"] = (
+            "test.zip",
+            f.read(),
+        )
+
+        response = form.submit("_import_zaaktype").follow()
+        response = response.form.submit("_select")
+        # fails (dues to a overlap error)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(ZaakType.objects.all().count(), 1)
+
+        response = self.app.get(url)
+        form = response.form
+        f.seek(0)
+        form["file"] = (
+            "test.zip",
+            f.read(),
+        )
+        form["identificatie"] = "ZAAKTYPE_2"
+        response = form.submit("_import_zaaktype").follow()
+
+        response = response.form.submit("_select")
+        # succeeds as it is imported under a different name
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(ZaakType.objects.all().count(), 2)
+        self.assertTrue(ZaakType.objects.filter(identificatie="ZAAKTYPE_2").exists())
+
 
 @patch(
     "openzaak.components.catalogi.models.zaaktype.Service.get_client",

--- a/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
@@ -1505,7 +1505,7 @@ class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
             ZaakType.objects.filter(identificatie="PREFIX_ZAAKTYPE_1").exists()
         )
 
-    def test_import_zaaktype_with_different_identification_excedes_max_length(
+    def test_import_zaaktype_with_different_identification_exceeds_max_length(
         self, *mocks
     ):
         catalogus = CatalogusFactory.create(rsin="000000000", domein="TEST")
@@ -1557,13 +1557,14 @@ class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
         response = form.submit("_import_zaaktype").follow()
 
         response = response.form.submit("_select")
-        # succeeds as it is imported under a different name
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(ZaakType.objects.all().count(), 2)
-        self.assertTrue(
-            ZaakType.objects.filter(
-                identificatie="PREFIX_Identification_that_is_fifty_characters_lon"
-            ).exists()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(ZaakType.objects.all().count(), 1)
+
+        self.assertIn(
+            _("Identification {} is too long with prefix. Max 50 characters.").format(
+                "PREFIX_" + "Identification_that_is_fifty_characters_long_00000"
+            ),
+            response.text,
         )
 
 

--- a/src/openzaak/templates/admin/catalogi/import_zaaktype.html
+++ b/src/openzaak/templates/admin/catalogi/import_zaaktype.html
@@ -23,6 +23,7 @@
             <div>
                 <fieldset class="module aligned ">
                     {% csrf_token %}
+                    {{ form.errors }}
                     {% for field in form %}
                         {{ field.label.capitalize }}: {{ field }}<br/>
                         {{ field.help_text }}<br/><br/>


### PR DESCRIPTION
Fixes #1531 

Adds option to enter zaaktype identification on import page. Uses identification from file if not entered.