### PR TITLE
✅ Add basic performance test for zaken list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,28 @@ jobs:
           path: ${{ github.workspace }}/.coverage-cmis
           include-hidden-files: true
 
+  performance-tests:
+    name: Run the performance test suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bring up docker compose and load data
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.factories.yml up -d --build || ( docker compose logs >&2 && exit 1; )
+          until docker compose logs web.local | grep -q "spawned uWSGI worker"; do
+            echo "uWSGI not running yet, waiting..."
+            sleep 3
+          done
+          docker compose exec --user root web.local pip install factory-boy
+          cat performance_test/create_data.py | docker compose exec -T web.local src/manage.py shell
+
+      - name: Run tests
+        run: |
+          pip install -r requirements/ci.txt
+          pytest performance_test/ --benchmark-json output.json
+
   publish_codecov:
     name: Publish coverage results
     runs-on: ubuntu-latest

--- a/docker-compose.factories.yml
+++ b/docker-compose.factories.yml
@@ -1,0 +1,17 @@
+# This is a compose file inteded for trying out the project locally and absolutely
+# not suitable for production usage. The configuration here contains non-safe defaults.
+#
+# If you want to try out CMIS with Alfresco, see docker-compose.alfresco.yml
+
+version: '3.4'
+
+services:
+  web.local:
+    volumes:
+      - ./src/openzaak/components/autorisaties/tests:/app/src/openzaak/components/autorisaties/tests
+      - ./src/openzaak/components/zaken/tests:/app/src/openzaak/components/zaken/tests
+      - ./src/openzaak/components/documenten/tests:/app/src/openzaak/components/documenten/tests
+      - ./src/openzaak/components/catalogi/tests:/app/src/openzaak/components/catalogi/tests
+      - ./src/openzaak/components/besluiten/tests:/app/src/openzaak/components/besluiten/tests
+      - ./src/openzaak/import_data/tests/:/app/src/openzaak/import_data/tests
+      - ./src/openzaak/tests/:/app/src/openzaak/tests

--- a/performance_test/conftest.py
+++ b/performance_test/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+@pytest.fixture
+def benchmark_assertions(benchmark):
+    def wrapper(**kwargs):
+        stats = benchmark.stats["stats"]
+        for name, value in kwargs.items():
+            assert (
+                getattr(stats, name) < value
+            ), f"{name} {getattr(stats, name)}s exceeded {value}s"
+
+    return wrapper

--- a/performance_test/create_data.py
+++ b/performance_test/create_data.py
@@ -1,0 +1,50 @@
+from vng_api_common.models import JWTSecret
+
+from openzaak.components.autorisaties.tests.factories import (
+    ApplicatieFactory,
+    AutorisatieFactory,
+)
+from openzaak.components.catalogi.models import Catalogus
+from openzaak.components.catalogi.tests.factories import ZaakTypeFactory
+from openzaak.components.zaken.tests.factories import ZaakFactory
+
+catalogus, _ = Catalogus.objects.get_or_create(
+    domein="AAAAA", rsin="000000000", defaults={"naam": "catalogus"}
+)
+
+zaaktype = ZaakTypeFactory.create(catalogus=catalogus)
+zaaktype2 = ZaakTypeFactory.create(catalogus=catalogus)
+
+JWTSecret.objects.get_or_create(identifier="foo", secret="bar")
+ApplicatieFactory.create(client_ids=["foo"], heeft_alle_autorisaties=True)
+
+JWTSecret.objects.get_or_create(identifier="non_superuser", secret="non_superuser")
+applicatie = ApplicatieFactory.create(
+    client_ids=["non_superuser"], heeft_alle_autorisaties=False
+)
+AutorisatieFactory.create(
+    applicatie=applicatie,
+    component="zrc",
+    scopes=["zaken.lezen"],
+    max_vertrouwelijkheidaanduiding="zeer_geheim",
+    zaaktype=f"http://localhost:8000/catalogi/api/v1/zaaktypen/{zaaktype.uuid}",
+)
+AutorisatieFactory.create(
+    applicatie=applicatie,
+    component="zrc",
+    scopes=["zaken.lezen"],
+    max_vertrouwelijkheidaanduiding="zeer_geheim",
+    zaaktype=f"http://localhost:8000/catalogi/api/v1/zaaktypen/{zaaktype2.uuid}",
+)
+
+ZaakFactory.create_batch(
+    2000,
+    zaaktype=zaaktype,
+)
+ZaakFactory.create_batch(
+    1000,
+    zaaktype=zaaktype2,
+)
+ZaakFactory.create_batch(
+    500,
+)

--- a/performance_test/test_zaken_list.py
+++ b/performance_test/test_zaken_list.py
@@ -1,0 +1,68 @@
+import time
+
+import jwt
+import pytest
+import requests
+from furl import furl
+
+BASE_URL = furl("http://localhost:8000/zaken/api/v1/")
+
+
+def generate_token(client_id: str, secret: str) -> str:
+    payload = {
+        "iss": "openzaak",
+        "iat": int(time.time()),
+        "client_id": client_id,
+        "user_id": client_id,
+        "user_representation": client_id,
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+TOKEN_SUPERUSER = generate_token("foo", "bar")
+HEADERS = {"Authorization": f"Bearer {TOKEN_SUPERUSER}", "Accept-Crs": "EPSG:4326"}
+
+TOKEN_NON_SUPERUSER = generate_token("non_superuser", "non_superuser")
+HEADERS_NON_SUPERUSER = {
+    "Authorization": f"Bearer {TOKEN_NON_SUPERUSER}",
+    "Accept-Crs": "EPSG:4326",
+}
+
+
+TOKEN_NON_SUPERUSER = generate_token("non_superuser", "non_superuser")
+HEADERS_NON_SUPERUSER = {
+    "Authorization": f"Bearer {TOKEN_NON_SUPERUSER}",
+    "Accept-Crs": "EPSG:4326",
+}
+
+
+@pytest.mark.benchmark(max_time=60, min_rounds=5)
+def test_zaken_list(benchmark, benchmark_assertions):
+    params = {"pageSize": 100, "page": 34}
+
+    def make_request():
+        return requests.get((BASE_URL / "zaken").set(params), headers=HEADERS)
+
+    result = benchmark(make_request)
+
+    assert result.status_code == 200
+    assert result.json()["count"] == 3500
+
+    benchmark_assertions(mean=1, median=1)
+
+
+@pytest.mark.benchmark(max_time=60, min_rounds=5)
+def test_zaken_list_non_superuser(benchmark, benchmark_assertions):
+    params = {"pageSize": 100, "page": 29}
+
+    def make_request():
+        return requests.get(
+            (BASE_URL / "zaken").set(params), headers=HEADERS_NON_SUPERUSER
+        )
+
+    result = benchmark(make_request)
+
+    assert result.status_code == 200
+    assert result.json()["count"] == 3000
+
+    benchmark_assertions(mean=1, median=1)

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -653,6 +653,8 @@ psycopg2==2.9.9
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   open-api-framework
+py-cpuinfo==9.0.0
+    # via pytest-benchmark
 pycodestyle==2.12.1
     # via flake8
 pycparser==2.21
@@ -712,6 +714,10 @@ pyrsistent==0.18.1
     #   -r requirements/base.txt
     #   jsonschema
 pytest==8.3.3
+    # via
+    #   -r requirements/test-tools.in
+    #   pytest-benchmark
+pytest-benchmark==5.1.0
     # via -r requirements/test-tools.in
 python-crontab==3.2.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -764,6 +764,11 @@ psycopg2==2.9.9
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   open-api-framework
+py-cpuinfo==9.0.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   pytest-benchmark
 pyasn1==0.4.8
     # via
     #   pyasn1-modules
@@ -844,6 +849,11 @@ pyrsistent==0.18.1
     #   -r requirements/ci.txt
     #   jsonschema
 pytest==8.3.3
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   pytest-benchmark
+pytest-benchmark==5.1.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/test-tools.in
+++ b/requirements/test-tools.in
@@ -13,6 +13,7 @@ vcrpy
 
 # CI tools
 pytest
+pytest-benchmark
 codecov
 
 # Code formatting


### PR DESCRIPTION
Related issue: https://github.com/maykinmedia/open-api-framework/issues/114

I looked into codspeed, but I couldn't get it to work with their walltime instrument yet (https://github.com/maykinmedia/objects-api/pull/555), to at least get started with improving performance, I added similar tests to the ones I added in objects-api a few weeks back.

Not sure how consistent the results are in CI because we don't run it on dedicated runners, but it at least gives some indication of performance and can be used locally 