### PR TITLE
:whale: change DB image in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ version: '3.4'
 
 services:
   db:
-    image: mdillon/postgis
+    image: postgis/postgis:12-2.5
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     command: postgres -c max_connections=300 -c log_min_messages=LOG


### PR DESCRIPTION
DB image in `docker-compose.yml` was out-of-date and didn't work with django app image anymore. 
