### PR TITLE
add linkcheck_request_headers for jwt.io

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,12 @@ linkcheck_ignore = [
     r"http://localhost:\d+/",
     r"http://127\.0\.0\.1:\d+/",
     r"https://.*sentry\.openzaak\.nl.*",
-    r"https://jwt.io.*",  # raises 500 errors when making requests with curl/requests
 ]
+
+linkcheck_request_headers = {
+    "https://jwt.io": {
+        "Accept-Language": "en-US",
+    },
+}
 
 sphinx_tabs_valid_builders = ["linkcheck"]


### PR DESCRIPTION
jwt.io returns 500 with curl and within the ci. The reason is that it expects an `Accept-Language` header.

**Changes**

- Add Accept-Language header to jwt.io requests within the docs.

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

(feel free to close if it's unnecessary)
