### PR TITLE
 👷 [#1712] Further improvements to CI runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,9 @@ jobs:
             gdal-bin
 
       - name: Install dependencies
-        run: pip install -r requirements/ci.txt
+        run: |
+          pip install uv
+          uv pip install --system -r requirements/ci.txt
 
       - name: Test migrate and check
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,10 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
 
 WORKDIR /app
 
+# Use uv to install dependencies
+RUN pip install uv -U
 COPY ./requirements /app/requirements
-RUN pip install pip "setuptools>=70.0.0"
-RUN pip install -r requirements/production.txt
+RUN uv pip install --system -r requirements/production.txt
 
 
 # Stage 2 - build frontend
@@ -52,8 +53,6 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
         libproj-dev \
         gdal-bin \
     && rm -rf /var/lib/apt/lists/*
-
-RUN pip install pip "setuptools>=70.0.0"
 
 WORKDIR /app
 COPY ./cache /app/cache

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -153,7 +153,7 @@ coreschema==0.0.4
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   coreapi
-coverage==6.3.2
+coverage==7.6.12
     # via
     #   -r requirements/test-tools.in
     #   codecov

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -182,7 +182,7 @@ coreschema==0.0.4
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   coreapi
-coverage==6.3.2
+coverage==7.6.12
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/openzaak/components/autorisaties/tests/admin/test_autorisaties_admin.py
+++ b/src/openzaak/components/autorisaties/tests/admin/test_autorisaties_admin.py
@@ -522,7 +522,11 @@ class ManageAutorisatiesAdmin(NotificationsConfigMixin, TestCase):
             "form-0-externe_typen": ["https://external.catalogi.com/api/v1/1234"],
         }
 
-        response = self.client.post(self.url, data)
+        with requests_mock.Mocker() as m:
+            m.get(
+                "https://external.catalogi.com/api/v1/1234", json={"invalid": "shape"}
+            )
+            response = self.client.post(self.url, data)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(Autorisatie.objects.count(), 0)

--- a/src/openzaak/components/autorisaties/tests/admin/test_autorisaties_admin.py
+++ b/src/openzaak/components/autorisaties/tests/admin/test_autorisaties_admin.py
@@ -168,18 +168,19 @@ class ManageAutorisatiesAdmin(NotificationsConfigMixin, TestCase):
         user.user_permissions.add(perm)
         cls.applicatie = ApplicatieFactory.create()
 
+        cls.url = reverse(
+            "admin:authorizations_applicatie_autorisaties",
+            kwargs={"object_id": cls.applicatie.pk},
+        )
+        cls.applicatie_url = reverse(
+            "applicatie-detail", kwargs={"version": 1, "uuid": cls.applicatie.uuid}
+        )
+        cls.catalogus = CatalogusFactory.create()
+
     def setUp(self):
         super().setUp()
 
         self.client.force_login(self.user)
-        self.url = reverse(
-            "admin:authorizations_applicatie_autorisaties",
-            kwargs={"object_id": self.applicatie.pk},
-        )
-        self.applicatie_url = reverse(
-            "applicatie-detail", kwargs={"version": 1, "uuid": self.applicatie.uuid}
-        )
-        self.catalogus = CatalogusFactory.create()
 
     def test_page_returns_on_get(self):
         # set up some initial data

--- a/src/openzaak/components/catalogi/tests/admin/test_admin_publish.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_admin_publish.py
@@ -471,10 +471,15 @@ class ZaaktypeAdminTests(
 class PublishWithGeldigheidTests(
     ReferentieLijstServiceMixin, ClearCachesMixin, WebTest
 ):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = SuperUserFactory.create()
+
     def setUp(self):
         super().setUp()
 
-        self.user = SuperUserFactory.create()
         self.app.set_user(self.user)
 
     def setUpData(self, request_mock):

--- a/src/openzaak/components/catalogi/tests/admin/test_besluittype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_besluittype_admin.py
@@ -24,26 +24,26 @@ class BesluitTypeAdminTests(WebTest):
     def setUpTestData(cls):
         cls.user = SuperUserFactory.create()
 
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
-        self.catalogus = CatalogusFactory.create()
+        cls.catalogus = CatalogusFactory.create()
 
         # Delete automatically created ZaakTypen
         ZaakType.objects.all().delete()
-        self.zaaktype = ZaakTypeFactory.create(catalogus=self.catalogus)
+        cls.zaaktype = ZaakTypeFactory.create(catalogus=cls.catalogus)
         ZaakTypeFactory.create_batch(3, catalogus=CatalogusFactory.create())
 
         # Delete automatically created IOTypen
         InformatieObjectType.objects.all().delete()
-        self.iotype = InformatieObjectTypeFactory.create(
-            catalogus=self.catalogus, zaaktypen=[]
+        cls.iotype = InformatieObjectTypeFactory.create(
+            catalogus=cls.catalogus, zaaktypen=[]
         )
         InformatieObjectTypeFactory.create_batch(
             3, catalogus=CatalogusFactory.create(), zaaktypen=[]
         )
+
+    def setUp(self):
+        super().setUp()
+
+        self.app.set_user(self.user)
 
     def test_create_besluittype_m2m_relation_popup_filters_no_catalogus(self):
         response = self.app.get(reverse("admin:catalogi_besluittype_add"))
@@ -202,14 +202,14 @@ class BesluitTypePublishAdminTests(WebTest):
     def setUpTestData(cls):
         cls.user = SuperUserFactory.create()
 
+        cls.catalogus = CatalogusFactory.create()
+        cls.url = reverse_lazy("admin:catalogi_besluittype_changelist")
+        cls.query_params = {"catalogus_id__exact": cls.catalogus.pk}
+
     def setUp(self):
         super().setUp()
 
         self.app.set_user(self.user)
-
-        self.catalogus = CatalogusFactory.create()
-        self.url = reverse_lazy("admin:catalogi_besluittype_changelist")
-        self.query_params = {"catalogus_id__exact": self.catalogus.pk}
 
     def test_publish_selected_success(self):
         besluittype1, besluittype2 = BesluitTypeFactory.create_batch(

--- a/src/openzaak/components/catalogi/tests/admin/test_informatieobjecttype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_informatieobjecttype_admin.py
@@ -29,17 +29,17 @@ class ZiotFilterAdminTests(WebTest):
     def setUpTestData(cls):
         cls.user = SuperUserFactory.create()
 
+        cls.catalogus = CatalogusFactory.create()
+
+        # Delete automatically created ZaakTypen
+        ZaakType.objects.all().delete()
+        cls.zaaktype = ZaakTypeFactory.create(catalogus=cls.catalogus)
+        ZaakTypeFactory.create_batch(3, catalogus=CatalogusFactory.create())
+
     def setUp(self):
         super().setUp()
 
         self.app.set_user(self.user)
-
-        self.catalogus = CatalogusFactory.create()
-
-        # Delete automatically created ZaakTypen
-        ZaakType.objects.all().delete()
-        self.zaaktype = ZaakTypeFactory.create(catalogus=self.catalogus)
-        ZaakTypeFactory.create_batch(3, catalogus=CatalogusFactory.create())
 
     def test_create_ziot_zaaktype_popup_filter_no_catalogus(self):
         response = self.app.get(
@@ -127,16 +127,16 @@ class AddZiotAdminTests(WebTest):
     def setUpTestData(cls):
         cls.user = SuperUserFactory.create()
 
+        cls.catalogus = CatalogusFactory.create()
+
+        # Delete automatically created ZaakTypen
+        ZaakType.objects.all().delete()
+        cls.zaaktype = ZaakTypeFactory.create(catalogus=cls.catalogus)
+
     def setUp(self):
         super().setUp()
 
         self.app.set_user(self.user)
-
-        self.catalogus = CatalogusFactory.create()
-
-        # Delete automatically created ZaakTypen
-        ZaakType.objects.all().delete()
-        self.zaaktype = ZaakTypeFactory.create(catalogus=self.catalogus)
 
     def test_add_ziot(self):
         iot = InformatieObjectTypeFactory.create(catalogus=self.catalogus, zaaktypen=[])
@@ -164,14 +164,14 @@ class IoTypePublishAdminTests(WebTest):
     def setUpTestData(cls):
         cls.user = SuperUserFactory.create()
 
+        cls.catalogus = CatalogusFactory.create()
+        cls.url = reverse_lazy("admin:catalogi_informatieobjecttype_changelist")
+        cls.query_params = {"catalogus_id__exact": cls.catalogus.pk}
+
     def setUp(self):
         super().setUp()
 
         self.app.set_user(self.user)
-
-        self.catalogus = CatalogusFactory.create()
-        self.url = reverse_lazy("admin:catalogi_informatieobjecttype_changelist")
-        self.query_params = {"catalogus_id__exact": self.catalogus.pk}
 
     def test_publish_selected_success(self):
         iotype1, iotype2 = InformatieObjectTypeFactory.create_batch(

--- a/src/openzaak/components/catalogi/tests/admin/test_notifications.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_notifications.py
@@ -44,12 +44,13 @@ class NotificationAdminTests(
 
         cls.user = SuperUserFactory.create()
 
+        cls.catalogus = CatalogusFactory.create()
+        cls.catalogus_url = reverse(
+            "catalogus-detail", kwargs={"uuid": cls.catalogus.uuid, "version": 1}
+        )
+
     def setUp(self):
         super().setUp()
-        self.catalogus = CatalogusFactory.create()
-        self.catalogus_url = reverse(
-            "catalogus-detail", kwargs={"uuid": self.catalogus.uuid, "version": 1}
-        )
 
         self.app.set_user(self.user)
 

--- a/src/openzaak/components/catalogi/tests/base.py
+++ b/src/openzaak/components/catalogi/tests/base.py
@@ -11,14 +11,15 @@ from .utils import get_operation_url
 class CatalogusAPITestMixin:
     API_VERSION = "1"
 
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()  # type: ignore
 
-        self.catalogus = CatalogusFactory.create(domein="ABCDE", rsin="000000001")
+        cls.catalogus = CatalogusFactory.create(domein="ABCDE", rsin="000000001")
 
-        self.catalogus_list_url = get_operation_url("catalogus_list")
-        self.catalogus_detail_url = get_operation_url(
-            "catalogus_read", uuid=self.catalogus.uuid
+        cls.catalogus_list_url = get_operation_url("catalogus_list")
+        cls.catalogus_detail_url = get_operation_url(
+            "catalogus_read", uuid=cls.catalogus.uuid
         )
 
 

--- a/src/openzaak/components/catalogi/tests/test_catalogusautorisatie_sync.py
+++ b/src/openzaak/components/catalogi/tests/test_catalogusautorisatie_sync.py
@@ -36,48 +36,45 @@ class CatalogusAutorisatieSyncTestCase(NotificationsConfigMixin, TestCase):
         site.domain = "testserver"
         site.save()
 
-    def setUp(self):
-        super().setUp()
+        cls.catalogus1 = CatalogusFactory.create()
+        cls.catalogus2 = CatalogusFactory.create()
+        cls.applicatie1 = ApplicatieFactory.create()
+        cls.applicatie2 = ApplicatieFactory.create()
 
-        self.catalogus1 = CatalogusFactory.create()
-        self.catalogus2 = CatalogusFactory.create()
-        self.applicatie1 = ApplicatieFactory.create()
-        self.applicatie2 = ApplicatieFactory.create()
-
-        self.catalogus_autorisatie1 = CatalogusAutorisatieFactory.create(
-            applicatie=self.applicatie1,
-            catalogus=self.catalogus1,
+        cls.catalogus_autorisatie1 = CatalogusAutorisatieFactory.create(
+            applicatie=cls.applicatie1,
+            catalogus=cls.catalogus1,
             component=ComponentTypes.zrc,
             scopes=["zaken.lezen"],
             max_vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.beperkt_openbaar,
         )
-        self.catalogus_autorisatie2 = CatalogusAutorisatieFactory.create(
-            applicatie=self.applicatie1,
-            catalogus=self.catalogus2,
+        cls.catalogus_autorisatie2 = CatalogusAutorisatieFactory.create(
+            applicatie=cls.applicatie1,
+            catalogus=cls.catalogus2,
             component=ComponentTypes.zrc,
             scopes=["zaken.lezen"],
             max_vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.beperkt_openbaar,
         )
-        self.catalogus_autorisatie3 = CatalogusAutorisatieFactory.create(
-            applicatie=self.applicatie2,
-            catalogus=self.catalogus1,
+        cls.catalogus_autorisatie3 = CatalogusAutorisatieFactory.create(
+            applicatie=cls.applicatie2,
+            catalogus=cls.catalogus1,
             component=ComponentTypes.zrc,
             scopes=["zaken.lezen"],
             max_vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.beperkt_openbaar,
         )
-        self.catalogus_autorisatie4 = CatalogusAutorisatieFactory.create(
-            applicatie=self.applicatie2,
-            catalogus=self.catalogus2,
+        cls.catalogus_autorisatie4 = CatalogusAutorisatieFactory.create(
+            applicatie=cls.applicatie2,
+            catalogus=cls.catalogus2,
             component=ComponentTypes.zrc,
             scopes=["zaken.lezen"],
             max_vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.beperkt_openbaar,
         )
 
         # unrelated, should not be triggered
-        self.applicatie3 = ApplicatieFactory.create()
+        cls.applicatie3 = ApplicatieFactory.create()
         CatalogusAutorisatieFactory.create(
-            applicatie=self.applicatie3,
-            catalogus=self.catalogus2,
+            applicatie=cls.applicatie3,
+            catalogus=cls.catalogus2,
             component=ComponentTypes.zrc,
             scopes=["zaken.lezen"],
             max_vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduiding.beperkt_openbaar,

--- a/src/openzaak/components/documenten/tests/admin/test_eiocanonical_inline_audittrail.py
+++ b/src/openzaak/components/documenten/tests/admin/test_eiocanonical_inline_audittrail.py
@@ -29,15 +29,15 @@ class EioAdminInlineTests(WebTest):
         cls.canonical = EnkelvoudigInformatieObjectCanonicalFactory.create(
             latest_version=None
         )
+        cls.change_url = reverse(
+            "admin:documenten_enkelvoudiginformatieobjectcanonical_change",
+            args=(cls.canonical.pk,),
+        )
 
     def setUp(self):
         super().setUp()
 
         self.app.set_user(self.user)
-        self.change_url = reverse(
-            "admin:documenten_enkelvoudiginformatieobjectcanonical_change",
-            args=(self.canonical.pk,),
-        )
 
     def assertEioAudittrail(self, audittrail):
         self.assertEqual(audittrail.bron, "DRC")

--- a/src/openzaak/components/documenten/tests/test_auth.py
+++ b/src/openzaak/components/documenten/tests/test_auth.py
@@ -973,8 +973,9 @@ class ExternalInformatieObjectInformatieObjectTypescopeTests(JWTAuthMixin, APITe
     informatieobjecttype = IOTYPE_EXTERNAL
     component = ComponentTypes.drc
 
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
 
         site = Site.objects.get_current()
         site.domain = "testserver"

--- a/src/openzaak/components/documenten/tests/test_objectinformatieobject.py
+++ b/src/openzaak/components/documenten/tests/test_objectinformatieobject.py
@@ -52,8 +52,9 @@ class ObjectInformatieObjectTests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
     list_url = reverse_lazy("objectinformatieobject-list")
 
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
 
         site = Site.objects.get_current()
         site.domain = "testserver"

--- a/src/openzaak/components/documenten/tests/test_utils_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_utils_cmis.py
@@ -25,8 +25,10 @@ class CMISUtilsTests(JWTAuthMixin, APICMISTestCase):
     list_url = reverse_lazy(ZaakInformatieObject)
     heeft_alle_autorisaties = True
 
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
         site = Site.objects.get_current()
         site.domain = "testserver"
         site.save()

--- a/src/openzaak/components/zaken/tests/test_validation_zaak.py
+++ b/src/openzaak/components/zaken/tests/test_validation_zaak.py
@@ -36,9 +36,6 @@ class ZaakValidationTests(SelectieLijstMixin, JWTAuthMixin, APITestCase):
         cls.zaaktype = ZaakTypeFactory.create(concept=False)
         cls.zaaktype_url = reverse(cls.zaaktype)
 
-    def setUp(self):
-        super().setUp()
-
         ServiceFactory.create(api_root="https://example.com/", api_type=APITypes.ztc)
 
     @override_settings(ALLOWED_HOSTS=["testserver"])

--- a/src/openzaak/components/zaken/tests/test_zaak_archive.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_archive.py
@@ -31,7 +31,12 @@ from openzaak.components.documenten.constants import Statussen
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
-from openzaak.tests.utils import JWTAuthMixin, get_eio_response, mock_zrc_oas_get
+from openzaak.tests.utils import (
+    JWTAuthMixin,
+    get_eio_response,
+    mock_zrc_oas_get,
+    mock_ztc_oas_get,
+)
 
 from .factories import (
     RelevanteZaakRelatieFactory,
@@ -1369,6 +1374,7 @@ class ExternalDocumentsAPITests(JWTAuthMixin, APITestCase):
         }
 
         with requests_mock.Mocker() as m:
+            mock_ztc_oas_get(m)
             m.get(
                 statustype,
                 json=get_statustype_response(statustype, zaaktype, isEindstatus=True),

--- a/src/openzaak/components/zaken/tests/test_zaak_archive.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_archive.py
@@ -1254,8 +1254,9 @@ class ExternalDocumentsAPITests(JWTAuthMixin, APITestCase):
 
     heeft_alle_autorisaties = True
 
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
 
         ServiceFactory.create(
             api_root="https://external.nl/documenten/",

--- a/src/openzaak/components/zaken/tests/test_zaakeigenschap.py
+++ b/src/openzaak/components/zaken/tests/test_zaakeigenschap.py
@@ -511,11 +511,8 @@ class ZaakEigenschapWaardeTests(JWTAuthMixin, APITestCase):
         cls.zaaktype = ZaakTypeFactory.create()
         cls.zaak = ZaakFactory.create(zaaktype=cls.zaaktype)
 
-    def setUp(self):
-        super().setUp()
-
-        self.url = reverse(ZaakEigenschap, kwargs={"zaak_uuid": self.zaak.uuid})
-        self.zaak_url = f"http://testserver{reverse(self.zaak)}"
+        cls.url = reverse(ZaakEigenschap, kwargs={"zaak_uuid": cls.zaak.uuid})
+        cls.zaak_url = f"http://testserver{reverse(cls.zaak)}"
 
     def test_string_valid(self):
         eigenschap = EigenschapFactory.create(

--- a/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten_cmis.py
@@ -33,8 +33,9 @@ class ZaakInformatieObjectCMISAPITests(JWTAuthMixin, APICMISTestCase):
     list_url = reverse_lazy(ZaakInformatieObject)
     heeft_alle_autorisaties = True
 
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
 
         ServiceFactory.create(
             api_root="http://example.com/documenten/api/v1/", api_type=APITypes.drc

--- a/src/openzaak/conf/ci.py
+++ b/src/openzaak/conf/ci.py
@@ -32,6 +32,9 @@ CACHES = {
 
 LOGGING = LOGGING_SETTINGS  # Minimally required logging is nice
 
+# don't spend time on password hashing in tests/user factories
+PASSWORD_HASHERS = ["django.contrib.auth.hashers.UnsaltedMD5PasswordHasher"]
+
 #
 # Django-axes
 #

--- a/src/openzaak/tests/management/test_generate_data.py
+++ b/src/openzaak/tests/management/test_generate_data.py
@@ -148,11 +148,12 @@ class GenerateDataAdminTests(WebTest):
         super().setUpTestData()
         cls.user = SuperUserFactory.create()
 
-    def setUp(self):
-        super().setUp()
         site = Site.objects.get_current()
         site.domain = "testserver"
         site.save()
+
+    def setUp(self):
+        super().setUp()
 
         self.app.set_user(self.user)
 

--- a/src/openzaak/tests/test_view_config.py
+++ b/src/openzaak/tests/test_view_config.py
@@ -15,10 +15,11 @@ class ViewConfigTestCase(WebTest):
     url = reverse_lazy("view-config")
     api_root = "http://notifications.local/api/v1/"
 
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
 
-        self.config = NotificationsConfig.get_solo()
+        cls.config = NotificationsConfig.get_solo()
 
     def test_view_config_page_no_notifs_service(self):
         self.config.notifications_api_service = None


### PR DESCRIPTION
Closes #1712

Should cut CI time in half, resulting in ~10 mins: https://github.com/open-zaak/open-zaak/actions/runs/13859983660

**Changes**

* Upgrade coverage to 7.6.12
* Use faster password hasher when running tests
* Fix admin test that fired HTTP request to outside service
* Use uv to install deps in CI
* Install dependencies in docker build with UV
* Use setUpTestData instead of setUp to speed up testsuite
* Add missing mock for Catalogi API spec in archiving test

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
