### PR TITLE
Feature/1930 kenmerken filter

### DIFF
--- a/docs/api/experimental.rst
+++ b/docs/api/experimental.rst
@@ -73,6 +73,8 @@ Query parameters
     * ``rol__betrokkeneIdentificatie__vestiging__kvkNummer`` **(scheduled for deprecation in Open Zaak version 3.0)**
     * ``rol__machtiging``
     * ``rol__machtiging__loa``
+    * ``kenmerk__bron``
+    * ``kenmerk``
 
 
 Documenten API

--- a/docs/api/experimental.rst
+++ b/docs/api/experimental.rst
@@ -74,7 +74,7 @@ Query parameters
     * ``rol__machtiging``
     * ``rol__machtiging__loa``
     * ``kenmerk__bron``
-    * ``kenmerk``
+    * ``kenmerk`` A bron-kenmerk combination of a zaak. (format: ``<bron>:<kenmerk>``)
 
 
 Documenten API

--- a/src/openzaak/components/zaken/api/filters.py
+++ b/src/openzaak/components/zaken/api/filters.py
@@ -269,7 +269,7 @@ class ZaakFilter(FilterSetWithGroups):
         key_field_name="zaakkenmerk__bron",
         value_field_name="zaakkenmerk__kenmerk",
         help_text=mark_experimental(
-            "Een bron-kenmerk combinatie van de zaak. format: [<bron>:<kenmerk>]"
+            "Een bron-kenmerk combinatie van de zaak. format: <bron>:<kenmerk>"
         ),
     )
 

--- a/src/openzaak/components/zaken/api/filters.py
+++ b/src/openzaak/components/zaken/api/filters.py
@@ -15,6 +15,7 @@ from vng_api_common.utils import get_field_attribute, get_help_text
 from openzaak.components.zaken.api.serializers.zaken import ZaakSerializer
 from openzaak.utils.filters import (
     ExpandFilter,
+    KeyValueFilter,
     MaximaleVertrouwelijkheidaanduidingFilter,
 )
 from openzaak.utils.filterset import FilterGroup, FilterSet, FilterSetWithGroups
@@ -258,6 +259,20 @@ class ZaakFilter(FilterSetWithGroups):
             "gelijk is aan de aangegeven aanduiding worden teruggeven als resultaten."
         ),
     )
+
+    kenmerk__bron = filters.CharFilter(
+        field_name="zaakkenmerk__bron",
+        help_text=mark_experimental(get_help_text("zaken.ZaakKenmerk", "bron")),
+    )
+
+    kenmerk = KeyValueFilter(
+        key_field_name="zaakkenmerk__bron",
+        value_field_name="zaakkenmerk__kenmerk",
+        help_text=mark_experimental(
+            "Een bron-kenmerk combinatie van de zaak. format: [<bron>:<kenmerk>]"
+        ),
+    )
+
     ordering = filters.OrderingFilter(
         fields=(
             "startdatum",

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -6663,6 +6663,18 @@ paths:
         description: '**EXPERIMENTEEL** De unieke identificatie van de ZAAK (bevat
           de identificatie de gegeven waarden (hoofdletterongevoelig))'
       - in: query
+        name: kenmerk
+        schema:
+          type: string
+        description: '**EXPERIMENTEEL** Een bron-kenmerk combinatie van de zaak. format:
+          [<bron>:<kenmerk>]'
+      - in: query
+        name: kenmerk__bron
+        schema:
+          type: string
+        description: '**EXPERIMENTEEL** De aanduiding van de administratie waar het
+          kenmerk op slaat.'
+      - in: query
         name: maximaleVertrouwelijkheidaanduiding
         schema:
           type: string
@@ -10365,6 +10377,18 @@ paths:
         description: '**EXPERIMENTEEL** De unieke identificatie van de ZAAK (bevat
           de identificatie de gegeven waarden (hoofdletterongevoelig))'
       - in: query
+        name: kenmerk
+        schema:
+          type: string
+        description: '**EXPERIMENTEEL** Een bron-kenmerk combinatie van de zaak. format:
+          [<bron>:<kenmerk>]'
+      - in: query
+        name: kenmerk__bron
+        schema:
+          type: string
+        description: '**EXPERIMENTEEL** De aanduiding van de administratie waar het
+          kenmerk op slaat.'
+      - in: query
         name: maximaleVertrouwelijkheidaanduiding
         schema:
           type: string
@@ -10969,6 +10993,14 @@ paths:
                     \ Laag (2+)\n* `urn:etoegang:core:assurance-class:loa3` - Substantieel\
                     \ (3)\n* `urn:etoegang:core:assurance-class:loa4` - Hoog (4)\n\
                     \n"
+                kenmerk__bron:
+                  type: string
+                  description: '**EXPERIMENTEEL** De aanduiding van de administratie
+                    waar het kenmerk op slaat.'
+                kenmerk:
+                  type: string
+                  description: '**EXPERIMENTEEL** Een bron-kenmerk combinatie van
+                    de zaak. format: [<bron>:<kenmerk>]'
                 ordering:
                   type: array
                   items:

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -6667,7 +6667,7 @@ paths:
         schema:
           type: string
         description: '**EXPERIMENTEEL** Een bron-kenmerk combinatie van de zaak. format:
-          [<bron>:<kenmerk>]'
+          <bron>:<kenmerk>'
       - in: query
         name: kenmerk__bron
         schema:
@@ -10381,7 +10381,7 @@ paths:
         schema:
           type: string
         description: '**EXPERIMENTEEL** Een bron-kenmerk combinatie van de zaak. format:
-          [<bron>:<kenmerk>]'
+          <bron>:<kenmerk>'
       - in: query
         name: kenmerk__bron
         schema:
@@ -11000,7 +11000,7 @@ paths:
                 kenmerk:
                   type: string
                   description: '**EXPERIMENTEEL** Een bron-kenmerk combinatie van
-                    de zaak. format: [<bron>:<kenmerk>]'
+                    de zaak. format: <bron>:<kenmerk>'
                 ordering:
                   type: array
                   items:

--- a/src/openzaak/components/zaken/tests/factories.py
+++ b/src/openzaak/components/zaken/tests/factories.py
@@ -185,3 +185,12 @@ class ZaakVerzoekFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = "zaken.ZaakVerzoek"
+
+
+class ZaakKenmerkFactory(factory.django.DjangoModelFactory):
+    zaak = factory.SubFactory(ZaakFactory)
+    kenmerk = factory.Faker("word")
+    bron = factory.Faker("word")
+
+    class Meta:
+        model = "zaken.ZaakKenmerk"

--- a/src/openzaak/components/zaken/tests/test_zaak_filter.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_filter.py
@@ -353,7 +353,7 @@ class ZaakFilterTests(JWTAuthMixin, APITestCase):
         with self.subTest("existing combination"):
             response = self.client.get(
                 self.url,
-                {"kenmerk": "[BAG-id:123]"},
+                {"kenmerk": "BAG-id:123"},
                 **ZAAK_WRITE_KWARGS,
             )
 
@@ -363,9 +363,18 @@ class ZaakFilterTests(JWTAuthMixin, APITestCase):
         with self.subTest("non existing combination"):
             response = self.client.get(
                 self.url,
-                {"kenmerk": "[BAG-id:456]"},
+                {"kenmerk": "BAG-id:456"},
                 **ZAAK_WRITE_KWARGS,
             )
 
             self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
             self.assertEqual(response.json()["count"], 0)
+
+        with self.subTest("only one `:`"):
+            response = self.client.get(
+                self.url,
+                {"kenmerk": "b:aa:cc"},
+                **ZAAK_WRITE_KWARGS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/src/openzaak/components/zaken/tests/test_zaak_filter.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_filter.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2023 Dimpact
 from datetime import date
+from urllib.parse import urlencode
 
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -378,3 +379,12 @@ class ZaakFilterTests(JWTAuthMixin, APITestCase):
             )
 
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        with self.subTest("urlencode"):
+            response = self.client.get(
+                f"{self.url}?{urlencode({'kenmerk': 'BAG-id:123'})}",
+                **ZAAK_WRITE_KWARGS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+            self.assertEqual(response.json()["count"], 1)

--- a/src/openzaak/utils/filters.py
+++ b/src/openzaak/utils/filters.py
@@ -70,8 +70,11 @@ class KeyValueFilter(filters.CharFilter):
 
         value_list = value.strip("[]").split(":")
 
-        if len(value_list) != 2:
-            raise ParseError(_("Ongeldig format voor key-value filter."))
+        # This should not be possible because of the regex validator but to be sure:
+        if len(value_list) != 2:  # pragma: nocover
+            raise ParseError(
+                _("Ongeldig format voor key-value filter.")
+            )  # pragma: nocover
 
         key_field_value, value_field_value = value_list
 

--- a/src/openzaak/utils/filters.py
+++ b/src/openzaak/utils/filters.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
+from django.core.validators import RegexValidator
 from django.utils.translation import gettext_lazy as _
 
 from django_filters import filters
+from rest_framework.exceptions import ParseError
 from vng_api_common.constants import VertrouwelijkheidsAanduiding
 
 from .expansion import get_expand_options_for_serializer
@@ -49,3 +51,33 @@ class ExpandFilter(filters.BaseInFilter, filters.ChoiceFilter):
 
     def filter(self, qs, value):
         return qs
+
+
+class KeyValueFilter(filters.CharFilter):
+
+    def __init__(self, key_field_name, value_field_name, *args, **kwargs):
+        self.key_field_name = key_field_name
+        self.value_field_name = value_field_name
+        self.validators = RegexValidator(
+            r"^\[([^:\[\]]+):([^:\[\]]+)\]$"
+        )  # [key:value] where the key and value cannot contain `[`, `]` or `:`
+
+        super().__init__(*args, **kwargs)
+
+    def filter(self, qs, value):
+        if value in filters.EMPTY_VALUES:
+            return qs
+
+        value_list = value.strip("[]").split(":")
+
+        if len(value_list) != 2:
+            raise ParseError(_("Ongeldig format voor key-value filter."))
+
+        key_field_value, value_field_value = value_list
+
+        key_lookup = "%s__%s" % (self.key_field_name, self.lookup_expr)
+        value_lookup = "%s__%s" % (self.value_field_name, self.lookup_expr)
+
+        return self.get_method(qs)(
+            **{key_lookup: key_field_value, value_lookup: value_field_value}
+        )

--- a/src/openzaak/utils/filters.py
+++ b/src/openzaak/utils/filters.py
@@ -56,11 +56,11 @@ class ExpandFilter(filters.BaseInFilter, filters.ChoiceFilter):
 class KeyValueFilter(filters.CharFilter):
 
     def __init__(self, key_field_name, value_field_name, *args, **kwargs):
+        kwargs.setdefault(
+            "validators", [RegexValidator(r"^([^:\[\]]+):([^:\[\]]+)$")]
+        )  # key:value where the key and value cannot contain `[`, `]` or `:`
         self.key_field_name = key_field_name
         self.value_field_name = value_field_name
-        self.validators = RegexValidator(
-            r"^\[([^:\[\]]+):([^:\[\]]+)\]$"
-        )  # [key:value] where the key and value cannot contain `[`, `]` or `:`
 
         super().__init__(*args, **kwargs)
 
@@ -68,7 +68,7 @@ class KeyValueFilter(filters.CharFilter):
         if value in filters.EMPTY_VALUES:
             return qs
 
-        value_list = value.strip("[]").split(":")
+        value_list = value.split(":")
 
         # This should not be possible because of the regex validator but to be sure:
         if len(value_list) != 2:  # pragma: nocover

--- a/src/openzaak/utils/filters.py
+++ b/src/openzaak/utils/filters.py
@@ -61,7 +61,7 @@ class KeyValueFilter(filters.CharFilter):
         assert isinstance(validators, list), "'validators' must be of type list."
 
         # key:value where the key and value cannot contain `[`, `]` or `:`
-        validators.append(RegexValidator(r"^([^:\[\]]+):([^:\[\]]+)$"))
+        validators.append(RegexValidator(r"^([^:]+):([^:]+)$"))
 
         kwargs["validators"] = validators
 

--- a/src/openzaak/utils/filters.py
+++ b/src/openzaak/utils/filters.py
@@ -56,13 +56,18 @@ class ExpandFilter(filters.BaseInFilter, filters.ChoiceFilter):
 class KeyValueFilter(filters.CharFilter):
 
     def __init__(self, key_field_name, value_field_name, *args, **kwargs):
-        kwargs.setdefault(
-            "validators", [RegexValidator(r"^([^:\[\]]+):([^:\[\]]+)$")]
-        )  # key:value where the key and value cannot contain `[`, `]` or `:`
-        self.key_field_name = key_field_name
-        self.value_field_name = value_field_name
+        validators = kwargs.get("validators", [])
+
+        assert isinstance(validators, list), "'validators' must be of type list."
+
+        # key:value where the key and value cannot contain `[`, `]` or `:`
+        validators.append(RegexValidator(r"^([^:\[\]]+):([^:\[\]]+)$"))
+
+        kwargs["validators"] = validators
 
         super().__init__(*args, **kwargs)
+        self.key_field_name = key_field_name
+        self.value_field_name = value_field_name
 
     def filter(self, qs, value):
         if value in filters.EMPTY_VALUES:


### PR DESCRIPTION
Closes #1930 

**Changes**
- Adds `kenmerk__bron` filter
- Adds `kenmerk` filter that can filter on a bron-kenmerk combination. format `[<bron>:<kenmerk>]`

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
