### PR TITLE
[open-zaak/open-notificaties#231] Add catalogus kenmerk to besluiten & documenten kanaal

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,19 @@ Changelog
 
 **New features**
 
+* [open-zaak/open-notificaties#231] Add catalogus kenmerk to besluiten & documenten kanaal.
+
+.. warning::
+
+    In order to use this new kenmerk, the ``src/manage.py register_kanalen`` command must be run in Open Zaak to update
+    the ``besluiten`` & ``documenten`` kanaal with this new kenmerk.
+
+.. warning::
+
+    If you are using ``django-setup-configuration`` to configure Open Zaak and Open Notificaties,
+    make sure to add ``besluittype.catalogus`` to the filters of the ``besluiten`` kanaal & ``informatieobjecttype.catalogus``
+    to the filters of the ``documenten`` kanaal in ``notifications_kanalen_config``.
+
 * [:open-zaak:`1905`] Confirm support for Postgres versions 15 and 16 and Postgis 3.4 and 3.5
 
 1.18.0 (2025-02-14)

--- a/docs/api/experimental.rst
+++ b/docs/api/experimental.rst
@@ -70,6 +70,11 @@ Query parameters
 Documenten API
 ==============
 
+Notifications
+-------------
+
+For ``documenten`` notification channel a new "kenmerk" ``informatieobjecttype.catalogus`` is added.
+
 Endpoints
 ---------
 
@@ -130,7 +135,10 @@ Query parameters
 Besluiten API
 =============
 
-No deviation from the standard
+Notifications
+-------------
+
+For ``besluiten`` notification channel a new "kenmerk" ``besluittype.catalogus`` is added.
 
 
 Autorisaties API

--- a/src/notificaties.md
+++ b/src/notificaties.md
@@ -45,6 +45,7 @@ De architectuur van de notificaties staat beschreven op <a href="https://github.
 
 * `verantwoordelijke_organisatie`: Het RSIN van de niet-natuurlijk persoon zijnde de organisatie die het besluit heeft vastgesteld.
 * `besluittype`: URL-referentie naar het BESLUITTYPE (in de Catalogi API).
+* `besluittype.catalogus`: **EXPERIMENTEEL** URL-referentie naar de CATALOGUS waartoe dit BESLUITTYPE behoort.
 
 **Resources en acties**
 
@@ -91,6 +92,7 @@ De architectuur van de notificaties staat beschreven op <a href="https://github.
 * `bronorganisatie`: Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd.
 * `informatieobjecttype`: URL-referentie naar het INFORMATIEOBJECTTYPE (in de Catalogi API).
 * `vertrouwelijkheidaanduiding`: Aanduiding van de mate waarin het INFORMATIEOBJECT voor de openbaarheid bestemd is.
+* `informatieobjecttype.catalogus`: **EXPERIMENTEEL** URL-referentie naar de CATALOGUS waartoe dit INFORMATIEOBJECTTYPE behoort.
 
 **Resources en acties**
 
@@ -177,7 +179,7 @@ De architectuur van de notificaties staat beschreven op <a href="https://github.
 
 * <code>klantcontact</code>: create
 
-* <code>rol</code>: create, destroy
+* <code>rol</code>: create, update, destroy
 
 * <code>resultaat</code>: create, update, destroy
 

--- a/src/openzaak/components/besluiten/api/kanalen.py
+++ b/src/openzaak/components/besluiten/api/kanalen.py
@@ -1,11 +1,19 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
-from notifications_api_common.kanalen import Kanaal
+from openzaak.notifications.kanaal import Kanaal
+from openzaak.utils.help_text import mark_experimental
 
 from ..models import Besluit
 
 KANAAL_BESLUITEN = Kanaal(
     "besluiten",
     main_resource=Besluit,
-    kenmerken=("verantwoordelijke_organisatie", "besluittype"),
+    kenmerken=("verantwoordelijke_organisatie", "besluittype", "besluittype.catalogus"),
+    extra_kwargs={
+        "besluittype.catalogus": {
+            "help_text": mark_experimental(
+                "URL-referentie naar de CATALOGUS waartoe dit BESLUITTYPE behoort."
+            )
+        }
+    },
 )

--- a/src/openzaak/components/besluiten/openapi.yaml
+++ b/src/openzaak/components/besluiten/openapi.yaml
@@ -78,6 +78,7 @@ info:
 
     * `verantwoordelijke_organisatie`: Het RSIN van de niet-natuurlijk persoon zijnde de organisatie die het besluit heeft vastgesteld.
     * `besluittype`: URL-referentie naar het BESLUITTYPE (in de Catalogi API).
+    * `besluittype.catalogus`: **EXPERIMENTEEL** URL-referentie naar de CATALOGUS waartoe dit BESLUITTYPE behoort.
 
     **Resources en acties**
 

--- a/src/openzaak/components/besluiten/tests/test_notifications_send.py
+++ b/src/openzaak/components/besluiten/tests/test_notifications_send.py
@@ -70,6 +70,7 @@ class SendNotifTestCase(NotificationsConfigMixin, JWTAuthMixin, APITestCase):
                 "kenmerken": {
                     "verantwoordelijkeOrganisatie": "517439943",
                     "besluittype": f"http://testserver{besluittype_url}",
+                    "besluittype.catalogus": f"http://testserver{reverse(besluittype.catalogus)}",
                 },
             },
         )
@@ -102,6 +103,7 @@ class SendNotifTestCase(NotificationsConfigMixin, JWTAuthMixin, APITestCase):
                 "kenmerken": {
                     "verantwoordelijkeOrganisatie": besluit.verantwoordelijke_organisatie,
                     "besluittype": f"http://testserver{besluittype_url}",
+                    "besluittype.catalogus": f"http://testserver{reverse(besluit.besluittype.catalogus)}",
                 },
             },
         )
@@ -148,6 +150,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "verantwoordelijkeOrganisatie": data["verantwoordelijkeOrganisatie"],
                 "besluittype": f"http://testserver{besluittype_url}",
+                "besluittype.catalogus": f"http://testserver{reverse(besluittype.catalogus)}",
             },
             "resource": "besluit",
             "resourceUrl": data["url"],
@@ -188,6 +191,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "verantwoordelijkeOrganisatie": besluit.verantwoordelijke_organisatie,
                 "besluittype": f"http://testserver{reverse(besluit.besluittype)}",
+                "besluittype.catalogus": f"http://testserver{reverse(besluit.besluittype.catalogus)}",
             },
             "resource": "besluit",
             "resourceUrl": f"http://testserver{url}",
@@ -242,6 +246,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "verantwoordelijkeOrganisatie": besluit.verantwoordelijke_organisatie,
                 "besluittype": f"http://testserver{reverse(besluit.besluittype)}",
+                "besluittype.catalogus": f"http://testserver{reverse(besluit.besluittype.catalogus)}",
             },
             "resource": "besluitinformatieobject",
             "resourceUrl": data["url"],
@@ -284,6 +289,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "verantwoordelijkeOrganisatie": bio.besluit.verantwoordelijke_organisatie,
                 "besluittype": f"http://testserver{reverse(bio.besluit.besluittype)}",
+                "besluittype.catalogus": f"http://testserver{reverse(bio.besluit.besluittype.catalogus)}",
             },
             "resource": "besluitinformatieobject",
             "resourceUrl": f"http://testserver{url}",

--- a/src/openzaak/components/besluiten/tests/test_notifications_send_cmis.py
+++ b/src/openzaak/components/besluiten/tests/test_notifications_send_cmis.py
@@ -62,6 +62,7 @@ class SendNotifTestCase(NotificationsConfigMixin, JWTAuthMixin, APICMISTestCase)
                 "kenmerken": {
                     "verantwoordelijkeOrganisatie": bio.besluit.verantwoordelijke_organisatie,
                     "besluittype": f"http://testserver{reverse(bio.besluit.besluittype)}",
+                    "besluittype.catalogus": f"http://testserver{reverse(bio.besluit.besluittype.catalogus)}",
                 },
             }
         )
@@ -122,6 +123,7 @@ class FailedNotificationCMISTests(
             "kenmerken": {
                 "verantwoordelijkeOrganisatie": besluit.verantwoordelijke_organisatie,
                 "besluittype": f"http://testserver{reverse(besluit.besluittype)}",
+                "besluittype.catalogus": f"http://testserver{reverse(besluit.besluittype.catalogus)}",
             },
             "resource": "besluitinformatieobject",
             "resourceUrl": data["url"],
@@ -167,6 +169,7 @@ class FailedNotificationCMISTests(
             "kenmerken": {
                 "verantwoordelijkeOrganisatie": bio.besluit.verantwoordelijke_organisatie,
                 "besluittype": f"http://testserver{reverse(bio.besluit.besluittype)}",
+                "besluittype.catalogus": f"http://testserver{reverse(bio.besluit.besluittype.catalogus)}",
             },
             "resource": "besluitinformatieobject",
             "resourceUrl": f"http://testserver{url}",

--- a/src/openzaak/components/documenten/api/kanalen.py
+++ b/src/openzaak/components/documenten/api/kanalen.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
-from notifications_api_common.kanalen import Kanaal
+from openzaak.notifications.kanaal import Kanaal
+from openzaak.utils.help_text import mark_experimental
 
 from ..models import EnkelvoudigInformatieObject
 
@@ -11,5 +12,13 @@ KANAAL_DOCUMENTEN = Kanaal(
         "bronorganisatie",
         "informatieobjecttype",
         "vertrouwelijkheidaanduiding",
+        "informatieobjecttype.catalogus",
     ),
+    extra_kwargs={
+        "informatieobjecttype.catalogus": {
+            "help_text": mark_experimental(
+                "URL-referentie naar de CATALOGUS waartoe dit INFORMATIEOBJECTTYPE behoort."
+            )
+        }
+    },
 )

--- a/src/openzaak/components/documenten/openapi.yaml
+++ b/src/openzaak/components/documenten/openapi.yaml
@@ -89,6 +89,7 @@ info:
     * `bronorganisatie`: Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd.
     * `informatieobjecttype`: URL-referentie naar het INFORMATIEOBJECTTYPE (in de Catalogi API).
     * `vertrouwelijkheidaanduiding`: Aanduiding van de mate waarin het INFORMATIEOBJECT voor de openbaarheid bestemd is.
+    * `informatieobjecttype.catalogus`: **EXPERIMENTEEL** URL-referentie naar de CATALOGUS waartoe dit INFORMATIEOBJECTTYPE behoort.
 
     **Resources en acties**
     - `enkelvoudiginformatieobject`: create, update, destroy

--- a/src/openzaak/components/documenten/tests/test_notifications_send.py
+++ b/src/openzaak/components/documenten/tests/test_notifications_send.py
@@ -72,6 +72,7 @@ class SendNotifTestCase(NotificationsConfigMixin, JWTAuthMixin, APITestCase):
                 "kenmerken": {
                     "bronorganisatie": "159351741",
                     "informatieobjecttype": f"http://testserver{informatieobjecttype_url}",
+                    "informatieobjecttype.catalogus": f"http://testserver{reverse(informatieobjecttype.catalogus)}",
                     "vertrouwelijkheidaanduiding": VertrouwelijkheidsAanduiding.openbaar,
                 },
             },
@@ -123,6 +124,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "bronorganisatie": "159351741",
                 "informatieobjecttype": f"http://testserver{informatieobjecttype_url}",
+                "informatieobjecttype.catalogus": f"http://testserver{reverse(informatieobjecttype.catalogus)}",
                 "vertrouwelijkheidaanduiding": "openbaar",
             },
             "resource": "enkelvoudiginformatieobject",
@@ -164,6 +166,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "bronorganisatie": eio.bronorganisatie,
                 "informatieobjecttype": f"http://testserver{reverse(eio.informatieobjecttype)}",
+                "informatieobjecttype.catalogus": f"http://testserver{reverse(eio.informatieobjecttype.catalogus)}",
                 "vertrouwelijkheidaanduiding": eio.vertrouwelijkheidaanduiding,
             },
             "resource": "enkelvoudiginformatieobject",
@@ -214,6 +217,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "bronorganisatie": eio.bronorganisatie,
                 "informatieobjecttype": f"http://testserver{reverse(eio.informatieobjecttype)}",
+                "informatieobjecttype.catalogus": f"http://testserver{reverse(eio.informatieobjecttype.catalogus)}",
                 "vertrouwelijkheidaanduiding": eio.vertrouwelijkheidaanduiding,
             },
             "resource": "gebruiksrechten",
@@ -259,6 +263,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APITestCas
             "kenmerken": {
                 "bronorganisatie": eio.bronorganisatie,
                 "informatieobjecttype": f"http://testserver{reverse(eio.informatieobjecttype)}",
+                "informatieobjecttype.catalogus": f"http://testserver{reverse(eio.informatieobjecttype.catalogus)}",
                 "vertrouwelijkheidaanduiding": eio.vertrouwelijkheidaanduiding,
             },
             "resource": "gebruiksrechten",

--- a/src/openzaak/components/documenten/tests/test_notifications_send_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_notifications_send_cmis.py
@@ -73,6 +73,7 @@ class SendNotifTestCase(NotificationsConfigMixin, JWTAuthMixin, APICMISTestCase)
                 "kenmerken": {
                     "bronorganisatie": "159351741",
                     "informatieobjecttype": f"http://testserver{informatieobjecttype_url}",
+                    "informatieobjecttype.catalogus": f"http://testserver{reverse(informatieobjecttype.catalogus)}",
                     "vertrouwelijkheidaanduiding": VertrouwelijkheidsAanduiding.openbaar,
                 },
             },
@@ -135,6 +136,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APICMISTes
             "kenmerken": {
                 "bronorganisatie": "159351741",
                 "informatieobjecttype": f"http://testserver{informatieobjecttype_url}",
+                "informatieobjecttype.catalogus": f"http://testserver{reverse(informatieobjecttype.catalogus)}",
                 "vertrouwelijkheidaanduiding": "openbaar",
             },
             "resource": "enkelvoudiginformatieobject",
@@ -176,6 +178,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APICMISTes
             "kenmerken": {
                 "bronorganisatie": eio.bronorganisatie,
                 "informatieobjecttype": f"http://testserver{reverse(eio.informatieobjecttype)}",
+                "informatieobjecttype.catalogus": f"http://testserver{reverse(eio.informatieobjecttype.catalogus)}",
                 "vertrouwelijkheidaanduiding": eio.vertrouwelijkheidaanduiding,
             },
             "resource": "enkelvoudiginformatieobject",
@@ -226,6 +229,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APICMISTes
             "kenmerken": {
                 "bronorganisatie": eio.bronorganisatie,
                 "informatieobjecttype": f"http://testserver{reverse(eio.informatieobjecttype)}",
+                "informatieobjecttype.catalogus": f"http://testserver{reverse(eio.informatieobjecttype.catalogus)}",
                 "vertrouwelijkheidaanduiding": eio.vertrouwelijkheidaanduiding,
             },
             "resource": "gebruiksrechten",
@@ -272,6 +276,7 @@ class FailedNotificationTests(NotificationsConfigMixin, JWTAuthMixin, APICMISTes
             "kenmerken": {
                 "bronorganisatie": eio.bronorganisatie,
                 "informatieobjecttype": f"http://testserver{reverse(eio.informatieobjecttype)}",
+                "informatieobjecttype.catalogus": f"http://testserver{reverse(eio.informatieobjecttype.catalogus)}",
                 "vertrouwelijkheidaanduiding": eio.vertrouwelijkheidaanduiding,
             },
             "resource": "gebruiksrechten",

--- a/src/openzaak/components/urls.py
+++ b/src/openzaak/components/urls.py
@@ -17,7 +17,11 @@ urlpatterns = [
     # besluiten
     path(
         "besluiten/",
-        ComponentIndexView.as_view(component="besluiten"),
+        ComponentIndexView.as_view(
+            component="besluiten",
+            repository="https://github.com/open-zaak/open-zaak",
+            github_ref=__version__,
+        ),
         name="index-besluiten",
     ),
     path("besluiten/api/", include("openzaak.components.besluiten.api.urls")),
@@ -31,7 +35,11 @@ urlpatterns = [
     # documenten
     path(
         "documenten/",
-        ComponentIndexView.as_view(component="documenten", github_ref="stable/1.1.x"),
+        ComponentIndexView.as_view(
+            component="documenten",
+            repository="https://github.com/open-zaak/open-zaak",
+            github_ref=__version__,
+        ),
         name="index-documenten",
     ),
     path("documenten/api/", include("openzaak.components.documenten.api.urls")),

--- a/src/openzaak/components/zaken/api/kanalen.py
+++ b/src/openzaak/components/zaken/api/kanalen.py
@@ -1,60 +1,9 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
-from typing import Dict, cast
-
-from django.db.models import Field, Model
-
-from glom import glom
-from notifications_api_common.kanalen import Kanaal as _Kanaal
-from rest_framework.request import Request
-from vng_api_common.tests import reverse
-
+from openzaak.notifications.kanaal import Kanaal
 from openzaak.utils.help_text import mark_experimental
 
 from ..models import Zaak
-
-
-class Kanaal(_Kanaal):
-    @staticmethod
-    def get_field(model: Model, field: str) -> Field:
-        """
-        Function to retrieve a field from a Model, can also be passed a path to a field
-        (e.g. `zaaktype.catalogus`)
-        """
-        if "." in field:
-            model_field = None
-            bits = field.split(".")
-            for i, part in enumerate(bits):
-                model_field = model._meta.get_field(part)
-                if fk_field := getattr(model_field, "fk_field", None):
-                    model_field = model._meta.get_field(fk_field)
-                if i != len(bits):
-                    model = cast(Model, model_field.related_model)
-            assert model_field, "Could not find field on model"
-            return model_field
-        return model._meta.get_field(field)
-
-    def get_kenmerken(
-        self, obj: Model, data: dict | None = None, request: Request | None = None
-    ) -> Dict:
-        """
-        Overridden to support sending kenmerken that are not directly part of the main
-        resource (e.g `Zaak.zaaktype.catalogus`)
-        """
-        data = data or {}
-        kenmerken = {}
-        for kenmerk in self.kenmerken:
-            value = data.get(kenmerk, glom(obj, kenmerk, default=""))
-            if isinstance(value, Model):
-                if _loose_fk_data := getattr(value, "_loose_fk_data", None):
-                    value = _loose_fk_data["url"]
-                else:
-                    value = reverse(value)
-                    if request:
-                        value = request.build_absolute_uri(value)
-            kenmerken[kenmerk] = value
-        return kenmerken
-
 
 KANAAL_ZAKEN = Kanaal(
     "zaken",

--- a/src/openzaak/notifications/kanaal.py
+++ b/src/openzaak/notifications/kanaal.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2019 - 2025 Dimpact
+from typing import Dict, cast
+
+from django.db.models import Field, Model
+
+from glom import glom
+from notifications_api_common.kanalen import Kanaal as _Kanaal
+from rest_framework.request import Request
+from vng_api_common.tests import reverse
+
+from openzaak.utils.help_text import mark_experimental
+
+
+class Kanaal(_Kanaal):
+    @staticmethod
+    def get_field(model: Model, field: str) -> Field:
+        """
+        Function to retrieve a field from a Model, can also be passed a path to a field
+        (e.g. `zaaktype.catalogus`)
+        """
+        if "." in field:
+            model_field = None
+            bits = field.split(".")
+            for i, part in enumerate(bits):
+                model_field = model._meta.get_field(part)
+                if fk_field := getattr(model_field, "fk_field", None):
+                    model_field = model._meta.get_field(fk_field)
+                if i != len(bits):
+                    model = cast(Model, model_field.related_model)
+            assert model_field, "Could not find field on model"
+            return model_field
+        return model._meta.get_field(field)
+
+    def get_kenmerken(
+        self, obj: Model, data: dict | None = None, request: Request | None = None
+    ) -> Dict:
+        """
+        Overridden to support sending kenmerken that are not directly part of the main
+        resource (e.g `Zaak.zaaktype.catalogus`)
+        """
+        data = data or {}
+        kenmerken = {}
+        for kenmerk in self.kenmerken:
+            value = data.get(kenmerk, glom(obj, kenmerk, default=""))
+            if isinstance(value, Model):
+                if _loose_fk_data := getattr(value, "_loose_fk_data", None):
+                    value = _loose_fk_data["url"]
+                else:
+                    value = reverse(value)
+                    if request:
+                        value = request.build_absolute_uri(value)
+            kenmerken[kenmerk] = value
+        return kenmerken

--- a/src/openzaak/notifications/kanaal.py
+++ b/src/openzaak/notifications/kanaal.py
@@ -9,8 +9,6 @@ from notifications_api_common.kanalen import Kanaal as _Kanaal
 from rest_framework.request import Request
 from vng_api_common.tests import reverse
 
-from openzaak.utils.help_text import mark_experimental
-
 
 class Kanaal(_Kanaal):
     @staticmethod

--- a/src/openzaak/notifications/tests/test_register_kanaal.py
+++ b/src/openzaak/notifications/tests/test_register_kanaal.py
@@ -113,7 +113,11 @@ class RegisterKanaalTests(NotificationsConfigMixin, TestCase):
                     json={
                         "naam": "besluiten",
                         "documentatieLink": "https://example.com/ref/kanalen/#besluiten",
-                        "filters": ["verantwoordelijke_organisatie", "besluittype"],
+                        "filters": [
+                            "verantwoordelijke_organisatie",
+                            "besluittype",
+                            "besluittype.catalogus",
+                        ],
                     },
                 ),
                 call(
@@ -133,6 +137,7 @@ class RegisterKanaalTests(NotificationsConfigMixin, TestCase):
                             "bronorganisatie",
                             "informatieobjecttype",
                             "vertrouwelijkheidaanduiding",
+                            "informatieobjecttype.catalogus",
                         ],
                     },
                 ),


### PR DESCRIPTION


Closes open-zaak/open-notificaties#231

**Changes**
- Adds catalogus to kenmerken of `besluiten` & `documenten` kanaal.
- Moved the Kanaal class from `zaken/api/kanalen.py` to `utils` so that it could be used by the other components.

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
