### PR TITLE
:zap: [#1960] Optimize the Zaak list endpoint query

### DIFF
--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -248,8 +248,10 @@ class ZaakViewSet(
     """
 
     queryset = (
-        Zaak.objects.select_related("_zaaktype")
-        .prefetch_related(
+        Zaak.objects.prefetch_related(
+            # Prefetch _zaaktype instead of using `.select_related`, because using the latter
+            # causes the main Zaak query to contain a lot of duplicate data, increasing overhead
+            "_zaaktype",
             "deelzaken",
             models.Prefetch(
                 "relevante_andere_zaken",

--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -248,7 +248,7 @@ class ZaakViewSet(
     """
 
     queryset = (
-        Zaak.objects.select_related("_zaaktype", "_zaaktype__catalogus")
+        Zaak.objects.select_related("_zaaktype")
         .prefetch_related(
             "deelzaken",
             models.Prefetch(
@@ -299,6 +299,13 @@ class ZaakViewSet(
             # is needed, the queries will be done during serialization and the amount
             # of queries will be the same.
             qs = qs.prefetch_related(None)
+
+        if action not in ["list", "detail", "_zoek"]:
+            # Catalogus is only relevant for notifications (to include the `zaaktype.catalogus`)
+            # kenmerk. The read operations are slightly slower if we include this `select_related`
+            # on the base queryset, because it adds an extra join
+            qs = qs.select_related("_zaaktype__catalogus")
+
         return qs
 
     @property

--- a/src/openzaak/components/zaken/tests/test_auth.py
+++ b/src/openzaak/components/zaken/tests/test_auth.py
@@ -517,7 +517,7 @@ class ZaakListPerformanceTests(JWTAuthMixin, APITestCase):
         # queries because of the permission checks
         PERMISSION_CHECK_NUM_QUERIES = 6
         # queries because of the list endpoint itself
-        ENDPOINT_NUM_QUERIES = 11
+        ENDPOINT_NUM_QUERIES = 12
         TOTAL_EXPECTED_QUERIES = (
             BASE_NUM_QUERIES + PERMISSION_CHECK_NUM_QUERIES + ENDPOINT_NUM_QUERIES
         )


### PR DESCRIPTION
Closes https://github.com/open-zaak/open-zaak/issues/1960 

Increases performance by 25-30ms, so about 10-15% (from 214ms)

Baseline:
https://github.com/open-zaak/open-zaak/actions/runs/14055723188/job/39354660277#step:4:764

After removing catalogus select_related:
https://github.com/open-zaak/open-zaak/actions/runs/14108901120/job/39522128121#step:4:764

After replacing _zaaktype select_related with prefetch:
https://github.com/open-zaak/open-zaak/actions/runs/14130148304/job/39588155288#step:4:764

**Changes**

* Replace zaak._zaaktype select_related with prefetch
* Remove select_related on Zaak._zaaktype.catalogus for read operations

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
