### PR TITLE
:wrench: Use new issue types in templates instead of labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,9 @@
 name: Probleem melden / Bug report
 description: Meldt een probleem om ons te helpen verbeteren  / Create a report to help us improve
 title: "Title here"
+type: "Bug"
 labels: ["bug", "triage"]
+projects: ["maykinmedia/15"]
 assignees: []
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Verzoek tot verbetering / Feature request
 description: Stel een idee voor om het product beter te maken / Suggest an idea for this product
 title: "Title here"
+type: "Feature"
 labels: ["enhancement", "triage"]
 projects: ["maykinmedia/15"]
 assignees: []


### PR DESCRIPTION
I also added types to the issues that are currently open