### PR TITLE
:zap: [#1954] Pin django-loose-fk to improve DRF field performance 

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -166,7 +166,7 @@ django-jsonform==2.22.0
     #   open-api-framework
 django-log-outgoing-requests==0.6.1
     # via open-api-framework
-django-loose-fk==1.1.1
+django-loose-fk==1.1.2
     # via -r requirements/base.in
 django-markup==1.8.1
     # via open-api-framework

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -293,7 +293,7 @@ django-log-outgoing-requests==0.6.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   open-api-framework
-django-loose-fk==1.1.1
+django-loose-fk==1.1.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -334,7 +334,7 @@ django-log-outgoing-requests==0.6.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   open-api-framework
-django-loose-fk==1.1.1
+django-loose-fk==1.1.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Closes #1954 

Tried running performance tests with `_zaaktype` on the serializer instead of `zaaktype`, this bypasses django-loose-fk and just relies on drf HyperlinkedRelatedField to transform the fk into a URL
Baseline with 3500 zaken https://github.com/open-zaak/open-zaak/actions/runs/14055723188/job/39354660277
Only using local zaaktype (bypassing django-loose-fk): https://github.com/open-zaak/open-zaak/actions/runs/14058796484/job/39364290821?pr=1957

This seems to speed up the response time by about 35ms (had similar results locally). I think it is worth looking into optimizing django-loose-fk's serialization

Made a PR in django-loose-fk to improve serialization performance: https://github.com/maykinmedia/django-loose-fk/pull/40

Results seem to be about 25-35ms speedup for mean/median compared to baseline which is somewhere between 10-15%
https://github.com/open-zaak/open-zaak/actions/runs/14055723188/job/39354660277
https://github.com/open-zaak/open-zaak/actions/runs/14104624099/job/39508344381