### PR TITLE
Discontinue Foundation for Public Code stewardship

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,16 +33,4 @@ If all changes have been committed, you can push the branch to your fork of the 
 
 ### Reviews on releases
 
-All pull requests will be reviewed before they are merged to a release branch. As well as being reviewed for functionality and following the code style they will be checked against the [Standard for Public Code](https://standard.publiccode.net) by a [codebase steward](https://publiccode.net/codebase-stewardship/) from the [Foundation for Public Code](https://publiccode.net). Reviews will usually start within two business days of a submitted pull request.
-
-## Under Foundation for Public Code incubating codebase stewardship
-
-Open Zaak is in incubation [codebase stewardship](https://publiccode.net/codebase-stewardship/) with the [Foundation for Public Code](https://publiccode.net).
-
-The [codebase stewardship activities](https://about.publiccode.net/activities/codebase-stewardship/activities.html) by the Foundation for Public Code on this codebase include:
-
-* facilitating the community and its members
-* help all contributors contribute in line with the contributing guidelines and the [Standard for Public Code](https://standard.publiccode.net/)
-* work with the community to tell their stories, create their brand and market their products
-* support the technical steering team
-
+All pull requests will be reviewed before they are merged to a release branch.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -17,8 +17,6 @@ The OpenZaak community adheres to the following principles:
 
 The maintainers of OpenZaak have two steering teams, a technical one and a core group (kern groep).
 
-Through codebase stewardship the Foundation for Public Code supports the governance of OpenZaak, the product and technical steering teams, and its community.
-
 ## Technical steering team
 
 The OpenZaak technical steering team members are active contributors. As a team, they

--- a/README.en.md
+++ b/README.en.md
@@ -70,8 +70,6 @@ This repository contains the source code for the APIs. In order to use the APIs,
 
 These APIs have been developed by Maykin Media B.V. on behalf of Amsterdam, Rotterdam, Utrecht, Tilburg, Arnhem, Haarlem, 's-Hertogenbosch, SED, Delft and Hoorn under the direction of Dimpact.
 
-OpenZaak is in incubation [codebase stewardship](https://publiccode.net/codebase-stewardship/) with the [Foundation for Public Code](https://publiccode.net).
-
 ## License
 
 Licensed under the [EUPL](LICENSE.md).

--- a/docs/introduction/open-source/index.rst
+++ b/docs/introduction/open-source/index.rst
@@ -11,11 +11,8 @@ and `npm packages`_ under the hood.
 Public Code
 -----------
 
-The Open Zaak project benefits from the expertise of the `Foundation for Public
-Code`_ who helps to scale our codebase, community and development proces. With
-their codebase stewardship program, we are working on becomming fully
-compliant.
-
+The Open Zaak project benefited from the expertise of the `Foundation for Public
+Code`_ who helped to scale our codebase, community and development process.
 
 .. _`EUPL license`: https://github.com/open-zaak/open-zaak/blob/master/LICENSE.md
 .. _`Python libraries`: https://github.com/open-zaak/open-zaak/blob/master/requirements/base.txt


### PR DESCRIPTION
As [stated in email](https://lists.publiccode.net/hyperkitty/hyperkitty/list/openzaak-discuss@lists.publiccode.net/thread/A62NGGSGOTNEXAWXPK3B3X6J27DOB3A7/), the Foundation for Public Code will be winding down the office in Europe and will no longer be able to steward the OpenZaak codebase to the level which we aspire.

See also:

* https://blog.publiccode.net/news/2024/02/28/changes-at-the-europe-office.html

Fixes #1582

**Changes**

Removes text regarding active stewardship by the Foundation for Public Code.