### PR TITLE
 🐛 [#1585] Only rewrite host for API requests

### DIFF
--- a/src/openzaak/components/autorisaties/forms.py
+++ b/src/openzaak/components/autorisaties/forms.py
@@ -25,6 +25,7 @@ from openzaak.components.catalogi.models import (
     ZaakType,
 )
 from openzaak.utils.auth import get_auth
+from openzaak.utils.middleware import override_request_host
 from openzaak.utils.validators import ResourceValidator
 
 from .constants import RelatedTypeSelectionMethods
@@ -422,6 +423,10 @@ class AutorisatieBaseFormSet(forms.BaseFormSet):
     @transaction.atomic
     def save(self, commit=True):
         # use the API representation to figure out if there were any changes
+        # we have to explicitly override the request host (because this is not an API request)
+        # to ensure the notification has the right URLs
+        override_request_host(self.request)
+
         old_version = get_applicatie_serializer(
             self.applicatie, request=self.request
         ).data

--- a/src/openzaak/components/autorisaties/utils.py
+++ b/src/openzaak/components/autorisaties/utils.py
@@ -97,14 +97,10 @@ def send_applicatie_changed_notification(
     applicatie: Applicatie, new_version: Optional[Dict[str, Any]] = None
 ):
     from openzaak.utils import build_fake_request
-    from openzaak.utils.middleware import override_request_host
 
     viewset = ApplicatieViewSet()
     viewset.action = "update"
     if new_version is None:
         request = build_fake_request(method="put")
-        # we have to explicitly override the request host (because this is not an API request)
-        # to ensure the notification has the right URLs
-        override_request_host(request)
         new_version = get_applicatie_serializer(applicatie, request).data
     viewset.notify(status_code=200, data=new_version, instance=applicatie)

--- a/src/openzaak/components/autorisaties/utils.py
+++ b/src/openzaak/components/autorisaties/utils.py
@@ -97,10 +97,14 @@ def send_applicatie_changed_notification(
     applicatie: Applicatie, new_version: Optional[Dict[str, Any]] = None
 ):
     from openzaak.utils import build_fake_request
+    from openzaak.utils.middleware import override_request_host
 
     viewset = ApplicatieViewSet()
     viewset.action = "update"
     if new_version is None:
         request = build_fake_request(method="put")
+        # we have to explicitly override the request host (because this is not an API request)
+        # to ensure the notification has the right URLs
+        override_request_host(request)
         new_version = get_applicatie_serializer(applicatie, request).data
     viewset.notify(status_code=200, data=new_version, instance=applicatie)


### PR DESCRIPTION
Fixes #1585

**Changes**

* Only apply rewrite host middleware to API requests
* Specifically apply host rewrite for authorization admin notifications