### PR TITLE
:zap: [#1976] Cache the result of get_queryset per request

### DIFF
--- a/src/openzaak/components/besluiten/api/viewsets.py
+++ b/src/openzaak/components/besluiten/api/viewsets.py
@@ -29,6 +29,7 @@ from openzaak.components.zaken.api.mixins import ClosedZaakMixin
 from openzaak.components.zaken.api.utils import delete_remote_zaakbesluit
 from openzaak.utils.api import delete_remote_oio
 from openzaak.utils.data_filtering import ListFilterByAuthorizationsMixin
+from openzaak.utils.mixins import CacheQuerysetMixin
 from openzaak.utils.pagination import OptimizedPagination
 from openzaak.utils.permissions import AuthRequired
 from openzaak.utils.views import AuditTrailViewSet
@@ -190,6 +191,7 @@ class BesluitViewSet(
 )
 @conditional_retrieve()
 class BesluitInformatieObjectViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     NotificationCreateMixin,
     NotificationDestroyMixin,
     AuditTrailCreateMixin,

--- a/src/openzaak/components/catalogi/api/viewsets/besluittype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/besluittype.py
@@ -7,6 +7,7 @@ from rest_framework.decorators import action
 from vng_api_common.caching import conditional_retrieve
 from vng_api_common.viewsets import CheckQueryParamsMixin
 
+from openzaak.utils.mixins import CacheQuerysetMixin
 from openzaak.utils.pagination import OptimizedPagination
 from openzaak.utils.permissions import AuthRequired
 from openzaak.utils.schema import COMMON_ERROR_RESPONSES, VALIDATION_ERROR_RESPONSES
@@ -54,6 +55,7 @@ from .mixins import ConceptMixin, M2MConceptDestroyMixin
 )
 @conditional_retrieve()
 class BesluitTypeViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     CheckQueryParamsMixin,
     ConceptMixin,
     M2MConceptDestroyMixin,

--- a/src/openzaak/components/catalogi/api/viewsets/catalogus.py
+++ b/src/openzaak/components/catalogi/api/viewsets/catalogus.py
@@ -5,6 +5,7 @@ from rest_framework import mixins, viewsets
 from vng_api_common.caching import conditional_retrieve
 from vng_api_common.viewsets import CheckQueryParamsMixin
 
+from openzaak.utils.mixins import CacheQuerysetMixin
 from openzaak.utils.pagination import OptimizedPagination
 from openzaak.utils.permissions import AuthRequired
 
@@ -29,7 +30,10 @@ from ..serializers import CatalogusSerializer
 )
 @conditional_retrieve()
 class CatalogusViewSet(
-    CheckQueryParamsMixin, mixins.CreateModelMixin, viewsets.ReadOnlyModelViewSet
+    CacheQuerysetMixin,  # should be applied before other mixins
+    CheckQueryParamsMixin,
+    mixins.CreateModelMixin,
+    viewsets.ReadOnlyModelViewSet,
 ):
     """
     Opvragen en bewerken van CATALOGUSsen.

--- a/src/openzaak/components/catalogi/api/viewsets/eigenschap.py
+++ b/src/openzaak/components/catalogi/api/viewsets/eigenschap.py
@@ -6,6 +6,7 @@ from vng_api_common.caching import conditional_retrieve
 from vng_api_common.viewsets import CheckQueryParamsMixin
 
 from openzaak.components.catalogi.models import Eigenschap
+from openzaak.utils.mixins import CacheQuerysetMixin
 from openzaak.utils.pagination import OptimizedPagination
 from openzaak.utils.permissions import AuthRequired
 
@@ -60,7 +61,10 @@ from .mixins import ZaakTypeConceptMixin
 )
 @conditional_retrieve()
 class EigenschapViewSet(
-    CheckQueryParamsMixin, ZaakTypeConceptMixin, viewsets.ModelViewSet
+    CacheQuerysetMixin,  # should be applied before other mixins
+    CheckQueryParamsMixin,
+    ZaakTypeConceptMixin,
+    viewsets.ModelViewSet,
 ):
     """
     Opvragen en bewerken van EIGENSCHAPpen van een ZAAKTYPE.

--- a/src/openzaak/components/catalogi/api/viewsets/informatieobjecttype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/informatieobjecttype.py
@@ -14,6 +14,7 @@ from vng_api_common.utils import get_help_text
 from vng_api_common.viewsets import CheckQueryParamsMixin
 
 from openzaak.utils.help_text import mark_experimental
+from openzaak.utils.mixins import CacheQuerysetMixin
 from openzaak.utils.pagination import OptimizedPagination
 from openzaak.utils.permissions import AuthRequired
 from openzaak.utils.schema import COMMON_ERROR_RESPONSES, VALIDATION_ERROR_RESPONSES
@@ -82,6 +83,7 @@ from .mixins import ConceptMixin, M2MConceptDestroyMixin
 )
 @conditional_retrieve()
 class InformatieObjectTypeViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     CheckQueryParamsMixin,
     ConceptMixin,
     M2MConceptDestroyMixin,

--- a/src/openzaak/components/catalogi/api/viewsets/relatieklassen.py
+++ b/src/openzaak/components/catalogi/api/viewsets/relatieklassen.py
@@ -9,6 +9,7 @@ from rest_framework.exceptions import ValidationError
 from vng_api_common.caching import conditional_retrieve
 from vng_api_common.viewsets import CheckQueryParamsMixin
 
+from openzaak.utils.mixins import CacheQuerysetMixin
 from openzaak.utils.pagination import OptimizedPagination
 from openzaak.utils.permissions import AuthRequired
 
@@ -76,6 +77,7 @@ from .mixins import ConceptDestroyMixin, ConceptFilterMixin
 )
 @conditional_retrieve()
 class ZaakTypeInformatieObjectTypeViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     CheckQueryParamsMixin,
     ConceptFilterMixin,
     ConceptDestroyMixin,

--- a/src/openzaak/components/catalogi/api/viewsets/resultaattype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/resultaattype.py
@@ -5,6 +5,7 @@ from rest_framework import viewsets
 from vng_api_common.caching import conditional_retrieve
 from vng_api_common.viewsets import CheckQueryParamsMixin
 
+from openzaak.utils.mixins import CacheQuerysetMixin
 from openzaak.utils.pagination import OptimizedPagination
 from openzaak.utils.permissions import AuthRequired
 
@@ -60,7 +61,10 @@ from .mixins import ZaakTypeConceptMixin
 )
 @conditional_retrieve()
 class ResultaatTypeViewSet(
-    CheckQueryParamsMixin, ZaakTypeConceptMixin, viewsets.ModelViewSet
+    CacheQuerysetMixin,  # should be applied before other mixins
+    CheckQueryParamsMixin,
+    ZaakTypeConceptMixin,
+    viewsets.ModelViewSet,
 ):
     """
     Opvragen en bewerken van RESULTAATTYPEn van een ZAAKTYPE.

--- a/src/openzaak/components/catalogi/api/viewsets/roltype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/roltype.py
@@ -5,6 +5,7 @@ from rest_framework import viewsets
 from vng_api_common.caching import conditional_retrieve
 from vng_api_common.viewsets import CheckQueryParamsMixin
 
+from openzaak.utils.mixins import CacheQuerysetMixin
 from openzaak.utils.pagination import OptimizedPagination
 from openzaak.utils.permissions import AuthRequired
 
@@ -60,7 +61,10 @@ from .mixins import ZaakTypeConceptMixin
 )
 @conditional_retrieve()
 class RolTypeViewSet(
-    CheckQueryParamsMixin, ZaakTypeConceptMixin, viewsets.ModelViewSet
+    CacheQuerysetMixin,  # should be applied before other mixins
+    CheckQueryParamsMixin,
+    ZaakTypeConceptMixin,
+    viewsets.ModelViewSet,
 ):
     """
     Opvragen en bewerken van ROLTYPEn van een ZAAKTYPE.

--- a/src/openzaak/components/catalogi/api/viewsets/statustype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/statustype.py
@@ -5,6 +5,7 @@ from rest_framework import viewsets
 from vng_api_common.caching import conditional_retrieve
 from vng_api_common.viewsets import CheckQueryParamsMixin
 
+from openzaak.utils.mixins import CacheQuerysetMixin
 from openzaak.utils.pagination import OptimizedPagination
 from openzaak.utils.permissions import AuthRequired
 
@@ -60,7 +61,10 @@ from .mixins import ZaakTypeConceptMixin
 )
 @conditional_retrieve()
 class StatusTypeViewSet(
-    CheckQueryParamsMixin, ZaakTypeConceptMixin, viewsets.ModelViewSet
+    CacheQuerysetMixin,  # should be applied before other mixins
+    CheckQueryParamsMixin,
+    ZaakTypeConceptMixin,
+    viewsets.ModelViewSet,
 ):
     """
     Opvragen en bewerken van STATUSTYPEn van een ZAAKTYPE.

--- a/src/openzaak/components/catalogi/api/viewsets/zaakobjecttype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/zaakobjecttype.py
@@ -5,6 +5,7 @@ from rest_framework import viewsets
 from vng_api_common.caching import conditional_retrieve
 from vng_api_common.viewsets import CheckQueryParamsMixin
 
+from openzaak.utils.mixins import CacheQuerysetMixin
 from openzaak.utils.pagination import OptimizedPagination
 from openzaak.utils.permissions import AuthRequired
 
@@ -48,7 +49,10 @@ from .mixins import ZaakTypeConceptMixin
 )
 @conditional_retrieve()
 class ZaakObjectTypeViewSet(
-    CheckQueryParamsMixin, ZaakTypeConceptMixin, viewsets.ModelViewSet
+    CacheQuerysetMixin,  # should be applied before other mixins
+    CheckQueryParamsMixin,
+    ZaakTypeConceptMixin,
+    viewsets.ModelViewSet,
 ):
     """
     Opvragen en bewerken van ZAAKOBJECTTYPEn.

--- a/src/openzaak/components/catalogi/api/viewsets/zaaktype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/zaaktype.py
@@ -8,6 +8,7 @@ from rest_framework.decorators import action
 from vng_api_common.caching import conditional_retrieve
 from vng_api_common.viewsets import CheckQueryParamsMixin
 
+from openzaak.utils.mixins import CacheQuerysetMixin
 from openzaak.utils.pagination import OptimizedPagination
 from openzaak.utils.permissions import AuthRequired
 from openzaak.utils.schema import COMMON_ERROR_RESPONSES, VALIDATION_ERROR_RESPONSES
@@ -78,6 +79,7 @@ from .mixins import (
 )
 @conditional_retrieve()
 class ZaakTypeViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     CheckQueryParamsMixin,
     ConceptPublishMixin,
     ConceptDestroyMixin,

--- a/src/openzaak/components/documenten/api/viewsets.py
+++ b/src/openzaak/components/documenten/api/viewsets.py
@@ -43,6 +43,7 @@ from openzaak.utils.data_filtering import ListFilterByAuthorizationsMixin
 from openzaak.utils.exceptions import CMISNotSupportedException
 from openzaak.utils.help_text import mark_experimental
 from openzaak.utils.mixins import (
+    CacheQuerysetMixin,
     CMISConnectionPoolMixin,
     ConvertCMISAdapterExceptions,
     ExpandMixin,
@@ -209,6 +210,7 @@ REGISTRATIE_QUERY_PARAM = OpenApiParameter(
 )
 @cmis_conditional_retrieve()
 class EnkelvoudigInformatieObjectViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     CMISConnectionPoolMixin,
     ConvertCMISAdapterExceptions,
     CheckQueryParamsMixin,
@@ -666,6 +668,7 @@ class EnkelvoudigInformatieObjectImportDestroyView(ImportDestroyView):
 )
 @cmis_conditional_retrieve()
 class GebruiksrechtenViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     CMISConnectionPoolMixin,
     ConvertCMISAdapterExceptions,
     CheckQueryParamsMixin,
@@ -779,6 +782,7 @@ class EnkelvoudigInformatieObjectAuditTrailViewSet(
 )
 @cmis_conditional_retrieve()
 class ObjectInformatieObjectViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     CMISConnectionPoolMixin,
     ConvertCMISAdapterExceptions,
     CheckQueryParamsMixin,
@@ -911,6 +915,7 @@ class BestandsDeelViewSet(UpdateWithoutPartialMixin, viewsets.GenericViewSet):
 )
 @cmis_conditional_retrieve()
 class VerzendingViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     CheckQueryParamsMixin,
     ExpandMixin,
     NotificationViewSetMixin,

--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -46,7 +46,7 @@ from openzaak.utils.api import (
 )
 from openzaak.utils.data_filtering import ListFilterByAuthorizationsMixin
 from openzaak.utils.help_text import mark_experimental
-from openzaak.utils.mixins import ExpandMixin
+from openzaak.utils.mixins import CacheQuerysetMixin, ExpandMixin
 from openzaak.utils.pagination import OptimizedPagination
 from openzaak.utils.permissions import AuthRequired
 from openzaak.utils.schema import (
@@ -230,6 +230,7 @@ ZAAK_UUID_PARAMETER = OpenApiParameter(
 )
 @conditional_retrieve(extra_depends_on={"status"})
 class ZaakViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     ExpandMixin,
     NotificationViewSetMixin,
     AuditTrailViewsetMixin,
@@ -475,6 +476,7 @@ class ZaakViewSet(
 )
 @conditional_retrieve()
 class StatusViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     NotificationCreateMixin,
     AuditTrailCreateMixin,
     CheckQueryParamsMixin,
@@ -600,6 +602,7 @@ class StatusViewSet(
     ),
 )
 class ZaakObjectViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     CheckQueryParamsMixin,
     NotificationViewSetMixin,
     ListFilterByAuthorizationsMixin,
@@ -698,6 +701,7 @@ class ZaakObjectViewSet(
 )
 @conditional_retrieve()
 class ZaakInformatieObjectViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     NotificationCreateMixin,
     AuditTrailViewsetMixin,
     CheckQueryParamsMixin,
@@ -815,6 +819,7 @@ class ZaakInformatieObjectViewSet(
 )
 @conditional_retrieve()
 class ZaakEigenschapViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     NotificationViewSetMixin,
     AuditTrailCreateMixin,
     NestedViewSetMixin,
@@ -953,6 +958,7 @@ class KlantContactViewSet(
 )
 @conditional_retrieve()
 class RolViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     NotificationViewSetMixin,
     AuditTrailViewsetMixin,
     CheckQueryParamsMixin,
@@ -1037,6 +1043,7 @@ class RolViewSet(
 )
 @conditional_retrieve()
 class ResultaatViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     NotificationViewSetMixin,
     AuditTrailViewsetMixin,
     CheckQueryParamsMixin,
@@ -1123,6 +1130,7 @@ class ZaakAuditTrailViewSet(AuditTrailViewSet):
     ),
 )
 class ZaakBesluitViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     NotificationCreateMixin,
     AuditTrailCreateMixin,
     AuditTrailDestroyMixin,
@@ -1266,6 +1274,7 @@ class ZaakBesluitViewSet(
     ),
 )
 class ZaakContactMomentViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     NotificationCreateMixin,
     AuditTrailCreateMixin,
     AuditTrailDestroyMixin,
@@ -1345,6 +1354,7 @@ class ZaakContactMomentViewSet(
     ),
 )
 class ZaakVerzoekViewSet(
+    CacheQuerysetMixin,  # should be applied before other mixins
     NotificationCreateMixin,
     AuditTrailCreateMixin,
     AuditTrailDestroyMixin,

--- a/src/openzaak/utils/mixins.py
+++ b/src/openzaak/utils/mixins.py
@@ -115,3 +115,29 @@ class ExpandMixin:
             raise CMISNotSupportedException()
 
         return super().retrieve(request, *args, **kwargs)
+
+
+class CacheQuerysetMixin:
+    """
+    Mixin for ViewSets to avoid doing redundant calls to `ViewSet.get_queryset()`
+
+    NOTE: make sure that this mixin is applied before any other mixins that override
+    `get_queryset`
+
+    `get_queryset` is actually an additional time when pagination is applied to
+    an endpoint, similarly it is called an additional time when query parameters are used
+    to filter the queryset. To avoid constructing the exact same queryset twice, we cache
+    the result on the ViewSet instance which is a different instance for every request,
+    so this caching will only be applied for the same request
+    """
+
+    _cached_queryset = None
+
+    def get_queryset(self):
+        # `get_queryset` is actually executed twice when pagination is applied to
+        # an endpoint, to avoid constructing the exact same queryset twice, we cache
+        # the result on the ViewSet instance which is a different instance for every request,
+        # so this caching will only be applied for the same request
+        if self._cached_queryset is None:
+            self._cached_queryset = super().get_queryset()
+        return self._cached_queryset


### PR DESCRIPTION
Both pagination and filtering cause `get_queryset` to be called additional times, while the result of this method does not change for the same request. By caching the result of get_queryset on the ViewSet instance we avoid constructing the same queryset multiple times and doing multiple extra database queries

This boosts performance for non-superusers especially, reduces median response time by about 10% in CI

Baseline on main: https://github.com/open-zaak/open-zaak/actions/runs/14312657378/job/40111275657#step:4:760
After changes: https://github.com/open-zaak/open-zaak/actions/runs/14327974895/job/40157184391?pr=1977#step:4:760

Closes #1976

**Changes**

* Cache the result of get_queryset per request

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
