### PR TITLE
 🐛 [#1594] Catch missing scopes error in authorization form

### DIFF
--- a/src/openzaak/components/autorisaties/forms.py
+++ b/src/openzaak/components/autorisaties/forms.py
@@ -438,8 +438,18 @@ class AutorisatieBaseFormSet(forms.BaseFormSet):
             send_applicatie_changed_notification(self.applicatie, new_version)
 
     def clean(self):
+        self._validate_authorizations_have_scopes()
         # validate overlap zaaktypen between different auths
         self._validate_overlapping_types()
+
+    def _validate_authorizations_have_scopes(self):
+        for form in self.forms:
+            if form.cleaned_data:
+                if "scopes" not in form.cleaned_data:
+                    raise ValidationError(
+                        _("One or more authorizations are missing scopes."),
+                        code="missing_scopes",
+                    )
 
     def _validate_overlapping_types(self):
         scope_types = {}

--- a/src/openzaak/components/autorisaties/tests/admin/test_autorisaties_admin.py
+++ b/src/openzaak/components/autorisaties/tests/admin/test_autorisaties_admin.py
@@ -894,6 +894,37 @@ class ManageAutorisatiesAdmin(NotificationsConfigMixin, TestCase):
             _("Scopes in {component} may not be duplicated.").format(component="ztc"),
         )
 
+    @tag("gh-1594")
+    def test_add_autorisaties_without_scopes(self):
+        data = {
+            # management form
+            "form-TOTAL_FORMS": 2,
+            "form-INITIAL_FORMS": 0,
+            "form-MIN_NUM_FORMS": 0,
+            "form-MAX_NUM_FORMS": 1000,
+            "form-0-component": ComponentTypes.ztc,
+            "form-0-scopes": [],
+            "form-1-component": ComponentTypes.zrc,
+            "form-1-scopes": [],
+        }
+
+        response = self.client.post(self.url, data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Autorisatie.objects.count(), 0)
+        self.assertEqual(
+            response.context_data["formset"]._non_form_errors[0],
+            _("One or more authorizations are missing scopes."),
+        )
+        self.assertEqual(
+            response.context_data["formset"][0].errors["scopes"],
+            [_("This field is required.")],
+        )
+        self.assertEqual(
+            response.context_data["formset"][1].errors["scopes"],
+            [_("This field is required.")],
+        )
+
     @tag("gh-1080")
     def test_autorisaties_visible_even_if_only_a_spec_exists_brc(self):
         """


### PR DESCRIPTION
Fixes #1594

**Changes**
* Validate for missing scopes in authorization admin form

