### PR TITLE
:zap: Add missing prefetch_related for Rol.statussen

### DIFF
--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -975,6 +975,7 @@ class RolViewSet(
             "vestiging",
             "organisatorischeeenheid",
             "medewerker",
+            "statussen",
         )
         .order_by("-pk")
     )


### PR DESCRIPTION
a lot of duplicate queries were done due to this missing prefetch

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
