### PR TITLE
:memo: Fix broken reference to autorisaties notificaties.md

### DIFF
--- a/src/openzaak/components/urls.py
+++ b/src/openzaak/components/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     # autorisaties
     path(
         "autorisaties/",
-        ComponentIndexView.as_view(component="autorisaties"),
+        ComponentIndexView.as_view(component="autorisaties", github_ref="1.0.1-alpha1"),
         name="index-autorisaties",
     ),
     path("autorisaties/api/", include("openzaak.components.autorisaties.api.urls")),


### PR DESCRIPTION
it seems that the stable/1.0.x branch was removed from the VNG repo