### PR TITLE
:bug: [#1907] Make sure requests_cache is not applied globally

### DIFF
--- a/src/openzaak/components/catalogi/management/commands/import.py
+++ b/src/openzaak/components/catalogi/management/commands/import.py
@@ -13,7 +13,7 @@ from rest_framework.versioning import URLPathVersioning
 
 from openzaak.components.catalogi.api import serializers
 from openzaak.components.catalogi.constants import IMPORT_ORDER
-from openzaak.utils.cache import requests_cache_enabled
+from openzaak.utils.cache import run_in_process_with_caching
 
 
 class Command(BaseCommand):
@@ -38,9 +38,11 @@ class Command(BaseCommand):
             ),
         )
 
-    @requests_cache_enabled()
-    @transaction.atomic
     def handle(self, *args, **options):
+        run_in_process_with_caching(self.run_import, *args, **options)
+
+    @transaction.atomic
+    def run_import(self, *args, **options):
         import_file = options.pop("import_file")
         import_file_content = options.pop("import_file_content")
         generate_new_uuids = options.pop("generate_new_uuids")

--- a/src/openzaak/components/catalogi/migrations/0011_auto_20220531_1017.py
+++ b/src/openzaak/components/catalogi/migrations/0011_auto_20220531_1017.py
@@ -7,11 +7,11 @@ from django.db import migrations
 from zgw_consumers.models import Service
 
 from openzaak.client import get_client
-from openzaak.utils.cache import requests_cache_enabled
+from openzaak.utils.cache import _requests_cache_enabled
 from vng_api_common.client import to_internal_data
 
 
-@requests_cache_enabled()
+@_requests_cache_enabled()
 def set_selectieklasse_procestype_default_year(apps, _):
     ZaakType = apps.get_model("catalogi.ZaakType")
 

--- a/src/openzaak/components/catalogi/tests/admin/test_import_export_catalogus.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_import_export_catalogus.py
@@ -43,7 +43,9 @@ from ..factories import (
 from .test_import_export_zaaktype import MockSelectielijst
 
 
+@tag("catalogi-import")
 @disable_admin_mfa()
+@override_settings(REQUESTS_CACHING_IN_SEPARATE_PROCESS=False)
 class CatalogusAdminImportExportTests(MockSelectielijst, WebTest):
     @classmethod
     def setUpTestData(cls):

--- a/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_import_export_zaaktype.py
@@ -106,6 +106,8 @@ class MockSelectielijst(SelectieLijstMixin):
 
 
 @disable_admin_mfa()
+@tag("zaaktype-import")
+@override_settings(REQUESTS_CACHING_IN_SEPARATE_PROCESS=False)
 class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
     @classmethod
     def setUpTestData(cls):
@@ -1925,6 +1927,8 @@ class ZaakTypeAdminImportExportTests(MockSelectielijst, WebTest):
 
 
 @disable_admin_mfa()
+@tag("zaaktype-import")
+@override_settings(REQUESTS_CACHING_IN_SEPARATE_PROCESS=False)
 class ZaakTypeAdminImportExportTransactionTests(MockSelectielijst, TransactionWebTest):
     def setUp(self):
         super().setUp()

--- a/src/openzaak/components/catalogi/tests/management/test_import_export.py
+++ b/src/openzaak/components/catalogi/tests/management/test_import_export.py
@@ -210,6 +210,7 @@ class ExportCatalogiTests(ImportExportMixin, TestCase):
         self.assertTrue(data["url"].startswith("https://openzaak.example.com:8443/"))
 
 
+@override_settings(REQUESTS_CACHING_IN_SEPARATE_PROCESS=False)
 @tag("catalogi-import")
 class ImportCatalogiTests(SelectieLijstMixin, ImportExportMixin, TestCase):
     def test_import_catalogus(self):

--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -453,3 +453,8 @@ IMPORT_DOCUMENTEN_BATCH_SIZE = config(
     ),
     group="Documenten import",
 )
+
+# Can be overridden by tests to avoid errors when running tests in parallel,
+# because parallel test processes are run with daemon=True, which means they can't spawn
+# child processes
+REQUESTS_CACHING_IN_SEPARATE_PROCESS = True

--- a/src/openzaak/utils/tests/test_cache.py
+++ b/src/openzaak/utils/tests/test_cache.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2025 Dimpact
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from time import sleep
+
+from django.test import SimpleTestCase, tag
+
+import requests
+from furl import furl
+
+from openzaak.tests.utils import require_cmis
+
+from ..cache import _requests_cache_enabled, run_in_process_with_caching
+
+TEST_SERVER_URL = furl("http://localhost:8888/")
+
+
+class TestRequestHandler(BaseHTTPRequestHandler):
+    """
+    `requests_mock.Mocker` cannot be used to perform assertions to the request_history when
+    performing requests from different processes, so instead we spin up a temporary
+    HTTP server and store the requests to make assertions on them
+    """
+
+    request_log = []  # Stores all received requests for verification
+
+    def do_GET(self):
+        """Handles GET requests."""
+        self.__class__.request_log.append(self.path)  # Log request
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"Test Response")
+
+
+def start_test_server():
+    """Starts a simple HTTP server on localhost:8888"""
+    server = HTTPServer(("localhost", 8888), TestRequestHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+class RequestsCacheTests(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+
+        server = start_test_server()
+
+        # clear the logs
+        TestRequestHandler.request_log = []
+        self.addCleanup(server.shutdown)
+
+    @tag("gh-1907")
+    def test_request_cache_applies_globally_if_run_in_same_process(self):
+        """
+        When performing requests within the `_requests_cache_enabled` context manager
+        in the same process, requests will be cached globally while that context manager is active
+        """
+
+        def cached_function():
+            with _requests_cache_enabled():
+                sleep(0.2)
+                requests.get((TEST_SERVER_URL / "inside-context-manager").url)
+                requests.get((TEST_SERVER_URL / "inside-context-manager").url)
+
+                from vng_api_common.client import Client
+
+                client = Client(base_url=TEST_SERVER_URL.url)
+
+                client.get("/custom-client-inside-context-manager")
+                client.get("/custom-client-inside-context-manager")
+
+        def perform_requests():
+            # Make two requests, these should not be patched
+            sleep(0.1)
+            requests.get((TEST_SERVER_URL / "not-inside-context-manager").url)
+            requests.get((TEST_SERVER_URL / "not-inside-context-manager").url)
+
+            from vng_api_common.client import Client
+
+            client = Client(base_url=TEST_SERVER_URL.url)
+            client.get("/custom-client-not-inside-context-manager")
+            client.get("/custom-client-not-inside-context-manager")
+
+        cached_thread = threading.Thread(target=cached_function)
+        non_cached_thread = threading.Thread(target=perform_requests)
+
+        # start and wait for threads to finish
+        cached_thread.start()
+        non_cached_thread.start()
+        cached_thread.join()
+        non_cached_thread.join()
+
+        self.assertEqual(len(TestRequestHandler.request_log), 4)
+
+        request1, request2, request3, request4 = TestRequestHandler.request_log
+        self.assertEqual(request1, "/not-inside-context-manager")
+        self.assertEqual(request2, "/custom-client-not-inside-context-manager")
+        self.assertEqual(request3, "/inside-context-manager")
+        self.assertEqual(request4, "/custom-client-inside-context-manager")
+
+    # Unfortunately this test cannot be run in parallel, because parallel processes
+    # with daemon=True cannot spawn child processes themselves, so we run it as part of
+    # the CMIS tests, which are not run in parallel
+    @require_cmis
+    @tag("gh-1907")
+    def test_request_cache_does_not_apply_globally_if_run_in_separate_process(self):
+        """
+        When performing requests within the `_requests_cache_enabled` context manager
+        in a different process, requests should not be cached globally while this different
+        process is active. This is the preferred way of using requests-cache
+        """
+
+        def cached_function():
+            def perform_requests():
+                sleep(0.2)
+                requests.get((TEST_SERVER_URL / "cached").url)
+                requests.get((TEST_SERVER_URL / "cached").url)
+
+                from vng_api_common.client import Client
+
+                client = Client(base_url=TEST_SERVER_URL.url)
+                client.get("/custom-client-cached")
+                client.get("/custom-client-cached")
+
+            run_in_process_with_caching(perform_requests)
+
+        def perform_requests():
+            # Make two requests, these should not be patched
+            sleep(0.1)
+            requests.get((TEST_SERVER_URL / "not-cached").url)
+            requests.get((TEST_SERVER_URL / "not-cached").url)
+
+            from vng_api_common.client import Client
+
+            client = Client(base_url=TEST_SERVER_URL.url)
+            client.get("/custom-client-not-cached")
+            client.get("/custom-client-not-cached")
+
+        cached_thread = threading.Thread(target=cached_function)
+        non_cached_thread = threading.Thread(target=perform_requests)
+
+        # start and wait for threads to finish
+        cached_thread.start()
+        non_cached_thread.start()
+        cached_thread.join()
+        non_cached_thread.join()
+
+        self.assertEqual(len(TestRequestHandler.request_log), 6)
+
+        request1, request2, request3, request4, request5, request6 = (
+            TestRequestHandler.request_log
+        )
+
+        self.assertEqual(request1, "/not-cached")
+        self.assertEqual(request2, "/not-cached")
+        self.assertEqual(request3, "/custom-client-not-cached")
+        self.assertEqual(request4, "/custom-client-not-cached")
+        self.assertEqual(request5, "/cached")
+        self.assertEqual(request6, "/custom-client-cached")
+
+    # Unfortunately this test cannot be run in parallel, because parallel processes
+    # with daemon=True cannot spawn child processes themselves, so we run it as part of
+    # the CMIS tests, which are not run in parallel
+    @require_cmis
+    @tag("gh-1907")
+    def test_errors_in_parallel_process_are_raised(self):
+        """
+        Assert that any exceptions raised within a function that is being run in a separate
+        process bubble up
+        """
+
+        def function_that_raises_exception():
+            raise Exception
+
+        with self.assertRaises(Exception):
+            run_in_process_with_caching(function_that_raises_exception)


### PR DESCRIPTION
Closes #1907

This is a temporary fix for the issue with requests_cache being applied globally. I think the proper way to fully fix this is to run imports in Celery tasks, that way we both ensure that they are run in a separate process and we can run them asynchronously, which is a better user experience if imports take some time to complete (https://github.com/open-zaak/open-zaak/issues/1017)

Running things in Celery does mean we have to properly provide feedback to the user (is the task still running, did it fail, etc.) and I do not want to rush that functionality for the sake of fixing this issue, so that's why I want to apply this bandaid fix first.

**Changes**

* Make sure requests_cache is not applied globally

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
