### PR TITLE
:sparkles:[#1793] add statustype_omschrijving to generate_data status…

### DIFF
--- a/src/openzaak/components/catalogi/tests/factories/statustype.py
+++ b/src/openzaak/components/catalogi/tests/factories/statustype.py
@@ -9,6 +9,7 @@ from .zaaktype import ZaakTypeFactory
 class StatusTypeFactory(factory.django.DjangoModelFactory):
     statustypevolgnummer = factory.sequence(lambda n: n + 1)
     zaaktype = factory.SubFactory(ZaakTypeFactory)
+    statustype_omschrijving = factory.Faker("sentence", locale="nl")
 
     class Meta:
         model = StatusType

--- a/src/openzaak/tests/management/test_generate_data.py
+++ b/src/openzaak/tests/management/test_generate_data.py
@@ -13,7 +13,7 @@ from maykin_2fa.test import disable_admin_mfa
 from rest_framework.test import APITestCase
 
 from openzaak.accounts.tests.factories import SuperUserFactory
-from openzaak.components.catalogi.models import ResultaatType, ZaakType
+from openzaak.components.catalogi.models import ResultaatType, StatusType, ZaakType
 from openzaak.components.zaken.models import Zaak
 from openzaak.selectielijst.models import ReferentieLijstConfig
 from openzaak.selectielijst.tests import mock_selectielijst_oas_get
@@ -119,6 +119,10 @@ class GenerateDataTests(SelectieLijstMixin, APITestCase):
                     f"{config.service.api_root}resultaten/cc5ae4e3-a9e6-4386-bcee-46be4986a829",
                 )
                 self.assertIsNotNone(zaak.archiefactiedatum)
+
+        self.assertEquals(
+            StatusType.objects.filter(statustype_omschrijving="").count(), 0
+        )
 
     def test_generate_data_no(self):
         with patch("builtins.input", lambda *args: "no"):


### PR DESCRIPTION
Fixes #1793


