### PR TITLE
:bug: [#1901] Remove unnecessary geo headers for reserveer zaaknummer endpoint

### DIFF
--- a/src/openzaak/components/autorisaties/openapi.yaml
+++ b/src/openzaak/components/autorisaties/openapi.yaml
@@ -111,13 +111,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       tags:

--- a/src/openzaak/components/besluiten/openapi.yaml
+++ b/src/openzaak/components/besluiten/openapi.yaml
@@ -115,13 +115,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query

--- a/src/openzaak/components/catalogi/openapi.yaml
+++ b/src/openzaak/components/catalogi/openapi.yaml
@@ -154,13 +154,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -1305,13 +1305,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -1829,13 +1829,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -2841,13 +2841,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -3985,13 +3985,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -5002,13 +5002,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -5998,13 +5998,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -7028,13 +7028,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -8014,13 +8014,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -9036,13 +9036,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -11355,7 +11355,7 @@ components:
         hierarchieInformatieobjecttypeOmschrijvingGeneriek:
           type: string
           title: Hierarchie
-          description: De plaats in de rangorde van het informatieobjecttype.
+          description: De plaats in de rangorde van het informatieobjecttype
           maxLength: 80
         opmerkingInformatieobjecttypeOmschrijvingGeneriek:
           type: string
@@ -11399,7 +11399,7 @@ components:
         hierarchieInformatieobjecttypeOmschrijvingGeneriek:
           type: string
           title: Hierarchie
-          description: De plaats in de rangorde van het informatieobjecttype.
+          description: De plaats in de rangorde van het informatieobjecttype
           maxLength: 80
         opmerkingInformatieobjecttypeOmschrijvingGeneriek:
           type: string

--- a/src/openzaak/components/documenten/openapi.yaml
+++ b/src/openzaak/components/documenten/openapi.yaml
@@ -396,13 +396,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -2340,13 +2340,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -5454,13 +5454,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       tags:

--- a/src/openzaak/components/zaken/api/urls.py
+++ b/src/openzaak/components/zaken/api/urls.py
@@ -8,6 +8,7 @@ from vng_api_common import routers
 from ..api.schema import custom_settings
 from .viewsets import (
     KlantContactViewSet,
+    ReserveerZaakNummerViewSet,
     ResultaatViewSet,
     RolViewSet,
     StatusViewSet,
@@ -39,7 +40,7 @@ router.register("resultaten", ResultaatViewSet)
 router.register("zaakinformatieobjecten", ZaakInformatieObjectViewSet)
 router.register("zaakcontactmomenten", ZaakContactMomentViewSet)
 router.register("zaakverzoeken", ZaakVerzoekViewSet)
-
+router.register("reserveer_zaaknummer", ReserveerZaakNummerViewSet)
 
 urlpatterns = [
     re_path(

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -113,13 +113,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -736,13 +736,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -1893,13 +1893,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -2738,13 +2738,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -4931,13 +4931,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -6701,13 +6701,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -10396,13 +10396,13 @@ paths:
       - name: page
         required: false
         in: query
-        description: Een pagina binnen de gepagineerde set resultaten.
+        description: A page number within the paginated result set.
         schema:
           type: integer
       - name: pageSize
         required: false
         in: query
-        description: Het aantal resultaten terug te geven per pagina.
+        description: Number of results to return per page.
         schema:
           type: integer
       - in: query
@@ -14366,7 +14366,7 @@ components:
           allOf:
           - $ref: '#/components/schemas/DigiDAuthContext'
           nullable: true
-          title: authentication context
+          title: authenticatiecontext
           description: |-
             Information about the authentication and mandate (if relevant) that applied when the role was added to the case. It is essential when you later want to retrieve information again which should match certain authentication guarantees, like minimum level of assurance. The exact shape of data depends on the selected `betrokkeneType`.
 
@@ -14380,7 +14380,7 @@ components:
           allOf:
           - $ref: '#/components/schemas/DigiDAuthContextRequest'
           nullable: true
-          title: authentication context
+          title: authenticatiecontext
           description: |-
             Information about the authentication and mandate (if relevant) that applied when the role was added to the case. It is essential when you later want to retrieve information again which should match certain authentication guarantees, like minimum level of assurance. The exact shape of data depends on the selected `betrokkeneType`.
 
@@ -14394,7 +14394,7 @@ components:
           allOf:
           - $ref: '#/components/schemas/eHerkenningAuthContext'
           nullable: true
-          title: authentication context
+          title: authenticatiecontext
           description: |-
             Information about the authentication and mandate (if relevant) that applied when the role was added to the case. It is essential when you later want to retrieve information again which should match certain authentication guarantees, like minimum level of assurance. The exact shape of data depends on the selected `betrokkeneType`.
 
@@ -14408,7 +14408,7 @@ components:
           allOf:
           - $ref: '#/components/schemas/eHerkenningAuthContextRequest'
           nullable: true
-          title: authentication context
+          title: authenticatiecontext
           description: |-
             Information about the authentication and mandate (if relevant) that applied when the role was added to the case. It is essential when you later want to retrieve information again which should match certain authentication guarantees, like minimum level of assurance. The exact shape of data depends on the selected `betrokkeneType`.
 
@@ -14447,7 +14447,7 @@ components:
           allOf:
           - $ref: '#/components/schemas/eHerkenningAuthContext'
           nullable: true
-          title: authentication context
+          title: authenticatiecontext
           description: |-
             Information about the authentication and mandate (if relevant) that applied when the role was added to the case. It is essential when you later want to retrieve information again which should match certain authentication guarantees, like minimum level of assurance. The exact shape of data depends on the selected `betrokkeneType`.
 
@@ -14461,7 +14461,7 @@ components:
           allOf:
           - $ref: '#/components/schemas/eHerkenningAuthContextRequest'
           nullable: true
-          title: authentication context
+          title: authenticatiecontext
           description: |-
             Information about the authentication and mandate (if relevant) that applied when the role was added to the case. It is essential when you later want to retrieve information again which should match certain authentication guarantees, like minimum level of assurance. The exact shape of data depends on the selected `betrokkeneType`.
 

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -561,6 +561,172 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
           description: Internal server error
+  /reserveer_zaaknummer:
+    post:
+      operationId: zaak_reserveer_zaaknummer
+      description: '**EXPERIMENTEEL** Reserveer een zaaknummer binnen een specifieke
+        bronorganisatie zonder direct een Zaak aan te maken. Dit zaaknummer zal toegekend
+        worden aan de eerstvolgende Zaak die met dit zaaknummer wordt aangemaakt binnen
+        de bronorganisatie en het zaaknummer kan daarna niet hergebruikt worden.'
+      summary: Reserveer een zaaknummer
+      parameters:
+      - in: header
+        name: Content-Type
+        schema:
+          type: string
+          enum:
+          - application/json
+        description: Content type van de verzoekinhoud.
+        required: true
+      tags:
+      - reserveer_zaaknummer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReserveZaakIdentificatieRequest'
+        required: true
+      security:
+      - JWT-Claims:
+        - zaken.aanmaken
+      responses:
+        '201':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: URL waar de resource leeft.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReserveZaakIdentificatie'
+          description: Created
+        '400':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+          description: Bad request
+        '401':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unauthorized
+        '403':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Forbidden
+        '406':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Not acceptable
+        '409':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Conflict
+        '410':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Gone
+        '415':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Unsupported media type
+        '429':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Too many requests
+        '500':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Internal server error
+        '412':
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+          description: Precondition failed
   /resultaten:
     get:
       operationId: resultaat_list
@@ -10857,200 +11023,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedExpandZaakList'
           description: OK
-        '400':
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ValidatieFout'
-          description: Bad request
-        '401':
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-          description: Unauthorized
-        '403':
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-          description: Forbidden
-        '406':
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-          description: Not acceptable
-        '409':
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-          description: Conflict
-        '410':
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-          description: Gone
-        '415':
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-          description: Unsupported media type
-        '429':
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-          description: Too many requests
-        '500':
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-          description: Internal server error
-        '412':
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Fout'
-          description: Precondition failed
-  /zaken/reserveer_zaaknummer:
-    post:
-      operationId: zaak_reserveer_zaaknummer
-      description: '**EXPERIMENTEEL** Reserveer een zaaknummer binnen een specifieke
-        bronorganisatie zonder direct een Zaak aan te maken. Dit zaaknummer zal toegekend
-        worden aan de eerstvolgende Zaak die met dit zaaknummer wordt aangemaakt binnen
-        de bronorganisatie en het zaaknummer kan daarna niet hergebruikt worden.'
-      summary: Reserveer een zaaknummer
-      parameters:
-      - in: header
-        name: Accept-Crs
-        schema:
-          type: string
-          enum:
-          - EPSG:4326
-        description: 'The desired ''Coordinate Reference System'' (CRS) of the response
-          data. According to the GeoJSON spec, WGS84 is the default (EPSG: 4326 is
-          the same as WGS84).'
-      - in: header
-        name: Content-Crs
-        schema:
-          type: string
-          enum:
-          - EPSG:4326
-        description: 'The ''Coordinate Reference System'' (CRS) of the request data.
-          According to the GeoJSON spec, WGS84 is the default (EPSG: 4326 is the same
-          as WGS84).'
-        required: true
-      - in: header
-        name: Content-Type
-        schema:
-          type: string
-          enum:
-          - application/json
-        description: Content type van de verzoekinhoud.
-        required: true
-      tags:
-      - zaken
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ReserveZaakIdentificatieRequest'
-        required: true
-      security:
-      - JWT-Claims:
-        - zaken.aanmaken
-      responses:
-        '201':
-          headers:
-            API-version:
-              schema:
-                type: string
-              description: 'Geeft een specifieke API-versie aan in de context van
-                een specifieke aanroep. Voorbeeld: 1.2.1.'
-            Location:
-              schema:
-                type: string
-                format: uri
-              description: URL waar de resource leeft.
-            Content-Crs:
-              schema:
-                type: string
-                enum:
-                - EPSG:4326
-              description: 'The ''Coordinate Reference System'' (CRS) of the request
-                data. According to the GeoJSON spec, WGS84 is the default (EPSG: 4326
-                is the same as WGS84).'
-              required: true
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ReserveZaakIdentificatie'
-          description: Created
         '400':
           headers:
             API-version:

--- a/src/openzaak/components/zaken/tests/test_auth.py
+++ b/src/openzaak/components/zaken/tests/test_auth.py
@@ -1723,3 +1723,17 @@ class ExternalZaaktypeScopeTests(JWTAuthMixin, APITestCase):
 
         self.assertEqual(response1.status_code, status.HTTP_200_OK)
         self.assertEqual(response2.status_code, status.HTTP_403_FORBIDDEN)
+
+
+@tag("gh-1836")
+class ReserveerZaaknummerTests(JWTAuthMixin, APITestCase):
+    scopes = [SCOPE_ZAKEN_ALLES_LEZEN, SCOPE_ZAKEN_BIJWERKEN]
+    max_vertrouwelijkheidaanduiding = VertrouwelijkheidsAanduiding.beperkt_openbaar
+    component = ComponentTypes.zrc
+
+    def test_cannot_reserveer_zaaknummer_without_correct_scope(self):
+        url = reverse("zaakidentificatie-list")
+
+        response = self.client.post(url, {"bronorganisatie": "000000000"})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/src/openzaak/components/zaken/tests/test_zaken.py
+++ b/src/openzaak/components/zaken/tests/test_zaken.py
@@ -715,13 +715,12 @@ class ZakenTests(JWTAuthMixin, APITestCase):
         error = get_validation_errors(response, "zaaktype")
         self.assertEqual(error["code"], "does_not_exist")
 
+    @tag("gh-1836")
     def test_reserve_zaak_identity(self):
 
         data = {"bronorganisatie": "111222333"}
 
-        response = self.client.post(
-            reverse("zaak-reserveer_zaaknummer"), data, **ZAAK_WRITE_KWARGS
-        )
+        response = self.client.post(reverse("zaakidentificatie-list"), data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         self.assertEqual(Zaak.objects.count(), 0)
@@ -763,15 +762,14 @@ class ZakenTests(JWTAuthMixin, APITestCase):
         )
         self.assertEqual(create_response_2.status_code, status.HTTP_400_BAD_REQUEST)
 
+    @tag("gh-1836")
     def test_reserve_zaak_identity_with_different_bronorganisatie(self):
 
         data = {"bronorganisatie": "111222333"}
 
-        response = self.client.post(
-            reverse("zaak-reserveer_zaaknummer"), data, **ZAAK_WRITE_KWARGS
-        )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        response = self.client.post(reverse("zaakidentificatie-list"), data)
 
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Zaak.objects.count(), 0)
         self.assertEqual(ZaakIdentificatie.objects.count(), 1)
 
@@ -789,8 +787,8 @@ class ZakenTests(JWTAuthMixin, APITestCase):
         create_response = self.client.post(
             reverse("zaak-list"), zaak_data, **ZAAK_WRITE_KWARGS
         )
-        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
 
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Zaak.objects.count(), 1)
         self.assertEqual(ZaakIdentificatie.objects.count(), 2)
 


### PR DESCRIPTION
Closes #1901

**Changes**

* Remove unnecessary geo headers for reserveer zaaknummer endpoint

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
