### PR TITLE
[#1599] revert docker configuration file from `68ff9e1`

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,8 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    location /openzaak {
+        proxy_pass   http://web:8000;
+    }
+}


### PR DESCRIPTION
Fixes #1599 

**Changes**

Reverts the nginx configuration file [which the docker compose setup expects.](https://github.com/open-zaak/open-zaak/blob/main/docker-compose.yml#L96)

