### PR TITLE
:zap: [#1965] Don't run expand related code if expand query param is unused

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -11,6 +11,7 @@ django-debug-toolbar
 django-extensions
 django-silk
 whitenoise
+pyinstrument
 
 # Deployment
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -812,6 +812,8 @@ pygments==2.18.0
     #   -r requirements/ci.txt
     #   sphinx
     #   sphinx-tabs
+pyinstrument==5.0.1
+    # via -r requirements/dev.in
 pyjwt==2.4.0
     # via
     #   -c requirements/ci.txt

--- a/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject.py
+++ b/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject.py
@@ -376,6 +376,7 @@ class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APITestCase):
             "locked": False,
             "verschijningsvorm": "",
             "trefwoorden": [],
+            "_expand": {},
         }
 
         response_data = response.json()

--- a/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject_cmis.py
@@ -309,6 +309,7 @@ class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APICMISTestCase):
             "locked": False,
             "verschijningsvorm": "",
             "trefwoorden": [],
+            "_expand": {},
         }
 
         response_data = response.json()

--- a/src/openzaak/components/documenten/tests/test_verzending.py
+++ b/src/openzaak/components/documenten/tests/test_verzending.py
@@ -100,6 +100,7 @@ class VerzendingAPITests(JWTAuthMixin, APITestCase):
                 "emailadres": verzending.emailadres,
                 "mijnOverheid": verzending.mijn_overheid,
                 "telefoonnummer": verzending.telefoonnummer,
+                "_expand": {},
             },
         )
 
@@ -146,6 +147,7 @@ class VerzendingAPITests(JWTAuthMixin, APITestCase):
                 "emailadres": verzending.emailadres,
                 "mijnOverheid": verzending.mijn_overheid,
                 "telefoonnummer": verzending.telefoonnummer,
+                "_expand": {},
             },
         )
 
@@ -192,6 +194,7 @@ class VerzendingAPITests(JWTAuthMixin, APITestCase):
                 "emailadres": verzending.emailadres,
                 "mijnOverheid": verzending.mijn_overheid,
                 "telefoonnummer": verzending.telefoonnummer,
+                "_expand": {},
             },
         )
 

--- a/src/openzaak/components/zaken/tests/test_create.py
+++ b/src/openzaak/components/zaken/tests/test_create.py
@@ -547,17 +547,15 @@ class PerformanceTests(
             44: insert audit trail
          45-46: notifications, select created zaak (?), notifs config
             47: release savepoint (from NotificationsCreateMixin)
-            48: select zaak relevantezaakrelatie (nested inline create, can't avoid this)
-            49: select zaak kenmerken (nested inline create, can't avoid this)
-            50: savepoint create transaction.on_commit ETag handler (start new transaction)
-            51: update ETag column of zaak
-            52: release savepoint (commit transaction)
+            48: savepoint create transaction.on_commit ETag handler (start new transaction)
+            59: update ETag column of zaak
+            50: release savepoint (commit transaction)
         """
         # create a random zaak to get some other initial setup queries out of the way
         # (most notable figuring out the PG/postgres version)
         ZaakFactory.create()
 
-        EXPECTED_NUM_QUERIES = 52
+        EXPECTED_NUM_QUERIES = 50
 
         zaaktype_url = reverse(self.zaaktype)
         url = get_operation_url("zaak_create")

--- a/src/openzaak/components/zaken/tests/test_zaak_expand.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_expand.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2022 Dimpact
+from unittest import skip
+
 from django.contrib.gis.geos import Point
 from django.test import override_settings, tag
 
@@ -90,6 +92,51 @@ class ZakenIncludeTests(JWTAuthMixin, APITestCase):
             },
             {**hoofdzaak_data, "_expand": {"zaaktype": zaaktype_data}},
         ]
+        self.assertEqual(data, expected_results)
+
+    def test_zaak_list_no_expand(self):
+        """
+        Verify that the _expand key is also present if the expand query parameter is unused
+        """
+        zaak = ZaakFactory.create(zaaktype=self.zaaktype)
+
+        zaak_data = self.client.get(reverse(zaak), **ZAAK_READ_KWARGS).json()
+
+        response = self.client.get(
+            self.url,
+            **ZAAK_READ_KWARGS,
+        )
+
+        data = response.json()["results"]
+        expected_results = [
+            {
+                **zaak_data,
+                "_expand": {},
+            }
+        ]
+
+        self.assertEqual(data, expected_results)
+
+    @skip("Currently the _expand attribute is not present in the detail response")
+    def test_zaak_retrieve_no_expand(self):
+        """
+        Verify that the _expand key is also present if the expand query parameter is unused
+        """
+        zaak = ZaakFactory.create(zaaktype=self.zaaktype)
+
+        zaak_data = self.client.get(reverse(zaak), **ZAAK_READ_KWARGS).json()
+
+        response = self.client.get(
+            reverse(zaak),
+            **ZAAK_READ_KWARGS,
+        )
+
+        data = response.json()
+        expected_results = {
+            **zaak_data,
+            "_expand": {},
+        }
+
         self.assertEqual(data, expected_results)
 
     def test_zaak_zoek_include(self):

--- a/src/openzaak/components/zaken/tests/test_zaak_expand.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_expand.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2022 Dimpact
-from unittest import skip
-
 from django.contrib.gis.geos import Point
 from django.test import override_settings, tag
 
@@ -117,7 +115,6 @@ class ZakenIncludeTests(JWTAuthMixin, APITestCase):
 
         self.assertEqual(data, expected_results)
 
-    @skip("Currently the _expand attribute is not present in the detail response")
     def test_zaak_retrieve_no_expand(self):
         """
         Verify that the _expand key is also present if the expand query parameter is unused
@@ -161,6 +158,11 @@ class ZakenIncludeTests(JWTAuthMixin, APITestCase):
         eigenschap_data = self.client.get(
             reverse(eigenschap, kwargs={"zaak_uuid": zaak.uuid})
         ).json()
+
+        # The detail responses also include the _expand attribute, but the list response
+        # only has a _expand attribute at the root level (no _expand nested inside _expand)
+        del zaak_data["_expand"]
+        del hoofdzaak_data["_expand"]
 
         response = self.client.post(
             reverse("zaak--zoek"),
@@ -254,6 +256,11 @@ class ZakenIncludeTests(JWTAuthMixin, APITestCase):
         eigenschap_data = self.client.get(
             reverse(eigenschap, kwargs={"zaak_uuid": zaak.uuid})
         ).json()
+
+        # The detail responses also include the _expand attribute, but the list response
+        # only has a _expand attribute at the root level (no _expand nested inside _expand)
+        del zaak_data["_expand"]
+        del hoofdzaak_data["_expand"]
 
         response = self.client.get(
             zaak_url,

--- a/src/openzaak/conf/dev.py
+++ b/src/openzaak/conf/dev.py
@@ -88,6 +88,10 @@ if config("PROFILE", default=False, add_to_docs=False):
     security_index = MIDDLEWARE.index("django.middleware.security.SecurityMiddleware")
     MIDDLEWARE.insert(security_index + 1, "whitenoise.middleware.WhiteNoiseMiddleware")
 
+if config("USE_PYINSTRUMENT", default=False, add_to_docs=False):  # pragma:no cover
+    MIDDLEWARE = ["openzaak.utils.middleware.PyInstrumentMiddleware"] + MIDDLEWARE
+
+
 warnings.filterwarnings(
     "error",
     r"DateTimeField .* received a naive datetime",

--- a/src/openzaak/utils/expansion.py
+++ b/src/openzaak/utils/expansion.py
@@ -371,10 +371,14 @@ class ExpandJSONRenderer(InclusionJSONRenderer, CamelCaseJSONRenderer):
             EXPAND_QUERY_PARAM not in request.query_params
             and EXPAND_QUERY_PARAM not in request.data
         ):
-            # Always include the `_expand` attribute for list operations
+            # Always include the empty `_expand` attribute
             if isinstance(serializer_data, list):
                 for record in serializer_data:
                     record[EXPAND_KEY] = {}
+
+            if isinstance(serializer_data, dict):
+                serializer_data[EXPAND_KEY] = {}
+
             return render_data
 
         inclusion_loader = self.loader_class(get_allowed_paths(request, view=view))

--- a/src/openzaak/utils/expansion.py
+++ b/src/openzaak/utils/expansion.py
@@ -9,6 +9,7 @@ from django.utils.module_loading import import_string
 from django_loose_fk.loaders import FetchError
 from django_loose_fk.virtual_models import ProxyMixin
 from djangorestframework_camel_case.render import CamelCaseJSONRenderer
+from rest_framework.request import Request
 from rest_framework.serializers import BaseSerializer, Field, Serializer
 from rest_framework_inclusions.core import InclusionLoader
 from rest_framework_inclusions.renderer import (
@@ -22,6 +23,7 @@ from openzaak.utils.serializer_fields import FKOrServiceUrlField
 logger = logging.getLogger(__name__)
 
 EXPAND_KEY = "_expand"
+EXPAND_QUERY_PARAM = "expand"
 
 
 class InclusionNode:
@@ -362,7 +364,18 @@ class ExpandJSONRenderer(InclusionJSONRenderer, CamelCaseJSONRenderer):
                 )
                 return None
 
-        request = renderer_context.get("request")
+        request: Request | None = renderer_context.get("request")
+        assert request
+
+        if (
+            EXPAND_QUERY_PARAM not in request.query_params
+            and EXPAND_QUERY_PARAM not in request.data
+        ):
+            # Always include the `_expand` attribute for list operations
+            if isinstance(serializer_data, list):
+                for record in serializer_data:
+                    record[EXPAND_KEY] = {}
+            return render_data
 
         inclusion_loader = self.loader_class(get_allowed_paths(request, view=view))
         inclusions = inclusion_loader.inclusions_dict(serializer)

--- a/src/openzaak/utils/middleware.py
+++ b/src/openzaak/utils/middleware.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
 import logging
+import os
 from dataclasses import dataclass
 from typing import Dict, Optional
 
 from django.conf import settings
-from django.http import HttpRequest, HttpResponseNotFound
+from django.http import HttpRequest, HttpResponse, HttpResponseNotFound
 
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
@@ -198,3 +199,42 @@ class DeprecationMiddleware:
         )
 
         return None
+
+
+class PyInstrumentMiddleware:  # pragma:no cover
+    """
+    Middleware that's included in dev environments if `USE_PYINSTRUMENT=true`,
+    allows profiling of the request/response cycle. Profiling results can be viewed
+    at `/_profiling`
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.profiler_output_path = "/tmp/pyinstrument_profile.html"
+
+    def __call__(self, request):
+        if request.path.startswith("/_profiling"):
+            return self._serve_profile()
+
+        # Local import to avoid having to install this in production environments
+        from pyinstrument import Profiler
+
+        profiler = Profiler()
+        profiler.start()
+
+        response = self.get_response(request)
+
+        profiler.stop()
+
+        # Save the profile to an HTML file
+        with open(self.profiler_output_path, "w") as f:
+            f.write(profiler.output_html())
+
+        return response
+
+    def _serve_profile(self):
+        """Serve the latest profiling report"""
+        if os.path.exists(self.profiler_output_path):
+            with open(self.profiler_output_path, "r") as f:
+                return HttpResponse(f.read(), content_type="text/html")
+        return HttpResponse("No profiling report available yet.", status=404)

--- a/src/openzaak/utils/mixins.py
+++ b/src/openzaak/utils/mixins.py
@@ -11,7 +11,7 @@ from vng_api_common.models import APIMixin as _APIMixin
 from openzaak.utils.decorators import convert_cmis_adapter_exceptions
 
 from .exceptions import CMISNotSupportedException
-from .expansion import ExpandJSONRenderer
+from .expansion import EXPAND_QUERY_PARAM, ExpandJSONRenderer
 
 
 def format_dict_diff(changes):
@@ -91,7 +91,7 @@ class APIMixin(_APIMixin):
 
 class ExpandMixin:
     renderer_classes = (ExpandJSONRenderer,)
-    expand_param = "expand"
+    expand_param = EXPAND_QUERY_PARAM
 
     def include_allowed(self):
         return self.action in ["list", "_zoek", "retrieve"]


### PR DESCRIPTION
this was causing overhead because it called reverse() for all objects returned by the query, even if expand was not supplied as a query parameter

Improves response time by up to 5-10% (if 100 objects are returned by a list endpoint)
- baseline https://github.com/open-zaak/open-zaak/actions/runs/14167931550/job/39685107057#step:4:765
- with changes https://github.com/open-zaak/open-zaak/actions/runs/14168658191/job/39687366304?pr=1961#step:4:762

Closes https://github.com/open-zaak/open-zaak/issues/1965

**Changes**

* Add middleware to profile request/response cycle with pyinstrument
* Don't run expand related code if expand query param is unused
* Add empty _expand attribute for detail operation if query param unused

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
