### PR TITLE
:sparkles: [#1748] add zaaktype.identificatie into generate_data command

### DIFF
--- a/src/openzaak/components/catalogi/tests/factories/zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/factories/zaaktype.py
@@ -64,6 +64,9 @@ class ZaakTypeFactory(factory.django.DjangoModelFactory):
         with_etag = factory.Trait(
             _etag=factory.PostGenerationMethodCall("calculate_etag_value")
         )
+        with_identificatie = factory.Trait(
+            identificatie=factory.Sequence(lambda n: "ZAAKTYPE_{}".format(n))
+        )
 
     @factory.lazy_attribute
     def verlengingstermijn(obj):

--- a/src/openzaak/management/commands/generate_data.py
+++ b/src/openzaak/management/commands/generate_data.py
@@ -249,7 +249,10 @@ class Command(BaseCommand):
 
         # zaaktype - 100
         zaaktypen = ZaakTypeFactory.build_batch(
-            self.zaaktypen_amount, catalogus=catalog, concept=False
+            self.zaaktypen_amount,
+            catalogus=catalog,
+            concept=False,
+            with_identificatie=True,
         )
         zaaktypen = ZaakType.objects.bulk_create(zaaktypen)
         self.log_created(zaaktypen)

--- a/src/openzaak/tests/management/test_generate_data.py
+++ b/src/openzaak/tests/management/test_generate_data.py
@@ -8,6 +8,7 @@ from django.core.management import CommandError, call_command
 import requests_mock
 from rest_framework.test import APITestCase
 
+from openzaak.components.catalogi.models import ZaakType
 from openzaak.components.zaken.models import Zaak
 from openzaak.selectielijst.models import ReferentieLijstConfig
 from openzaak.selectielijst.tests import mock_selectielijst_oas_get
@@ -73,6 +74,10 @@ class GenerateDataTests(APITestCase):
                 self.assertEqual(model.objects.count(), obj_count)
 
         # assert that some attributes are filled
+        # catalogi
+        zaaktype = ZaakType.objects.get()
+        self.assertEqual(zaaktype.identificatie, "ZAAKTYPE_0")
+        # zaken
         for zaak in Zaak.objects.all():
             with self.subTest(zaak):
                 self.assertEqual(

--- a/src/openzaak/tests/management/test_generate_data.py
+++ b/src/openzaak/tests/management/test_generate_data.py
@@ -76,7 +76,7 @@ class GenerateDataTests(APITestCase):
         # assert that some attributes are filled
         # catalogi
         zaaktype = ZaakType.objects.get()
-        self.assertEqual(zaaktype.identificatie, "ZAAKTYPE_0")
+        self.assertTrue(zaaktype.identificatie.startswith("ZAAKTYPE_"))
         # zaken
         for zaak in Zaak.objects.all():
             with self.subTest(zaak):


### PR DESCRIPTION
Fixes #1748
