### PR TITLE
:wrench: Always use requests.hostname for 2FA app title

### DIFF
--- a/src/openzaak/accounts/tests/test_2fa.py
+++ b/src/openzaak/accounts/tests/test_2fa.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2024 Dimpact
+from django.contrib.sites.models import Site
+from django.test import RequestFactory, TestCase, override_settings
+from django.urls import resolve
+
+
+@override_settings(ALLOWED_HOSTS=["some-domain.local"], DISABLE_2FA=False)
+class TwoFactorQRGeneratorTestCase(TestCase):
+    def test_qr_code_generator_does_not_use_sites_framework(self):
+        """
+        Regression test for https://github.com/maykinmedia/open-api-framework/issues/40
+
+        Testing the actual QR code output is too much of a hassle, so instead retrieve
+        the view class based on the URL and check if `get_issuer` behaves as expected
+        """
+        site = Site.objects.get_current()
+        site.domain = "testserver"
+        site.save()
+
+        qr_generator_view_class = resolve("/admin/mfa/qrcode/").func.view_class
+        issuer = qr_generator_view_class(
+            request=RequestFactory().get("/", headers={"Host": "some-domain.local"})
+        ).get_issuer()
+
+        self.assertEqual(issuer, "some-domain.local")

--- a/src/openzaak/accounts/views.py
+++ b/src/openzaak/accounts/views.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2024 Dimpact
+from django.contrib.sites.requests import RequestSite
+
+from maykin_2fa.views import QRGeneratorView as _QRGeneratorView
+
+
+class QRGeneratorView(_QRGeneratorView):
+    def get_issuer(self):
+        return RequestSite(self.request).name

--- a/src/openzaak/urls.py
+++ b/src/openzaak/urls.py
@@ -11,6 +11,7 @@ from django.views.generic import TemplateView
 from maykin_2fa import monkeypatch_admin
 from maykin_2fa.urls import urlpatterns, webauthn_urlpatterns
 
+from openzaak.accounts.views import QRGeneratorView
 from openzaak.utils.exceptions import RequestEntityTooLargeException
 from openzaak.utils.views import ErrorDocumentView, ViewConfigView
 
@@ -28,6 +29,11 @@ urlpatterns = [
         "admin/api/v1/catalogi/", include("openzaak.components.catalogi.api.admin.urls")
     ),
     # 2fa
+    # See https://github.com/maykinmedia/open-api-framework/issues/40
+    # and https://github.com/maykinmedia/open-api-framework/issues/59
+    # Temporary workaround to remove the dependency on `django.contrib.sites` when
+    # generating the app label for 2FA. This should be removed once `sites` are removed
+    path("admin/mfa/qrcode/", QRGeneratorView.as_view(), name="qr"),
     path("admin/", include((urlpatterns, "maykin_2fa"))),
     path("admin/", include((webauthn_urlpatterns, "two_factor"))),
     path("admin/", admin.site.urls),


### PR DESCRIPTION
Fixes https://github.com/maykinmedia/open-api-framework/issues/40 partly

**Changes**

* Always use requests.hostname for 2FA app title
