### PR TITLE
:zap: Optimize DRF hyperlinked fields

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -66,7 +66,7 @@ click-repl==0.2.0
     # via celery
 cmislib-maykin==0.7.4
     # via drc-cmis
-commonground-api-common==2.5.5
+commonground-api-common==2.6.0
     # via
     #   -r requirements/base.in
     #   drc-cmis

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -134,7 +134,7 @@ cmislib-maykin==0.7.4
     #   drc-cmis
 codecov==2.1.13
     # via -r requirements/test-tools.in
-commonground-api-common==2.5.5
+commonground-api-common==2.6.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -160,7 +160,7 @@ codecov==2.1.13
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-commonground-api-common==2.5.5
+commonground-api-common==2.6.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/openzaak/components/catalogi/api/serializers/besluittype.py
+++ b/src/openzaak/components/catalogi/api/serializers/besluittype.py
@@ -3,6 +3,7 @@
 from django.utils.text import gettext_lazy as _
 
 from rest_framework import serializers
+from vng_api_common.serializers import CachedHyperlinkedRelatedField
 from vng_api_common.utils import get_help_text
 
 from ...models import BesluitType, InformatieObjectType
@@ -17,7 +18,7 @@ from ..validators import (
 
 
 class BesluitTypeSerializer(serializers.HyperlinkedModelSerializer):
-    informatieobjecttypen = serializers.HyperlinkedRelatedField(
+    informatieobjecttypen = CachedHyperlinkedRelatedField(
         view_name="informatieobjecttype-detail",
         many=True,
         lookup_field="uuid",
@@ -25,7 +26,7 @@ class BesluitTypeSerializer(serializers.HyperlinkedModelSerializer):
         help_text=get_help_text("catalogi.BesluitType", "informatieobjecttypen"),
     )
 
-    zaaktypen = serializers.HyperlinkedRelatedField(
+    zaaktypen = CachedHyperlinkedRelatedField(
         many=True,
         view_name="zaaktype-detail",
         lookup_field="uuid",
@@ -33,7 +34,7 @@ class BesluitTypeSerializer(serializers.HyperlinkedModelSerializer):
         help_text=get_help_text("catalogi.BesluitType", "zaaktypen"),
     )
 
-    resultaattypen = serializers.HyperlinkedRelatedField(
+    resultaattypen = CachedHyperlinkedRelatedField(
         many=True,
         source="resultaattype_set",
         view_name="resultaattype-detail",

--- a/src/openzaak/components/catalogi/api/serializers/catalogus.py
+++ b/src/openzaak/components/catalogi/api/serializers/catalogus.py
@@ -3,12 +3,13 @@
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
+from vng_api_common.serializers import CachedHyperlinkedRelatedField
 
 from ...models import Catalogus
 
 
 class CatalogusSerializer(serializers.HyperlinkedModelSerializer):
-    zaaktypen = serializers.HyperlinkedRelatedField(
+    zaaktypen = CachedHyperlinkedRelatedField(
         many=True,
         read_only=True,
         source="zaaktype_set",
@@ -19,7 +20,7 @@ class CatalogusSerializer(serializers.HyperlinkedModelSerializer):
         ),
     )
 
-    besluittypen = serializers.HyperlinkedRelatedField(
+    besluittypen = CachedHyperlinkedRelatedField(
         many=True,
         read_only=True,
         source="besluittype_set",
@@ -30,7 +31,7 @@ class CatalogusSerializer(serializers.HyperlinkedModelSerializer):
         ),
     )
 
-    informatieobjecttypen = serializers.HyperlinkedRelatedField(
+    informatieobjecttypen = CachedHyperlinkedRelatedField(
         many=True,
         read_only=True,
         source="informatieobjecttype_set",

--- a/src/openzaak/components/catalogi/api/serializers/eigenschap.py
+++ b/src/openzaak/components/catalogi/api/serializers/eigenschap.py
@@ -4,7 +4,10 @@ from django.utils.translation import gettext_lazy as _
 
 from drf_writable_nested import NestedCreateMixin, NestedUpdateMixin
 from rest_framework import serializers
-from vng_api_common.serializers import add_choice_values_help_text
+from vng_api_common.serializers import (
+    CachedHyperlinkedRelatedField,
+    add_choice_values_help_text,
+)
 from vng_api_common.utils import get_help_text
 
 from openzaak.utils.validators import UniqueTogetherValidator
@@ -43,7 +46,7 @@ class EigenschapSerializer(
     specificatie = EigenschapSpecificatieSerializer(
         source="specificatie_van_eigenschap"
     )
-    catalogus = serializers.HyperlinkedRelatedField(
+    catalogus = CachedHyperlinkedRelatedField(
         view_name="catalogus-detail",
         source="zaaktype.catalogus",
         read_only=True,

--- a/src/openzaak/components/catalogi/api/serializers/relatieklassen.py
+++ b/src/openzaak/components/catalogi/api/serializers/relatieklassen.py
@@ -3,7 +3,10 @@
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
-from vng_api_common.serializers import add_choice_values_help_text
+from vng_api_common.serializers import (
+    CachedHyperlinkedRelatedField,
+    add_choice_values_help_text,
+)
 from vng_api_common.utils import get_help_text
 
 from openzaak.utils.validators import UniqueTogetherValidator
@@ -20,7 +23,7 @@ class ZaakTypeInformatieObjectTypeSerializer(serializers.HyperlinkedModelSeriali
     Relatie met informatieobjecttype dat relevant is voor zaaktype.
     """
 
-    catalogus = serializers.HyperlinkedRelatedField(
+    catalogus = CachedHyperlinkedRelatedField(
         view_name="catalogus-detail",
         source="zaaktype.catalogus",
         read_only=True,

--- a/src/openzaak/components/catalogi/api/serializers/resultaattype.py
+++ b/src/openzaak/components/catalogi/api/serializers/resultaattype.py
@@ -10,6 +10,7 @@ from vng_api_common.constants import (
     ZaakobjectTypes,
 )
 from vng_api_common.serializers import (
+    CachedHyperlinkedRelatedField,
     GegevensGroepSerializer,
     NestedGegevensGroepMixin,
     add_choice_values_help_text,
@@ -63,7 +64,7 @@ class ResultaatTypeSerializer(
             "start van de Archiefactietermijn (=brondatum) van het zaakdossier."
         ),
     )
-    catalogus = serializers.HyperlinkedRelatedField(
+    catalogus = CachedHyperlinkedRelatedField(
         view_name="catalogus-detail",
         source="zaaktype.catalogus",
         read_only=True,

--- a/src/openzaak/components/catalogi/api/serializers/roltype.py
+++ b/src/openzaak/components/catalogi/api/serializers/roltype.py
@@ -5,7 +5,10 @@ from django.utils.translation import gettext_lazy as _
 from drf_writable_nested import NestedCreateMixin
 from rest_framework import serializers
 from vng_api_common.constants import RolOmschrijving
-from vng_api_common.serializers import add_choice_values_help_text
+from vng_api_common.serializers import (
+    CachedHyperlinkedRelatedField,
+    add_choice_values_help_text,
+)
 from vng_api_common.utils import get_help_text
 
 from ...models import RolType
@@ -13,7 +16,7 @@ from ..validators import StartBeforeEndValidator, ZaakTypeConceptValidator
 
 
 class RolTypeSerializer(NestedCreateMixin, serializers.HyperlinkedModelSerializer):
-    catalogus = serializers.HyperlinkedRelatedField(
+    catalogus = CachedHyperlinkedRelatedField(
         view_name="catalogus-detail",
         source="zaaktype.catalogus",
         read_only=True,

--- a/src/openzaak/components/catalogi/api/serializers/statustype.py
+++ b/src/openzaak/components/catalogi/api/serializers/statustype.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext_lazy as _
 
 from drf_writable_nested import NestedCreateMixin, NestedUpdateMixin
 from rest_framework import serializers
+from vng_api_common.serializers import CachedHyperlinkedRelatedField
 from vng_api_common.utils import get_help_text
 
 from ...models import CheckListItem, StatusType
@@ -32,7 +33,7 @@ class StatusTypeSerializer(
             "met het hoogste volgnummer."
         ),
     )
-    catalogus = serializers.HyperlinkedRelatedField(
+    catalogus = CachedHyperlinkedRelatedField(
         view_name="catalogus-detail",
         source="zaaktype.catalogus",
         read_only=True,
@@ -47,7 +48,7 @@ class StatusTypeSerializer(
             "Unieke identificatie van het ZAAKTYPE binnen de CATALOGUS waarin het ZAAKTYPE voorkomt."
         ),
     )
-    eigenschappen = serializers.HyperlinkedRelatedField(
+    eigenschappen = CachedHyperlinkedRelatedField(
         view_name="eigenschap-detail",
         many=True,
         read_only=True,
@@ -57,7 +58,7 @@ class StatusTypeSerializer(
             "voordat een STATUS van dit STATUSTYPE kan worden gezet."
         ),
     )
-    zaakobjecttypen = serializers.HyperlinkedRelatedField(
+    zaakobjecttypen = CachedHyperlinkedRelatedField(
         view_name="zaakobjecttype-detail",
         many=True,
         read_only=True,

--- a/src/openzaak/components/catalogi/api/serializers/zaakobjecttype.py
+++ b/src/openzaak/components/catalogi/api/serializers/zaakobjecttype.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext as _
 
 from rest_framework import serializers
 from rest_framework.serializers import HyperlinkedModelSerializer
+from vng_api_common.serializers import CachedHyperlinkedRelatedField
 from vng_api_common.utils import get_help_text
 
 from ...models import ZaakObjectType
@@ -23,7 +24,7 @@ class ZaakObjectTypeSerializer(HyperlinkedModelSerializer):
             "Unieke identificatie van het ZAAKTYPE binnen de CATALOGUS waarin het ZAAKTYPE voorkomt."
         ),
     )
-    catalogus = serializers.HyperlinkedRelatedField(
+    catalogus = CachedHyperlinkedRelatedField(
         view_name="catalogus-detail",
         source="zaaktype.catalogus",
         read_only=True,

--- a/src/openzaak/components/catalogi/api/serializers/zaaktype.py
+++ b/src/openzaak/components/catalogi/api/serializers/zaaktype.py
@@ -8,11 +8,11 @@ from drf_writable_nested import NestedCreateMixin, NestedUpdateMixin
 from rest_framework.serializers import (
     DateField,
     HyperlinkedModelSerializer,
-    HyperlinkedRelatedField,
     ModelSerializer,
 )
 from vng_api_common.constants import VertrouwelijkheidsAanduiding
 from vng_api_common.serializers import (
+    CachedHyperlinkedRelatedField,
     GegevensGroepSerializer,
     NestedGegevensGroepMixin,
     add_choice_values_help_text,
@@ -110,7 +110,7 @@ class ZaakTypeSerializer(
     )
 
     # relations
-    informatieobjecttypen = HyperlinkedRelatedField(
+    informatieobjecttypen = CachedHyperlinkedRelatedField(
         many=True,
         read_only=True,
         view_name="informatieobjecttype-detail",
@@ -120,7 +120,7 @@ class ZaakTypeSerializer(
         ),
     )
 
-    statustypen = HyperlinkedRelatedField(
+    statustypen = CachedHyperlinkedRelatedField(
         many=True,
         read_only=True,
         view_name="statustype-detail",
@@ -130,7 +130,7 @@ class ZaakTypeSerializer(
         ),
     )
 
-    resultaattypen = HyperlinkedRelatedField(
+    resultaattypen = CachedHyperlinkedRelatedField(
         many=True,
         read_only=True,
         view_name="resultaattype-detail",
@@ -140,7 +140,7 @@ class ZaakTypeSerializer(
         ),
     )
 
-    eigenschappen = HyperlinkedRelatedField(
+    eigenschappen = CachedHyperlinkedRelatedField(
         many=True,
         read_only=True,
         source="eigenschap_set",
@@ -151,7 +151,7 @@ class ZaakTypeSerializer(
         ),
     )
 
-    roltypen = HyperlinkedRelatedField(
+    roltypen = CachedHyperlinkedRelatedField(
         many=True,
         read_only=True,
         source="roltype_set",
@@ -162,7 +162,7 @@ class ZaakTypeSerializer(
         ),
     )
 
-    besluittypen = HyperlinkedRelatedField(
+    besluittypen = CachedHyperlinkedRelatedField(
         many=True,
         label=_("heeft relevante besluittypen"),
         view_name="besluittype-detail",
@@ -172,7 +172,7 @@ class ZaakTypeSerializer(
             "URL-referenties naar de BESLUITTYPEN die mogelijk zijn binnen dit ZAAKTYPE."
         ),
     )
-    zaakobjecttypen = HyperlinkedRelatedField(
+    zaakobjecttypen = CachedHyperlinkedRelatedField(
         many=True,
         read_only=True,
         source="zaakobjecttype_set",

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -15,7 +15,6 @@ from django_loose_fk.virtual_models import ProxyMixin
 from drf_writable_nested import NestedCreateMixin, NestedUpdateMixin
 from rest_framework import serializers
 from rest_framework_gis.fields import GeometryField
-from rest_framework_nested.relations import NestedHyperlinkedRelatedField
 from rest_framework_nested.serializers import NestedHyperlinkedModelSerializer
 from vng_api_common.caching.etags import track_object_serializer
 from vng_api_common.constants import (
@@ -27,6 +26,9 @@ from vng_api_common.constants import (
 )
 from vng_api_common.polymorphism import Discriminator, PolymorphicSerializer
 from vng_api_common.serializers import (
+    CachedHyperlinkedIdentityField,
+    CachedHyperlinkedRelatedField,
+    CachedNestedHyperlinkedRelatedField,
     GegevensGroepSerializer,
     NestedGegevensGroepMixin,
     add_choice_values_help_text,
@@ -218,7 +220,8 @@ class ZaakSerializer(
     NestedUpdateMixin,
     serializers.HyperlinkedModelSerializer,
 ):
-    eigenschappen = NestedHyperlinkedRelatedField(
+    url = CachedHyperlinkedIdentityField(view_name="zaak-detail", lookup_field="uuid")
+    eigenschappen = CachedNestedHyperlinkedRelatedField(
         many=True,
         read_only=True,
         lookup_field="uuid",
@@ -227,7 +230,7 @@ class ZaakSerializer(
         source="zaakeigenschap_set",
         help_text=_("URL-referenties naar ZAAK-EIGENSCHAPPen."),
     )
-    rollen = NestedHyperlinkedRelatedField(
+    rollen = CachedHyperlinkedRelatedField(
         many=True,
         read_only=True,
         lookup_field="uuid",
@@ -235,7 +238,7 @@ class ZaakSerializer(
         source="rol_set",
         help_text=_("URL-referenties naar ROLLen."),
     )
-    status = serializers.HyperlinkedRelatedField(
+    status = CachedHyperlinkedRelatedField(
         source="current_status",
         read_only=True,
         allow_null=True,
@@ -243,7 +246,7 @@ class ZaakSerializer(
         lookup_field="uuid",
         help_text=_("Indien geen status bekend is, dan is de waarde 'null'"),
     )
-    zaakinformatieobjecten = NestedHyperlinkedRelatedField(
+    zaakinformatieobjecten = CachedHyperlinkedRelatedField(
         many=True,
         read_only=True,
         lookup_field="uuid",
@@ -251,7 +254,7 @@ class ZaakSerializer(
         source="zaakinformatieobject_set",
         help_text=_("URL-referenties naar ZAAKINFORMATIEOBJECTen."),
     )
-    zaakobjecten = NestedHyperlinkedRelatedField(
+    zaakobjecten = CachedHyperlinkedRelatedField(
         many=True,
         read_only=True,
         lookup_field="uuid",
@@ -290,7 +293,7 @@ class ZaakSerializer(
         ),
     )
 
-    deelzaken = serializers.HyperlinkedRelatedField(
+    deelzaken = CachedHyperlinkedRelatedField(
         read_only=True,
         many=True,
         view_name="zaak-detail",
@@ -299,7 +302,7 @@ class ZaakSerializer(
         help_text=_("URL-referenties naar deel ZAAKen."),
     )
 
-    resultaat = serializers.HyperlinkedRelatedField(
+    resultaat = CachedHyperlinkedRelatedField(
         read_only=True,
         allow_null=True,
         view_name="resultaat-detail",
@@ -876,7 +879,7 @@ class ZaakInformatieObjectSerializer(serializers.HyperlinkedModelSerializer):
 
 class ZaakEigenschapSerializer(NestedHyperlinkedModelSerializer):
     parent_lookup_kwargs = {"zaak_uuid": "zaak__uuid"}
-    zaak = serializers.HyperlinkedRelatedField(
+    zaak = CachedHyperlinkedRelatedField(
         queryset=Zaak.objects.all(),
         view_name="zaak-detail",
         lookup_field="uuid",

--- a/src/openzaak/components/zaken/tests/test_zaken.py
+++ b/src/openzaak/components/zaken/tests/test_zaken.py
@@ -50,7 +50,13 @@ from ..models import (
     ZaakIdentificatie,
 )
 from .constants import POLYGON_AMSTERDAM_CENTRUM
-from .factories import ResultaatFactory, RolFactory, StatusFactory, ZaakFactory
+from .factories import (
+    ResultaatFactory,
+    RolFactory,
+    StatusFactory,
+    ZaakEigenschapFactory,
+    ZaakFactory,
+)
 from .utils import (
     ZAAK_READ_KWARGS,
     ZAAK_WRITE_KWARGS,
@@ -435,6 +441,22 @@ class ZakenTests(JWTAuthMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.json()["deelzaken"], [f"http://testserver{deelzaak_url}"]
+        )
+
+    def test_zaakeigenschappen(self):
+        zaak = ZaakFactory.create(zaaktype=self.zaaktype)
+        zaakeigenschap = ZaakEigenschapFactory.create(zaak=zaak)
+        detail_url = reverse(zaak)
+        zaakeigenschap_url = reverse(
+            "zaakeigenschap-detail",
+            kwargs={"zaak_uuid": str(zaak.uuid), "uuid": str(zaakeigenschap.uuid)},
+        )
+
+        response = self.client.get(detail_url, **ZAAK_READ_KWARGS)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json()["eigenschappen"], [f"http://testserver{zaakeigenschap_url}"]
         )
 
     def test_create_deelzaak_success(self, *mocks):

--- a/src/openzaak/utils/serializer_fields.py
+++ b/src/openzaak/utils/serializer_fields.py
@@ -45,6 +45,7 @@ class LengthValidationMixin:
         return value
 
 
+# TODO performance: should this also use `vng_api_common.serializers.CacheMixin`?
 class LengthHyperlinkedRelatedField(
     LengthValidationMixin, serializers.HyperlinkedRelatedField
 ):


### PR DESCRIPTION
Closes https://github.com/open-zaak/open-zaak/issues/1970

Improves median response time by about 10-20% in CI
Baseline on main: https://github.com/open-zaak/open-zaak/actions/runs/14265544211/job/39986422488#step:4:760
After changes: https://github.com/open-zaak/open-zaak/actions/runs/14268741960/job/39996806525?pr=1969#step:4:775

Related PR: https://github.com/maykinmedia/commonground-api-common/pull/82

**Changes**

* Use cached hyperlinked DRF fields for several serializers, to avoid redundant logic from being evaluated to determine the base URLs

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
