### PR TITLE
:memo:[#1626] Add JWT examples to docs

### DIFF
--- a/docs/client-development/authentication.rst
+++ b/docs/client-development/authentication.rst
@@ -110,7 +110,7 @@ There is a link to a list of more libraries for these and other languages below.
             jwt_token = jwt.encode(payload, SECRET, algorithm="HS256")
 
             # add token token to the authentication HTTP header of your request library
-            zaaktype_url = "https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff"
+            zaaktype_url = "https://openzaak.gemeente.local/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff"
             headers = {"Authorization": "Bearer {token}".format(token=jwt_token)}
             response = requests.get(
                 zaaktype_url,
@@ -149,7 +149,7 @@ There is a link to a list of more libraries for these and other languages below.
             var jwt_token = getJWT()
 
             // add token token to the authentication HTTP header of fetch
-            const zaaktype_url = "https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff";
+            const zaaktype_url = "https://openzaak.gemeente.local/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff";
             fetch(
               zaaktype_url,
               {
@@ -187,7 +187,7 @@ There is a link to a list of more libraries for these and other languages below.
             $headers = [
                 "Authorization" => "Bearer " . $jwt_token,
             ];
-            $zaaktype_url ="https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff";
+            $zaaktype_url ="https://openzaak.gemeente.local/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff";
 
             $client = new \GuzzleHttp\Client();
             $response = $client->request("GET", $zaaktype_url, [
@@ -218,7 +218,7 @@ There is a link to a list of more libraries for these and other languages below.
 
             // add token token to the authentication HTTP header of your request library
             try {
-                URL zaaktype_url = new URL("https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff");
+                URL zaaktype_url = new URL("https://openzaak.gemeente.local/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff");
                 URLConnection zaaktype_connection = zaaktype_url.openConnection();
 
                 zaaktype_connection.setRequestProperty ("Authorization", "Bearer "+jwt_token);

--- a/docs/client-development/authentication.rst
+++ b/docs/client-development/authentication.rst
@@ -82,11 +82,14 @@ This would then be used in an API call like:
 Generating JWT Examples:
 ------------------------
 
+Example of how to generate JWT tokens in Java, JavaScript, PHP and Python with example libraries.
+There is a link to a list of more libraries for these and other languages below.
+
 .. tabs::
 
     .. group-tab:: Python (Django)
 
-        Using Django with `pyjwt`_
+        Using the `pyjwt`_ for python.
 
         .. code-block:: python
 
@@ -106,11 +109,14 @@ Generating JWT Examples:
             }
             jwt_token = jwt.encode(payload, client_secret, algorithm="HS256")
 
+            # add token token to the authentication HTTP header of your request library
+            zaaktype_url = "https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff"
             headers = {"Authorization": "Bearer {token}".format(token=jwt_token)}
-            request = requests.get(
-                "https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff",
+            response = requests.get(
+                zaaktype_url,
                 headers=headers,
             )
+            print(response.json())
 
     .. group-tab:: JavaScript
 
@@ -119,7 +125,6 @@ Generating JWT Examples:
         .. code-block:: javascript
 
             import jwt from 'jsonwebtoken';
-
 
             const CLIENT_ID = 'example';
             const SECRET = 'secret';
@@ -140,15 +145,17 @@ Generating JWT Examples:
               );
             };
 
-            const url = "https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff",
-            var token = getJWT()
 
+            var jwt_token = getJWT()
+
+            // add token token to the authentication HTTP header of fetch
+            const zaaktype_url = "https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff";
             fetch(
-              url,
+              zaaktype_url,
               {
                 method: 'get',
                 headers: {
-                  'Authorization': `Bearer ${token}`,
+                  'Authorization': `Bearer ${jwt_token}`,
                   'Accept': 'application/json',
                 },
               }
@@ -156,11 +163,11 @@ Generating JWT Examples:
               console.log(response);
             });
 
-    .. group-tab:: php
+    .. group-tab:: PHP
 
-        The `php-jwt`_ package is available which can generate the JWT token for you.
+        The `php-jwt`_ package is available for PHP which can generate the JWT token for you.
 
-        .. code-block:: PHP
+        .. code-block:: php
 
             use Firebase\JWT\JWT;
 
@@ -176,17 +183,52 @@ Generating JWT Examples:
             ];
 
             $jwt_token = JWT::encode($payload, $SECRET, "HS256");
+            // add token token to the authentication HTTP header of your request library
             $headers = [
                 "Authorization" => "Bearer " . $jwt_token,
             ];
-            $url ="http://127.0.0.1:8000/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff";
+            $zaaktype_url ="https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff";
 
             $client = new \GuzzleHttp\Client();
-            $response = $client->request("GET", $url, [
+            $response = $client->request("GET", $zaaktype_url, [
                 "headers" => $headers,
                 'http_errors' => false
             ]);
 
+            echo $response->getBody();
+
+    .. group-tab:: Java
+
+        The `java-jwt`_ package is available for java which can generate the JWT token for you.
+
+        .. code-block:: java
+
+            final String CLIENT_ID = "example";
+            final String SECRET = "secret";
+
+            Algorithm algorithm = Algorithm.HMAC256(SECRET);
+
+            String jwt_token = JWT.create()
+                .withIssuer(CLIENT_ID) // iss
+                .withIssuedAt(new Date()) // iat
+                .withClaim("client_id", CLIENT_ID)
+                .withClaim("user_id", "eample@example.com")
+                .withClaim("user_representation", "Example Name")
+                .sign(algorithm);
+
+            // add token token to the authentication HTTP header of your request library
+            try {
+                URL zaaktype_url = new URL("https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff");
+                URLConnection zaaktype_connection = zaaktype_url.openConnection();
+
+                zaaktype_connection.setRequestProperty ("Authorization", "Bearer "+jwt_token);
+                zaaktype_connection.addRequestProperty("Accept", "application/json");
+
+                BufferedReader in = new BufferedReader(
+                        new InputStreamReader(
+                            zaaktype_connection.getInputStream()));
+            } catch (Exception exception){
+            }
 
 Useful Links
 
@@ -198,3 +240,4 @@ Useful Links
 .. _pyjwt: https://pypi.org/project/PyJWT/
 .. _jsonwebtoken: https://www.npmjs.com/package/jsonwebtoken
 .. _php-jwt: https://github.com/firebase/php-jwt
+.. _java-jwt: https://github.com/auth0/java-jwt

--- a/docs/client-development/authentication.rst
+++ b/docs/client-development/authentication.rst
@@ -65,6 +65,7 @@ Which leads to the following JWT:
 This would then be used in an API call like:
 
 .. code-block:: http
+
     GET https://test.openzaak.nl/besluiten/api/v1/besuiten HTTP/1.1
     Host: test.open-zaak.nl
     Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkb2NzIiwiaWF0IjoxNjAyODU3MzAxLCJjbGllbnRfaWQiOiJkb2NzIiwidXNlcl9pZCI6ImRvY3NAZXhhbXBsZS5jb20iLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiRG9jdW1lbnRhdGlvbiBFeGFtcGxlIn0.DZu7E780xG4zqRiT8ZhrBeMudz45301wNVDT0ra-Iyw

--- a/docs/client-development/authentication.rst
+++ b/docs/client-development/authentication.rst
@@ -87,7 +87,7 @@ There is a link to a list of more libraries for these and other languages below.
 
 .. tabs::
 
-    .. group-tab:: Python (Django)
+    .. group-tab:: Python
 
         Using the `pyjwt`_ for python.
 
@@ -97,17 +97,17 @@ There is a link to a list of more libraries for these and other languages below.
             import requests
             import time
 
-            client_id = "example"
-            client_secret = "secret"
+            CLIENT_ID = "example"
+            SECRET = "secret"
 
             payload = {
-                "iss": client_id,
+                "iss": CLIENT_ID,
                 "iat": int(time.time()),  # current time in seconds
-                "client_id": client_id,
+                "client_id": CLIENT_ID,
                 "user_id": "eample@example.com",
                 "user_representation": "Example Name",
             }
-            jwt_token = jwt.encode(payload, client_secret, algorithm="HS256")
+            jwt_token = jwt.encode(payload, SECRET, algorithm="HS256")
 
             # add token token to the authentication HTTP header of your request library
             zaaktype_url = "https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff"
@@ -227,7 +227,10 @@ There is a link to a list of more libraries for these and other languages below.
                 BufferedReader in = new BufferedReader(
                         new InputStreamReader(
                             zaaktype_connection.getInputStream()));
+                // do stuff with buffer
+
             } catch (Exception exception){
+                // exception code
             }
 
 Useful Links

--- a/docs/client-development/authentication.rst
+++ b/docs/client-development/authentication.rst
@@ -99,10 +99,10 @@ Generating JWT Examples:
 
             payload = {
                 "iss": client_id,
-                "iat": int(time.time()),  # current unix time
+                "iat": int(time.time()),  # current time in seconds
                 "client_id": client_id,
-                "user_id": "user-id",
-                "user_representation": "User Name",
+                "user_id": "eample@example.com",
+                "user_representation": "Example Name",
             }
             jwt_token = jwt.encode(payload, client_secret, algorithm="HS256")
 
@@ -130,7 +130,7 @@ Generating JWT Examples:
                     // iat: placed automatically
                     client_id: CLIENT_ID,
                     user_id: "eample@example.com",
-                    user_representation: "Example name"
+                    user_representation: "Example Name"
                 },
                 SECRET,
                 {
@@ -156,6 +156,38 @@ Generating JWT Examples:
               console.log(response);
             });
 
+    .. group-tab:: php
+
+        The `php-jwt`_ package is available which can generate the JWT token for you.
+
+        .. code-block:: PHP
+
+            use Firebase\JWT\JWT;
+
+            $CLIENT_ID = "example";
+            $SECRET = "secret";
+
+            $payload = [
+                "iss" => $CLIENT_ID,
+                "iat" => time(),
+                "client_id" => $CLIENT_ID,
+                "user_id" => "eample@example.com",
+                "user_representation" => "Example Name",
+            ];
+
+            $jwt_token = JWT::encode($payload, $SECRET, "HS256");
+            $headers = [
+                "Authorization" => "Bearer " . $jwt_token,
+            ];
+            $url ="http://127.0.0.1:8000/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff";
+
+            $client = new \GuzzleHttp\Client();
+            $response = $client->request("GET", $url, [
+                "headers" => $headers,
+                'http_errors' => false
+            ]);
+
+
 Useful Links
 
    * `More indepth JWT Explanation`_
@@ -165,3 +197,4 @@ Useful Links
 .. _JWT implementations for various languages: https://jwt.io/libraries
 .. _pyjwt: https://pypi.org/project/PyJWT/
 .. _jsonwebtoken: https://www.npmjs.com/package/jsonwebtoken
+.. _php-jwt: https://github.com/firebase/php-jwt

--- a/docs/client-development/authentication.rst
+++ b/docs/client-development/authentication.rst
@@ -79,6 +79,82 @@ This would then be used in an API call like:
 
 .. _Standard: https://vng-realisatie.github.io/gemma-zaken/
 
+Generating JWT Examples:
+------------------------
+
+.. tabs::
+
+    .. group-tab:: Python (Django)
+
+        Using Django with `pyjwt`_
+
+        .. code-block:: python
+
+            import jwt
+            import requests
+            import time
+
+            client_id = "example"
+            client_secret = "secret"
+
+            payload = {
+                "iss": client_id,
+                "iat": int(time.time()),  # current unix time
+                "client_id": client_id,
+                "user_id": "user-id",
+                "user_representation": "User Name",
+            }
+            jwt_token = jwt.encode(payload, client_secret, algorithm="HS256")
+
+            headers = {"Authorization": "Bearer {token}".format(token=jwt_token)}
+            request = requests.get(
+                "https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff",
+                headers=headers,
+            )
+
+    .. group-tab:: JavaScript
+
+        In JavaScript, most of the token can be generated with the `jsonwebtoken`_ package.
+
+        .. code-block:: javascript
+
+            import jwt from 'jsonwebtoken';
+
+
+            const CLIENT_ID = 'example';
+            const SECRET = 'secret';
+
+            const getJWT = () => {
+              return jwt.sign(
+                {
+                    // iat: placed automatically
+                    client_id: CLIENT_ID,
+                    user_id: "eample@example.com",
+                    user_representation: "Example name"
+                },
+                SECRET,
+                {
+                  algorithm: 'HS256',
+                  issuer: CLIENT_ID, // iss in payload
+                }
+              );
+            };
+
+            const url = "https://test.openzaak.nl/catalogi/api/v1/zaaktypen/4acb5ab8-f189-4559-b18a-8a54553a74ff",
+            var token = getJWT()
+
+            fetch(
+              url,
+              {
+                method: 'get',
+                headers: {
+                  'Authorization': `Bearer ${token}`,
+                  'Accept': 'application/json',
+                },
+              }
+            ).then(response => {
+              console.log(response);
+            });
 
 Useful Links
 
@@ -87,3 +163,5 @@ Useful Links
 
 .. _More indepth JWT Explanation: https://jwt.io/introduction
 .. _JWT implementations for various languages: https://jwt.io/libraries
+.. _pyjwt: https://pypi.org/project/PyJWT/
+.. _jsonwebtoken: https://www.npmjs.com/package/jsonwebtoken

--- a/docs/client-development/authentication.rst
+++ b/docs/client-development/authentication.rst
@@ -80,11 +80,10 @@ This would then be used in an API call like:
 .. _Standard: https://vng-realisatie.github.io/gemma-zaken/
 
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Useful Links
-   `More indepth JWT Explanation`_
-   `JWT implementations for various languages`_
+Useful Links
+
+   * `More indepth JWT Explanation`_
+   * `JWT implementations for various languages`_
 
 .. _More indepth JWT Explanation: https://jwt.io/introduction
 .. _JWT implementations for various languages: https://jwt.io/libraries

--- a/docs/client-development/authentication.rst
+++ b/docs/client-development/authentication.rst
@@ -65,7 +65,6 @@ Which leads to the following JWT:
 This would then be used in an API call like:
 
 .. code-block:: http
-
     GET https://test.openzaak.nl/besluiten/api/v1/besuiten HTTP/1.1
     Host: test.open-zaak.nl
     Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkb2NzIiwiaWF0IjoxNjAyODU3MzAxLCJjbGllbnRfaWQiOiJkb2NzIiwidXNlcl9pZCI6ImRvY3NAZXhhbXBsZS5jb20iLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiRG9jdW1lbnRhdGlvbiBFeGFtcGxlIn0.DZu7E780xG4zqRiT8ZhrBeMudz45301wNVDT0ra-Iyw
@@ -78,3 +77,13 @@ This would then be used in an API call like:
     the application.
 
 .. _Standard: https://vng-realisatie.github.io/gemma-zaken/
+
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Useful Links
+   `More indepth JWT Explanation`_
+   `JWT implementations for various languages`_
+
+.. _More indepth JWT Explanation: https://jwt.io/introduction
+.. _JWT implementations for various languages: https://jwt.io/libraries

--- a/src/openzaak/components/autorisaties/openapi.yaml
+++ b/src/openzaak/components/autorisaties/openapi.yaml
@@ -54,6 +54,10 @@ info:
     vrije velden met als enige beperking dat de lengte maximaal de lengte van
     de overeenkomstige velden in de audit trail resources is (zie rest API spec).
 
+    **Handige JWT links**
+     * [VNG Authenticatie en autorisatie](https://vng-realisatie.github.io/gemma-zaken/themas/achtergronddocumentatie/authenticatie-autorisatie#autorisatie)
+     * [JWT Bibliotheken](https://jwt.io/libraries)
+
 
     ### Notificaties
 

--- a/src/openzaak/components/autorisaties/openapi.yaml
+++ b/src/openzaak/components/autorisaties/openapi.yaml
@@ -56,6 +56,7 @@ info:
 
     **Handige JWT links**
      * [VNG Authenticatie en autorisatie](https://vng-realisatie.github.io/gemma-zaken/themas/achtergronddocumentatie/authenticatie-autorisatie#autorisatie)
+     * [Codevoorbeelden voor Python, JavasScript, Java, PHP](https://open-zaak.readthedocs.io/en/stable/client-development/authentication.html#generating-jwt-examples)
      * [JWT Bibliotheken](https://jwt.io/libraries)
 
 

--- a/src/openzaak/components/autorisaties/openapi.yaml
+++ b/src/openzaak/components/autorisaties/openapi.yaml
@@ -54,10 +54,7 @@ info:
     vrije velden met als enige beperking dat de lengte maximaal de lengte van
     de overeenkomstige velden in de audit trail resources is (zie rest API spec).
 
-    **Handige JWT links**
-     * [VNG Authenticatie en autorisatie](https://vng-realisatie.github.io/gemma-zaken/themas/achtergronddocumentatie/authenticatie-autorisatie#autorisatie)
-     * [Codevoorbeelden voor Python, JavasScript, Java, PHP](https://open-zaak.readthedocs.io/en/stable/client-development/authentication.html#generating-jwt-examples)
-     * [JWT Bibliotheken](https://jwt.io/libraries)
+    [Link naar volledige documentatie(in het Engels)](https://open-zaak.readthedocs.io/en/stable/client-development/authentication.html) met codevoorbeelden voor Java, JavaScript, PHP, Python.
 
 
     ### Notificaties

--- a/src/openzaak/components/besluiten/openapi.yaml
+++ b/src/openzaak/components/besluiten/openapi.yaml
@@ -63,6 +63,7 @@ info:
 
     **Handige JWT links**
      * [VNG Authenticatie en autorisatie](https://vng-realisatie.github.io/gemma-zaken/themas/achtergronddocumentatie/authenticatie-autorisatie#autorisatie)
+     * [Codevoorbeelden voor Python, JavasScript, Java, PHP](https://open-zaak.readthedocs.io/en/stable/client-development/authentication.html#generating-jwt-examples)
      * [JWT Bibliotheken](https://jwt.io/libraries)
 
 

--- a/src/openzaak/components/besluiten/openapi.yaml
+++ b/src/openzaak/components/besluiten/openapi.yaml
@@ -61,10 +61,7 @@ info:
     vrije velden met als enige beperking dat de lengte maximaal de lengte van
     de overeenkomstige velden in de audit trail resources is (zie rest API spec).
 
-    **Handige JWT links**
-     * [VNG Authenticatie en autorisatie](https://vng-realisatie.github.io/gemma-zaken/themas/achtergronddocumentatie/authenticatie-autorisatie#autorisatie)
-     * [Codevoorbeelden voor Python, JavasScript, Java, PHP](https://open-zaak.readthedocs.io/en/stable/client-development/authentication.html#generating-jwt-examples)
-     * [JWT Bibliotheken](https://jwt.io/libraries)
+    [Link naar volledige documentatie(in het Engels)](https://open-zaak.readthedocs.io/en/stable/client-development/authentication.html) met codevoorbeelden voor Java, JavaScript, PHP, Python.
 
 
     ### Notificaties

--- a/src/openzaak/components/besluiten/openapi.yaml
+++ b/src/openzaak/components/besluiten/openapi.yaml
@@ -61,6 +61,10 @@ info:
     vrije velden met als enige beperking dat de lengte maximaal de lengte van
     de overeenkomstige velden in de audit trail resources is (zie rest API spec).
 
+    **Handige JWT links**
+     * [VNG Authenticatie en autorisatie](https://vng-realisatie.github.io/gemma-zaken/themas/achtergronddocumentatie/authenticatie-autorisatie#autorisatie)
+     * [JWT Bibliotheken](https://jwt.io/libraries)
+
 
     ### Notificaties
 

--- a/src/openzaak/components/catalogi/openapi.yaml
+++ b/src/openzaak/components/catalogi/openapi.yaml
@@ -59,6 +59,7 @@ info:
 
     **Handige JWT links**
      * [VNG Authenticatie en autorisatie](https://vng-realisatie.github.io/gemma-zaken/themas/achtergronddocumentatie/authenticatie-autorisatie#autorisatie)
+    * [Codevoorbeelden voor Python, JavasScript, Java, PHP](https://open-zaak.readthedocs.io/en/stable/client-development/authentication.html#generating-jwt-examples)
      * [JWT Bibliotheken](https://jwt.io/libraries)
 
 

--- a/src/openzaak/components/catalogi/openapi.yaml
+++ b/src/openzaak/components/catalogi/openapi.yaml
@@ -57,10 +57,7 @@ info:
     vrije velden met als enige beperking dat de lengte maximaal de lengte van
     de overeenkomstige velden in de audit trail resources is (zie rest API spec).
 
-    **Handige JWT links**
-     * [VNG Authenticatie en autorisatie](https://vng-realisatie.github.io/gemma-zaken/themas/achtergronddocumentatie/authenticatie-autorisatie#autorisatie)
-    * [Codevoorbeelden voor Python, JavasScript, Java, PHP](https://open-zaak.readthedocs.io/en/stable/client-development/authentication.html#generating-jwt-examples)
-     * [JWT Bibliotheken](https://jwt.io/libraries)
+    [Link naar volledige documentatie(in het Engels)](https://open-zaak.readthedocs.io/en/stable/client-development/authentication.html) met codevoorbeelden voor Java, JavaScript, PHP, Python.
 
 
     ### Notificaties

--- a/src/openzaak/components/catalogi/openapi.yaml
+++ b/src/openzaak/components/catalogi/openapi.yaml
@@ -57,6 +57,10 @@ info:
     vrije velden met als enige beperking dat de lengte maximaal de lengte van
     de overeenkomstige velden in de audit trail resources is (zie rest API spec).
 
+    **Handige JWT links**
+     * [VNG Authenticatie en autorisatie](https://vng-realisatie.github.io/gemma-zaken/themas/achtergronddocumentatie/authenticatie-autorisatie#autorisatie)
+     * [JWT Bibliotheken](https://jwt.io/libraries)
+
 
     ### Notificaties
 
@@ -12432,7 +12436,8 @@ components:
         naam:
           type: string
           title: Referentieprocesnaam
-          description: De naam van het Referentieproces.
+          description: De naam van het Referentieproces. Zie ook de Procesarchitectuur
+            Referentieprocessen op https://www.gemmaonline.nl/index.php/Procesarchitectuur_Referentieprocessen
           maxLength: 80
         link:
           type: string
@@ -12449,7 +12454,8 @@ components:
           type: string
           minLength: 1
           title: Referentieprocesnaam
-          description: De naam van het Referentieproces.
+          description: De naam van het Referentieproces. Zie ook de Procesarchitectuur
+            Referentieprocessen op https://www.gemmaonline.nl/index.php/Procesarchitectuur_Referentieprocessen
           maxLength: 80
         link:
           type: string

--- a/src/openzaak/components/documenten/openapi.yaml
+++ b/src/openzaak/components/documenten/openapi.yaml
@@ -71,6 +71,10 @@ info:
     vrije velden met als enige beperking dat de lengte maximaal de lengte van
     de overeenkomstige velden in de audit trail resources is (zie rest API spec).
 
+    **Handige JWT links**
+     * [VNG Authenticatie en autorisatie](https://vng-realisatie.github.io/gemma-zaken/themas/achtergronddocumentatie/authenticatie-autorisatie#autorisatie)
+     * [JWT Bibliotheken](https://jwt.io/libraries)
+
 
     ### Notificaties
 

--- a/src/openzaak/components/documenten/openapi.yaml
+++ b/src/openzaak/components/documenten/openapi.yaml
@@ -73,6 +73,7 @@ info:
 
     **Handige JWT links**
      * [VNG Authenticatie en autorisatie](https://vng-realisatie.github.io/gemma-zaken/themas/achtergronddocumentatie/authenticatie-autorisatie#autorisatie)
+     * [Codevoorbeelden voor Python, JavasScript, Java, PHP](https://open-zaak.readthedocs.io/en/stable/client-development/authentication.html#generating-jwt-examples)
      * [JWT Bibliotheken](https://jwt.io/libraries)
 
 

--- a/src/openzaak/components/documenten/openapi.yaml
+++ b/src/openzaak/components/documenten/openapi.yaml
@@ -71,10 +71,7 @@ info:
     vrije velden met als enige beperking dat de lengte maximaal de lengte van
     de overeenkomstige velden in de audit trail resources is (zie rest API spec).
 
-    **Handige JWT links**
-     * [VNG Authenticatie en autorisatie](https://vng-realisatie.github.io/gemma-zaken/themas/achtergronddocumentatie/authenticatie-autorisatie#autorisatie)
-     * [Codevoorbeelden voor Python, JavasScript, Java, PHP](https://open-zaak.readthedocs.io/en/stable/client-development/authentication.html#generating-jwt-examples)
-     * [JWT Bibliotheken](https://jwt.io/libraries)
+    [Link naar volledige documentatie(in het Engels)](https://open-zaak.readthedocs.io/en/stable/client-development/authentication.html) met codevoorbeelden voor Java, JavaScript, PHP, Python.
 
 
     ### Notificaties

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -54,6 +54,10 @@ info:
     vrije velden met als enige beperking dat de lengte maximaal de lengte van
     de overeenkomstige velden in de audit trail resources is (zie rest API spec).
 
+    **Handige JWT links**
+     * [VNG Authenticatie en autorisatie](https://vng-realisatie.github.io/gemma-zaken/themas/achtergronddocumentatie/authenticatie-autorisatie#autorisatie)
+     * [JWT Bibliotheken](https://jwt.io/libraries)
+
 
     ### Notificaties
 

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -56,6 +56,7 @@ info:
 
     **Handige JWT links**
      * [VNG Authenticatie en autorisatie](https://vng-realisatie.github.io/gemma-zaken/themas/achtergronddocumentatie/authenticatie-autorisatie#autorisatie)
+     * [Codevoorbeelden voor Python, JavasScript, Java, PHP](https://open-zaak.readthedocs.io/en/stable/client-development/authentication.html#generating-jwt-examples)
      * [JWT Bibliotheken](https://jwt.io/libraries)
 
 

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -54,10 +54,7 @@ info:
     vrije velden met als enige beperking dat de lengte maximaal de lengte van
     de overeenkomstige velden in de audit trail resources is (zie rest API spec).
 
-    **Handige JWT links**
-     * [VNG Authenticatie en autorisatie](https://vng-realisatie.github.io/gemma-zaken/themas/achtergronddocumentatie/authenticatie-autorisatie#autorisatie)
-     * [Codevoorbeelden voor Python, JavasScript, Java, PHP](https://open-zaak.readthedocs.io/en/stable/client-development/authentication.html#generating-jwt-examples)
-     * [JWT Bibliotheken](https://jwt.io/libraries)
+    [Link naar volledige documentatie(in het Engels)](https://open-zaak.readthedocs.io/en/stable/client-development/authentication.html) met codevoorbeelden voor Java, JavaScript, PHP, Python.
 
 
     ### Notificaties

--- a/src/openzaak/utils/apidoc.py
+++ b/src/openzaak/utils/apidoc.py
@@ -34,4 +34,9 @@ UNIX-timestamp die aangeeft op welk moment het token gegenereerd is.
 `user_id` en `user_representation` zijn nodig voor de audit trails. Het zijn
 vrije velden met als enige beperking dat de lengte maximaal de lengte van
 de overeenkomstige velden in de audit trail resources is (zie rest API spec).
+
+**Handige JWT links**
+ * [VNG Authenticatie en autorisatie](https://vng-realisatie.github.io\
+/gemma-zaken/themas/achtergronddocumentatie/authenticatie-autorisatie#autorisatie)
+ * [JWT Bibliotheken](https://jwt.io/libraries)
 """

--- a/src/openzaak/utils/apidoc.py
+++ b/src/openzaak/utils/apidoc.py
@@ -35,10 +35,7 @@ UNIX-timestamp die aangeeft op welk moment het token gegenereerd is.
 vrije velden met als enige beperking dat de lengte maximaal de lengte van
 de overeenkomstige velden in de audit trail resources is (zie rest API spec).
 
-**Handige JWT links**
- * [VNG Authenticatie en autorisatie](https://vng-realisatie.github.io\
-/gemma-zaken/themas/achtergronddocumentatie/authenticatie-autorisatie#autorisatie)
- * [Codevoorbeelden voor Python, JavasScript, Java, PHP]\
-(https://open-zaak.readthedocs.io/en/stable/client-development/authentication.html#generating-jwt-examples)
- * [JWT Bibliotheken](https://jwt.io/libraries)
+[Link naar volledige documentatie(in het Engels)]\
+(https://open-zaak.readthedocs.io/en/stable/client-development/authentication.html) \
+met codevoorbeelden voor Java, JavaScript, PHP, Python.
 """

--- a/src/openzaak/utils/apidoc.py
+++ b/src/openzaak/utils/apidoc.py
@@ -38,5 +38,7 @@ de overeenkomstige velden in de audit trail resources is (zie rest API spec).
 **Handige JWT links**
  * [VNG Authenticatie en autorisatie](https://vng-realisatie.github.io\
 /gemma-zaken/themas/achtergronddocumentatie/authenticatie-autorisatie#autorisatie)
+ * [Codevoorbeelden voor Python, JavasScript, Java, PHP]\
+(https://open-zaak.readthedocs.io/en/stable/client-development/authentication.html#generating-jwt-examples)
  * [JWT Bibliotheken](https://jwt.io/libraries)
 """


### PR DESCRIPTION
Fixes #1626

Added some links to JWT stuff.

Added examples for Python, PHP. Java and JavaScript