### PR TITLE
:sparkles:[#1584] fix autorisaties 500 error when related object deleted

### DIFF
--- a/src/openzaak/components/autorisaties/tests/admin/test_autorisaties_admin.py
+++ b/src/openzaak/components/autorisaties/tests/admin/test_autorisaties_admin.py
@@ -1009,3 +1009,22 @@ class ManageAutorisatiesAdmin(NotificationsConfigMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         initial_data = response.context["formdata"]
         self.assertEqual(len(initial_data), 2)  # 1 empty form, 1 unrelated auth spec
+
+    @tag("gh-1584")
+    def test_related_object_does_not_exist(self):
+        """
+        Assert that the autorisaties view does not crash
+        if an autorisatie fails to delete after its related object is deleted.
+        """
+
+        AutorisatieFactory.create(
+            applicatie=self.applicatie,
+            component=ComponentTypes.drc,
+            scopes=["documenten.lezen"],
+            max_vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.openbaar,
+            informatieobjecttype="http://testserver/url_to_nowhere/00000000-0000-0000-0000-000000000000",
+        )
+
+        # check that the admin page does not crash
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)

--- a/src/openzaak/components/autorisaties/utils.py
+++ b/src/openzaak/components/autorisaties/utils.py
@@ -27,8 +27,11 @@ def _get_related_object(model: ModelBase, url: str) -> Optional[RelatedTypeObjec
     if url == "":
         return None
     uuid = url.rsplit("/")[-1]
-    obj = model.objects.get(uuid=uuid)
-    return obj
+    try:
+        obj = model.objects.get(uuid=uuid)
+        return obj
+    except model.DoesNotExist:
+        return None
 
 
 def get_related_object(autorisatie: Autorisatie) -> Optional[RelatedTypeObject]:


### PR DESCRIPTION
Fixes #1584 


