### PR TITLE
:sparkles: [open-zaak/open-notificaties#156] Define kenmerk for Zaak.zaaktype.catalogus

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = False
 tag = False
 current_version = 1.16.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.dev(?P<dev>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}.dev{dev}
 	{major}.{minor}.{patch}
 
@@ -17,7 +17,7 @@ serialize =
 search = "version": "{current_version}",
 replace = "version": "{new_version}",
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<dev>\d+)-alpha)?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{dev}-alpha
 	{major}.{minor}.{patch}
 
@@ -28,3 +28,7 @@ replace = openzaak_version: '{new_version}'
 [bumpversion:file:deployment/single-server/open-zaak.yml]
 search = openzaak_version: '{current_version}'
 replace = openzaak_version: '{new_version}'
+
+[bumpversion:file:src/openzaak/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,23 @@ Changelog
 
 1.17.0 (TBD)
 ------------
+
+**New features**
+
+* [open-zaak/open-notificaties#156] Define kenmerk for Zaak.zaaktype.catalogus
+
+.. warning::
+
+    In order to use this new kenmerk, Open Notificaties must be updated to version 1.x.x (TBD)
+    and the ``src/manage.py register_kanalen`` command must be run in Open Zaak to update
+    the ``zaken`` kanaal with this new kenmerk
+
+.. warning::
+
+    If you are using ``django-setup-configuration`` to configure Open Zaak and Open Notificaties,
+    make sure to add ``zaaktype.catalogus`` to the filters of the ``zaken`` kanaal in ``notifications_kanalen_config``.
+
+
 **Bugfixes and QOL**
 
 * [maykinmedia/open-api-framework#66] updated commonground-api-common to 2.1.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -307,7 +307,7 @@ mozilla-django-oidc==4.0.1
     # via mozilla-django-oidc-db
 mozilla-django-oidc-db==0.19.0
     # via open-api-framework
-notifications-api-common==0.3.1
+notifications-api-common==0.5.0
     # via commonground-api-common
 open-api-framework==0.9.0
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -496,7 +496,7 @@ multidict==6.1.0
     # via yarl
 mypy-extensions==1.0.0
     # via black
-notifications-api-common==0.3.1
+notifications-api-common==0.5.0
     # via
     #   -r requirements/base.txt
     #   commonground-api-common

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -530,7 +530,7 @@ multidict==6.1.0
     # via yarl
 mypy-extensions==1.0.0
     # via black
-notifications-api-common==0.3.1
+notifications-api-common==0.5.0
     # via
     #   -r requirements/base.txt
     #   commonground-api-common

--- a/src/notificaties.md
+++ b/src/notificaties.md
@@ -1,0 +1,190 @@
+## Notificaties
+## Berichtkenmerken voor Open Zaak API
+
+Kanalen worden typisch per component gedefinieerd. Producers versturen berichten op bepaalde kanalen,
+consumers ontvangen deze. Consumers abonneren zich via een notificatiecomponent (zoals <a href="https://notificaties-api.vng.cloud/api/v1/schema/" rel="nofollow">https://notificaties-api.vng.cloud/api/v1/schema/</a>) op berichten.
+
+Hieronder staan de kanalen beschreven die door deze component gebruikt worden, met de kenmerken bij elk bericht.
+
+De architectuur van de notificaties staat beschreven op <a href="https://github.com/VNG-Realisatie/notificaties-api" rel="nofollow">https://github.com/VNG-Realisatie/notificaties-api</a>.
+
+
+### autorisaties
+
+**Kanaal**
+`autorisaties`
+
+**Main resource**
+
+`applicatie`
+
+
+
+**Kenmerken**
+
+
+
+**Resources en acties**
+
+
+* <code>applicatie</code>: create, update, destroy
+
+
+### besluiten
+
+**Kanaal**
+`besluiten`
+
+**Main resource**
+
+`besluit`
+
+
+
+**Kenmerken**
+
+* `verantwoordelijke_organisatie`: Het RSIN van de niet-natuurlijk persoon zijnde de organisatie die het besluit heeft vastgesteld.
+* `besluittype`: URL-referentie naar het BESLUITTYPE (in de Catalogi API).
+
+**Resources en acties**
+
+
+* <code>besluit</code>: create, update, destroy
+
+* <code>besluitinformatieobject</code>: create, destroy
+
+
+### besluittypen
+
+**Kanaal**
+`besluittypen`
+
+**Main resource**
+
+`besluittype`
+
+
+
+**Kenmerken**
+
+* `catalogus`: URL-referentie naar de CATALOGUS waartoe dit BESLUITTYPE behoort.
+
+**Resources en acties**
+
+
+* <code>besluittype</code>: create, update, destroy
+
+
+### documenten
+
+**Kanaal**
+`documenten`
+
+**Main resource**
+
+`enkelvoudiginformatieobject`
+
+
+
+**Kenmerken**
+
+* `bronorganisatie`: Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd.
+* `informatieobjecttype`: URL-referentie naar het INFORMATIEOBJECTTYPE (in de Catalogi API).
+* `vertrouwelijkheidaanduiding`: Aanduiding van de mate waarin het INFORMATIEOBJECT voor de openbaarheid bestemd is.
+
+**Resources en acties**
+
+
+* <code>enkelvoudiginformatieobject</code>: create, update, destroy
+
+* <code>gebruiksrechten</code>: create, update, destroy
+
+* <code>verzending</code>: create, update, destroy
+
+
+### informatieobjecttypen
+
+**Kanaal**
+`informatieobjecttypen`
+
+**Main resource**
+
+`informatieobjecttype`
+
+
+
+**Kenmerken**
+
+* `catalogus`: URL-referentie naar de CATALOGUS waartoe dit INFORMATIEOBJECTTYPE behoort.
+
+**Resources en acties**
+
+
+* <code>informatieobjecttype</code>: create, update, destroy
+
+
+### zaaktypen
+
+**Kanaal**
+`zaaktypen`
+
+**Main resource**
+
+`zaaktype`
+
+
+
+**Kenmerken**
+
+* `catalogus`: URL-referentie naar de CATALOGUS waartoe dit ZAAKTYPE behoort.
+
+**Resources en acties**
+
+
+* <code>zaaktype</code>: create, update, destroy
+
+
+### zaken
+
+**Kanaal**
+`zaken`
+
+**Main resource**
+
+`zaak`
+
+
+
+**Kenmerken**
+
+* `bronorganisatie`: Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die de zaak heeft gecreeerd. Dit moet een geldig RSIN zijn van 9 nummers en voldoen aan <a href="https://nl.wikipedia.org/wiki/Burgerservicenummer#11-proef" rel="nofollow">https://nl.wikipedia.org/wiki/Burgerservicenummer#11-proef</a>
+* `zaaktype`: URL-referentie naar het ZAAKTYPE (in de Catalogi API).
+* `zaaktype.catalogus`: **EXPERIMENTEEL** URL-referentie naar de CATALOGUS waartoe dit ZAAKTYPE behoort.
+* `vertrouwelijkheidaanduiding`: Aanduiding van de mate waarin het zaakdossier van de ZAAK voor de openbaarheid bestemd is.
+
+**Resources en acties**
+
+
+* <code>zaak</code>: create, update, destroy
+
+* <code>status</code>: create
+
+* <code>zaakobject</code>: create, update, destroy
+
+* <code>zaakinformatieobject</code>: create
+
+* <code>zaakeigenschap</code>: create, update, destroy
+
+* <code>klantcontact</code>: create
+
+* <code>rol</code>: create, destroy
+
+* <code>resultaat</code>: create, update, destroy
+
+* <code>zaakbesluit</code>: create
+
+* <code>zaakcontactmoment</code>: create
+
+* <code>zaakverzoek</code>: create
+
+

--- a/src/openzaak/__init__.py
+++ b/src/openzaak/__init__.py
@@ -3,6 +3,6 @@
 from .celery import app as celery_app
 
 __all__ = ("celery_app",)
-__version__ = "1.0.0"
+__version__ = "1.16.0"
 __author__ = "Maykin Media"
 __homepage__ = "https://github.com/open-zaak/open-zaak"

--- a/src/openzaak/components/catalogi/admin/admin_views.py
+++ b/src/openzaak/components/catalogi/admin/admin_views.py
@@ -324,7 +324,7 @@ class ZaaktypePublishView(AdminContextMixin, PermissionRequiredMixin, DetailView
 
     def send_notification(self, context_request):
 
-        viewset = ZaakTypeViewSet()
+        viewset = ZaakTypeViewSet(request=self.request)
         viewset.action = "update"
 
         reference_object = self.object

--- a/src/openzaak/components/catalogi/admin/side_effects.py
+++ b/src/openzaak/components/catalogi/admin/side_effects.py
@@ -99,7 +99,7 @@ class VersioningSideEffect(SideEffectBase):
 class NotificationSideEffect(SideEffectBase):
     def apply(self):
         viewset_cls = VIEWSET_FOR_MODEL[type(self.original)]
-        viewset = viewset_cls()
+        viewset = viewset_cls(request=self.request)
 
         send_notification = False
         is_create = (

--- a/src/openzaak/components/urls.py
+++ b/src/openzaak/components/urls.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2022 Dimpact
 from django.urls import include, path
 
+from openzaak import __version__
+
 from .views import ComponentIndexView
 
 urlpatterns = [
@@ -36,7 +38,11 @@ urlpatterns = [
     # zaken
     path(
         "zaken/",
-        ComponentIndexView.as_view(component="zaken", github_ref="stable/1.2.x"),
+        ComponentIndexView.as_view(
+            component="zaken",
+            repository="https://github.com/open-zaak/open-zaak",
+            github_ref=__version__,
+        ),
         name="index-zaken",
     ),
     path("zaken/api/", include("openzaak.components.zaken.api.urls")),

--- a/src/openzaak/components/views.py
+++ b/src/openzaak/components/views.py
@@ -8,10 +8,19 @@ DEFAULT_VNG_COMPONENTS_BRANCH = "stable/1.0.x"
 class ComponentIndexView(TemplateView):
     template_name = "index.html"
     # custom context
+    organization = "https://github.com/VNG-Realisatie"
     github_ref = DEFAULT_VNG_COMPONENTS_BRANCH
+    repository = ""
     component = ""
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context.update({"component": self.component, "github_ref": self.github_ref})
+        context.update(
+            {
+                "component": self.component,
+                "organization": self.organization,
+                "repository": self.repository,
+                "github_ref": self.github_ref,
+            }
+        )
         return context

--- a/src/openzaak/components/zaken/api/kanalen.py
+++ b/src/openzaak/components/zaken/api/kanalen.py
@@ -1,11 +1,75 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
-from notifications_api_common.kanalen import Kanaal
+from typing import Dict, cast
+
+from django.db.models import Field, Model
+
+from glom import glom
+from notifications_api_common.kanalen import Kanaal as _Kanaal
+from rest_framework.request import Request
+from vng_api_common.tests import reverse
+
+from openzaak.utils.help_text import mark_experimental
 
 from ..models import Zaak
+
+
+class Kanaal(_Kanaal):
+    @staticmethod
+    def get_field(model: Model, field: str) -> Field:
+        """
+        Function to retrieve a field from a Model, can also be passed a path to a field
+        (e.g. `zaaktype.catalogus`)
+        """
+        if "." in field:
+            model_field = None
+            bits = field.split(".")
+            for i, part in enumerate(bits):
+                model_field = model._meta.get_field(part)
+                if fk_field := getattr(model_field, "fk_field", None):
+                    model_field = model._meta.get_field(fk_field)
+                if i != len(bits):
+                    model = cast(Model, model_field.related_model)
+            assert model_field, "Could not find field on model"
+            return model_field
+        return model._meta.get_field(field)
+
+    def get_kenmerken(
+        self, obj: Model, data: dict | None = None, request: Request | None = None
+    ) -> Dict:
+        """
+        Overridden to support sending kenmerken that are not directly part of the main
+        resource (e.g `Zaak.zaaktype.catalogus`)
+        """
+        data = data or {}
+        kenmerken = {}
+        for kenmerk in self.kenmerken:
+            value = data.get(kenmerk, glom(obj, kenmerk, default=""))
+            if isinstance(value, Model):
+                if _loose_fk_data := getattr(value, "_loose_fk_data", None):
+                    value = _loose_fk_data["url"]
+                else:
+                    value = reverse(value)
+                    if request:
+                        value = request.build_absolute_uri(value)
+            kenmerken[kenmerk] = value
+        return kenmerken
+
 
 KANAAL_ZAKEN = Kanaal(
     "zaken",
     main_resource=Zaak,
-    kenmerken=("bronorganisatie", "zaaktype", "vertrouwelijkheidaanduiding"),
+    kenmerken=(
+        "bronorganisatie",
+        "zaaktype",
+        "zaaktype.catalogus",
+        "vertrouwelijkheidaanduiding",
+    ),
+    extra_kwargs={
+        "zaaktype.catalogus": {
+            "help_text": mark_experimental(
+                "URL-referentie naar de CATALOGUS waartoe dit ZAAKTYPE behoort."
+            )
+        }
+    },
 )

--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -246,7 +246,7 @@ class ZaakViewSet(
     """
 
     queryset = (
-        Zaak.objects.select_related("_zaaktype")
+        Zaak.objects.select_related("_zaaktype", "_zaaktype__catalogus")
         .prefetch_related(
             "deelzaken",
             models.Prefetch(

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -71,6 +71,7 @@ info:
 
     * `bronorganisatie`: Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die de zaak heeft gecreeerd. Dit moet een geldig RSIN zijn van 9 nummers en voldoen aan https://nl.wikipedia.org/wiki/Burgerservicenummer#11-proef
     * `zaaktype`: URL-referentie naar het ZAAKTYPE (in de Catalogi API).
+    * `zaaktype.catalogus`: **EXPERIMENTEEL** URL-referentie naar de CATALOGUS waartoe dit ZAAKTYPE behoort.
     * `vertrouwelijkheidaanduiding`: Aanduiding van de mate waarin het zaakdossier van de ZAAK voor de openbaarheid bestemd is.
 
     **Resources en acties**

--- a/src/openzaak/components/zaken/tests/test_notifications_send.py
+++ b/src/openzaak/components/zaken/tests/test_notifications_send.py
@@ -24,7 +24,7 @@ from vng_api_common.constants import (
 from vng_api_common.models import JWTSecret
 from vng_api_common.tests import reverse
 from zgw_consumers.constants import APITypes
-from zgw_consumers.models import Service
+from zgw_consumers.test.factories import ServiceFactory
 
 from openzaak.components.besluiten.tests.factories import BesluitFactory
 from openzaak.components.catalogi.tests.factories import (
@@ -121,7 +121,7 @@ class SendNotifTestCase(NotificationsConfigMixin, JWTAuthMixin, APITestCase):
         Check if the zaaktype.catalogus kenmerk is correctly sent if the Zaak
         has an external zaaktype
         """
-        Service.objects.create(
+        ServiceFactory.create(
             api_root="https://externe.catalogus.nl/api/v1/", api_type=APITypes.ztc
         )
 
@@ -185,7 +185,7 @@ class SendNotifTestCase(NotificationsConfigMixin, JWTAuthMixin, APITestCase):
         Check if the zaaktype.catalogus kenmerk is left empty sent if the Zaak
         has an external zaaktype and the Catalogus could not be fetched
         """
-        Service.objects.create(
+        ServiceFactory.create(
             api_root="https://externe.catalogus.nl/api/v1/", api_type=APITypes.ztc
         )
 
@@ -270,6 +270,7 @@ class SendNotifTestCase(NotificationsConfigMixin, JWTAuthMixin, APITestCase):
                 "kenmerken": {
                     "bronorganisatie": zaak.bronorganisatie,
                     "zaaktype": f"http://testserver{zaaktype_url}",
+                    "zaaktype.catalogus": f"http://testserver{reverse(zaak.zaaktype.catalogus)}",
                     "vertrouwelijkheidaanduiding": zaak.vertrouwelijkheidaanduiding,
                 },
             },
@@ -299,6 +300,7 @@ class SendNotifTestCase(NotificationsConfigMixin, JWTAuthMixin, APITestCase):
                 "kenmerken": {
                     "bronorganisatie": zaak.bronorganisatie,
                     "zaaktype": f"http://testserver{reverse(zaak.zaaktype)}",
+                    "zaaktype.catalogus": f"http://testserver{reverse(zaak.zaaktype.catalogus)}",
                     "vertrouwelijkheidaanduiding": zaak.vertrouwelijkheidaanduiding,
                 },
             },
@@ -330,6 +332,7 @@ class SendNotifTestCase(NotificationsConfigMixin, JWTAuthMixin, APITestCase):
                 "kenmerken": {
                     "bronorganisatie": zaak.bronorganisatie,
                     "zaaktype": f"http://testserver{reverse(zaak.zaaktype)}",
+                    "zaaktype.catalogus": f"http://testserver{reverse(zaak.zaaktype.catalogus)}",
                     "vertrouwelijkheidaanduiding": zaak.vertrouwelijkheidaanduiding,
                 },
             },
@@ -379,6 +382,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "bronorganisatie": data["bronorganisatie"],
                 "zaaktype": f"http://testserver{zaaktype_url}",
+                "zaaktype.catalogus": f"http://testserver{reverse(zaaktype.catalogus)}",
                 "vertrouwelijkheidaanduiding": data["vertrouwelijkheidaanduiding"],
             },
             "resource": "zaak",
@@ -419,6 +423,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "bronorganisatie": zaak.bronorganisatie,
                 "zaaktype": f"http://testserver{reverse(zaak.zaaktype)}",
+                "zaaktype.catalogus": f"http://testserver{reverse(zaak.zaaktype.catalogus)}",
                 "vertrouwelijkheidaanduiding": zaak.vertrouwelijkheidaanduiding,
             },
             "resource": "zaak",
@@ -476,6 +481,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "bronorganisatie": zaak.bronorganisatie,
                 "zaaktype": f"http://testserver{reverse(zaak.zaaktype)}",
+                "zaaktype.catalogus": f"http://testserver{reverse(zaak.zaaktype.catalogus)}",
                 "vertrouwelijkheidaanduiding": zaak.vertrouwelijkheidaanduiding,
             },
             "resource": "status",
@@ -530,6 +536,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "bronorganisatie": zaak.bronorganisatie,
                 "zaaktype": f"http://testserver{reverse(zaak.zaaktype)}",
+                "zaaktype.catalogus": f"http://testserver{reverse(zaak.zaaktype.catalogus)}",
                 "vertrouwelijkheidaanduiding": zaak.vertrouwelijkheidaanduiding,
             },
             "resource": "zaakobject",
@@ -587,6 +594,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "bronorganisatie": zaak.bronorganisatie,
                 "zaaktype": f"http://testserver{reverse(zaak.zaaktype)}",
+                "zaaktype.catalogus": f"http://testserver{reverse(zaak.zaaktype.catalogus)}",
                 "vertrouwelijkheidaanduiding": zaak.vertrouwelijkheidaanduiding,
             },
             "resource": "zaakinformatieobject",
@@ -631,6 +639,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "bronorganisatie": zio.zaak.bronorganisatie,
                 "zaaktype": f"http://testserver{reverse(zio.zaak.zaaktype)}",
+                "zaaktype.catalogus": f"http://testserver{reverse(zio.zaak.zaaktype.catalogus)}",
                 "vertrouwelijkheidaanduiding": zio.zaak.vertrouwelijkheidaanduiding,
             },
             "resource": "zaakinformatieobject",
@@ -682,6 +691,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "bronorganisatie": zaak.bronorganisatie,
                 "zaaktype": f"http://testserver{reverse(zaak.zaaktype)}",
+                "zaaktype.catalogus": f"http://testserver{reverse(zaak.zaaktype.catalogus)}",
                 "vertrouwelijkheidaanduiding": zaak.vertrouwelijkheidaanduiding,
             },
             "resource": "zaakeigenschap",
@@ -731,6 +741,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "bronorganisatie": zaak.bronorganisatie,
                 "zaaktype": f"http://testserver{reverse(zaak.zaaktype)}",
+                "zaaktype.catalogus": f"http://testserver{reverse(zaak.zaaktype.catalogus)}",
                 "vertrouwelijkheidaanduiding": zaak.vertrouwelijkheidaanduiding,
             },
             "resource": "klantcontact",
@@ -790,6 +801,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "bronorganisatie": zaak.bronorganisatie,
                 "zaaktype": f"http://testserver{reverse(zaak.zaaktype)}",
+                "zaaktype.catalogus": f"http://testserver{reverse(zaak.zaaktype.catalogus)}",
                 "vertrouwelijkheidaanduiding": zaak.vertrouwelijkheidaanduiding,
             },
             "resource": "rol",
@@ -831,6 +843,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "bronorganisatie": rol.zaak.bronorganisatie,
                 "zaaktype": f"http://testserver{reverse(rol.zaak.zaaktype)}",
+                "zaaktype.catalogus": f"http://testserver{reverse(rol.zaak.zaaktype.catalogus)}",
                 "vertrouwelijkheidaanduiding": rol.zaak.vertrouwelijkheidaanduiding,
             },
             "resource": "rol",
@@ -884,6 +897,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "bronorganisatie": zaak.bronorganisatie,
                 "zaaktype": f"http://testserver{reverse(zaak.zaaktype)}",
+                "zaaktype.catalogus": f"http://testserver{reverse(zaak.zaaktype.catalogus)}",
                 "vertrouwelijkheidaanduiding": zaak.vertrouwelijkheidaanduiding,
             },
             "resource": "resultaat",
@@ -927,6 +941,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "bronorganisatie": resultaat.zaak.bronorganisatie,
                 "zaaktype": f"http://testserver{reverse(resultaat.zaak.zaaktype)}",
+                "zaaktype.catalogus": f"http://testserver{reverse(resultaat.zaak.zaaktype.catalogus)}",
                 "vertrouwelijkheidaanduiding": resultaat.zaak.vertrouwelijkheidaanduiding,
             },
             "resource": "resultaat",
@@ -973,6 +988,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "bronorganisatie": besluit.zaak.bronorganisatie,
                 "zaaktype": f"http://testserver{reverse(besluit.zaak.zaaktype)}",
+                "zaaktype.catalogus": f"http://testserver{reverse(besluit.zaak.zaaktype.catalogus)}",
                 "vertrouwelijkheidaanduiding": besluit.zaak.vertrouwelijkheidaanduiding,
             },
             "resource": "zaakbesluit",

--- a/src/openzaak/components/zaken/tests/test_notifications_send_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_notifications_send_cmis.py
@@ -78,6 +78,7 @@ class FailedNotificationCMISTests(
             "kenmerken": {
                 "bronorganisatie": zaak.bronorganisatie,
                 "zaaktype": f"http://testserver{reverse(zaak.zaaktype)}",
+                "zaaktype.catalogus": f"http://testserver{reverse(zaak.zaaktype.catalogus)}",
                 "vertrouwelijkheidaanduiding": zaak.vertrouwelijkheidaanduiding,
             },
             "resource": "zaakinformatieobject",

--- a/src/openzaak/notifications/tests/test_notification_retry.py
+++ b/src/openzaak/notifications/tests/test_notification_retry.py
@@ -83,6 +83,7 @@ class NotificationCeleryRetryTestCase(
             "kenmerken": {
                 "bronorganisatie": "517439943",
                 "zaaktype": f"http://testserver{zaaktype_url}",
+                "zaaktype.catalogus": f"http://testserver{reverse(zaaktype.catalogus)}",
                 "vertrouwelijkheidaanduiding": VertrouwelijkheidsAanduiding.openbaar,
             },
         }
@@ -141,6 +142,7 @@ class NotificationCeleryRetryTestCase(
             "kenmerken": {
                 "bronorganisatie": "517439943",
                 "zaaktype": f"http://testserver{zaaktype_url}",
+                "zaaktype.catalogus": f"http://testserver{reverse(zaaktype.catalogus)}",
                 "vertrouwelijkheidaanduiding": VertrouwelijkheidsAanduiding.openbaar,
             },
         }

--- a/src/openzaak/notifications/tests/test_register_kanaal.py
+++ b/src/openzaak/notifications/tests/test_register_kanaal.py
@@ -168,6 +168,7 @@ class RegisterKanaalTests(NotificationsConfigMixin, TestCase):
                         "filters": [
                             "bronorganisatie",
                             "zaaktype",
+                            "zaaktype.catalogus",
                             "vertrouwelijkheidaanduiding",
                         ],
                     },

--- a/src/openzaak/templates/index.html
+++ b/src/openzaak/templates/index.html
@@ -41,7 +41,7 @@
             <div class="card">
               <h5 class="card__title"><i class="fas fa-bullhorn"></i> Notificaties</h5>
               <p>Gebeurtenissen waarover dit component notificaties verstuurt.</p>
-              <a href="https://github.com/VNG-Realisatie/{{ component }}-api/blob/{{ github_ref }}/src/notificaties.md" class="button button--primary">Notificaties</a>
+              <a href="{% if repository %}{{ repository }}{% else %}{{ organization }}/{{ component }}-api{% endif %}/blob/{{ github_ref }}/src/notificaties.md#{{ component }}" class="button button--primary">Notificaties</a>
             </div>
           </div>
         {% endblock %}


### PR DESCRIPTION
Fixes https://github.com/open-zaak/open-notificaties/issues/156

Related PR in Open Notificaties:
- https://github.com/open-zaak/open-notificaties/pull/208

**Changes**

* Add (experimental) notificaties kenmerk for Zaak.zaaktype.catalogus
* Refer to self hosted notification documentation (instead of the reference implementation github)
