### PR TITLE
:art: [#1640] changed buitenlands_correspondentieadres_adres_buitenla…

### DIFF
--- a/src/openzaak/components/documenten/tests/factories.py
+++ b/src/openzaak/components/documenten/tests/factories.py
@@ -132,8 +132,8 @@ class VerzendingFactory(factory.django.DjangoModelFactory):
             ),
         )
         has_outer_address = factory.Trait(
-            buitenlands_correspondentieadres_adres_buitenland_1=factory.Faker(
-                "street_address"
+            buitenlands_correspondentieadres_adres_buitenland_1=factory.fuzzy.FuzzyText(
+                length=35
             ),
             buitenlands_correspondentieadres_land_postadres=factory.Faker("url"),
         )


### PR DESCRIPTION
…nd_1 factory field to have max_lenght of 35

Fixes #1640

**Changes**

changed buitenlands_correspondentieadres_adres_buitenland_1 factory field to have a max_length of 35

