### PR TITLE
:green_heart: Fix failing CI due to openapitools issue

### DIFF
--- a/openapitools.json
+++ b/openapitools.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+    "spaces": 2,
+    "generator-cli": {
+        "version": "7.8.0"
+    }
+}


### PR DESCRIPTION
the generate-sdks job was failing (https://github.com/open-zaak/open-zaak/actions/runs/10937202249/job/30363822296?pr=1725) due to some network calls that were performed when validating the OAS, this is avoided by specifying the version of the generator-cli in openapitools.json

see also: https://github.com/OpenAPITools/openapi-generator-cli/issues/802

