### PR TITLE
[#1776] allow searching zaken on zaaktype omschrijving/identificatie

### DIFF
--- a/src/openzaak/components/zaken/admin/zaken.py
+++ b/src/openzaak/components/zaken/admin/zaken.py
@@ -663,6 +663,7 @@ class ZaakAdmin(
         "uuid",
         "zaaktype_url",
         "_zaaktype__identificatie",
+        "_zaaktype__zaaktype_omschrijving",
         "rol__natuurlijkpersoon__inp_bsn",
         "rol__nietnatuurlijkpersoon__inn_nnp_id",
     )


### PR DESCRIPTION
Fixes #1776 

**Changes**

Allows searching for zaken with local zaaktypes on `zaaktype_omschrijving` and `identificatie`. 

