### PR TITLE
:construction_worker: [#1905] Upgrade postgres/postgis versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
     services:
       postgres:
-        image: postgis/postgis:12-2.5
+        image: postgis/postgis:17-3.5
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
         ports:
@@ -106,14 +106,16 @@ jobs:
 
     strategy:
       matrix:
-        postgres: ['12', '13', '14']
-        postgis: ['2.5', '3.2']
+        postgres: ['14', '15', '16', '17']
+        postgis: ['3.2', '3.5']
         exclude:
-          # postgis 2.5 is not compatible with recent postgres versions
-          - postgres: '13'
-            postgis: '2.5'
-          - postgres: '14'
-            postgis: '2.5'
+          # postgis 3.2 is not compatible with recent postgres versions
+          - postgres: '17'
+            postgis: '3.2'
+          - postgres: '16'
+            postgis: '3.2'
+          - postgres: '15'
+            postgis: '3.2'
 
 
     name: Tests (PG ${{ matrix.postgres }}, postgis ${{ matrix.postgis }})
@@ -159,7 +161,7 @@ jobs:
 
       - name: Upload Coverage Report
         # TODO find a better way to upload this only once
-        if: ${{ matrix.postgres == '14' && matrix.postgis == '3.2' }}
+        if: ${{ matrix.postgres == '17' && matrix.postgis == '3.5' }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-regular-tests
@@ -177,24 +179,14 @@ jobs:
 
     strategy:
       matrix:
-        postgres: ['12', '13', '14']
-        postgis: ['2.5', '3.2']
+        postgres: ['17']
+        postgis: ['3.5']
         binding: ['BROWSER', 'WEBSERVICE']
         cmisurlmapping: ['False', 'True']
         exclude:
-          # postgis 2.5 is not compatible with recent postgres versions
-          - postgres: '13'
-            postgis: '2.5'
-          - postgres: '14'
-            postgis: '2.5'
           # Browser binding + cmisurlmapping is not supported
           - binding: 'BROWSER'
             cmisurlmapping: 'True'
-          # do not run tests for all CMIS bindings on all database versions (we only run on postgres 12)
-          - binding: 'WEBSERVICE'
-            postgres: '13'
-          - binding: 'WEBSERVICE'
-            postgres: '14'
 
     name: Tests (PG ${{ matrix.postgres }}-${{ matrix.postgis }} ${{ matrix.binding }} binding, CMIS URL mapping = ${{ matrix.cmisurlmapping }})
 
@@ -242,7 +234,7 @@ jobs:
 
       - name: Upload Coverage Report
         # TODO find a better way to upload this only once
-        if: ${{ matrix.postgres == '14' && matrix.postgis == '3.2' && matrix.binding == 'BROWSER' && matrix.cmisurlmapping == 'False' }}
+        if: ${{ matrix.postgres == '17' && matrix.postgis == '3.5' && matrix.binding == 'BROWSER' && matrix.cmisurlmapping == 'False' }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-cmis-tests

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -21,7 +21,7 @@ jobs:
       apt-packages: 'libgdal-dev gdal-bin'
       python-version: '3.11'
       node-version: '18'
-      postgres-image: 'postgis/postgis:12-2.5'
+      postgres-image: 'postgis/postgis:16-3.5'
 
       django-settings-module: 'openzaak.conf.ci'
       django-secret-key: dummy

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.19.0 (TBD)
+------------
+
+**New features**
+
+* [:open-zaak:`1905`] Confirm support for Postgres versions 15 and 16 and Postgis 3.4 and 3.5
+
 1.18.0 (2025-02-14)
 -------------------
 

--- a/deployment/kubernetes/README.md
+++ b/deployment/kubernetes/README.md
@@ -34,7 +34,7 @@ to the correct cluster.
 
 **Database**
 
-The deployment assumes that a PostgreSQL 11 database cluster is available.
+The deployment assumes that a PostgreSQL 14 database cluster is available.
 
 You need:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ version: '3.4'
 
 services:
   db:
-    image: postgis/postgis:12-2.5
+    image: postgis/postgis:17-3.5
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     command: postgres -c max_connections=300 -c log_min_messages=LOG

--- a/docker/postgres.entrypoint-initdb.d/0001-open-zaak.sql
+++ b/docker/postgres.entrypoint-initdb.d/0001-open-zaak.sql
@@ -1,3 +1,2 @@
 CREATE USER openzaak;
-CREATE DATABASE openzaak;
-GRANT ALL PRIVILEGES ON DATABASE openzaak TO openzaak;
+CREATE DATABASE openzaak WITH OWNER openzaak;

--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -20,8 +20,8 @@ You need the following libraries and/or programs:
 
 * `Python`_ 3.11
 * Python `Virtualenv`_ and `Pip`_ 20.0 or above
-* `PostgreSQL`_ 10.0 or above, with the `PostGIS-extension`_
-* `Node.js`_ 16.0 or above
+* `PostgreSQL`_ 14.0 or above, with the `PostGIS-extension`_ version 3.2 or above
+* `Node.js`_ 18.0 or above
 * `npm`_ 8.0 or above
 * `Docker`_ 19.03 or above (and `docker-compose`_)
 

--- a/docs/installation/prerequisites.rst
+++ b/docs/installation/prerequisites.rst
@@ -20,12 +20,12 @@ which requires the postgis_ extension to be enabled.
 The supported versions in the table below are tested in the CI pipeline. Other versions
 *may* work but we offer no guarantees.
 
-============ ============ ============ ============ ============ ============
-Matrix       Postgres 10  Postgres 11  Postgres 12  Postgres 13  Postgres 14
-============ ============ ============ ============ ============ ============
-Postgis 2.5  V            V            V            X            X
-Postgis 3.2  V            V            V            V            V
-============ ============ ============ ============ ============ ============
+============ ============ ============ ============ ============
+Matrix       Postgres 14  Postgres 15  Postgres 16  Postgres 17
+============ ============ ============ ============ ============
+Postgis 3.2  V            X            X            X
+Postgis 3.5  V            V            V            V
+============ ============ ============ ============ ============
 
 .. warning:: Open Zaak only supports maintained versions of PostgreSQL. Once a version is
    `EOL <https://www.postgresql.org/support/versioning/>`_, support will

--- a/publiccode.yaml
+++ b/publiccode.yaml
@@ -138,7 +138,7 @@ dependsOn:
   open:
     - name: PostgreSQL
       optional: true
-      versionMin: '10.0'
+      versionMin: '14.0'
     - name: Kubernetes
       optional: true
       versionMin: '1.12'


### PR DESCRIPTION
Closes #1905

Tests are skipped for the last run, because there are no changes to .py files, here is a successful CI run: https://github.com/open-zaak/open-zaak/actions/runs/13438418210

**Changes**

* Upgrade postgres/postgis versions in CI

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
