### PR TITLE
Feature/django cachalot

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -10,6 +10,7 @@ requests-cache
 self-certifi
 
 # Framework libraries
+django-cachalot
 django-db-logger
 django-extra-views
 django-loose-fk

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -96,6 +96,7 @@ django==5.1.7
     #   django-admin-index
     #   django-appconf
     #   django-axes
+    #   django-cachalot
     #   django-celery-beat
     #   django-cors-headers
     #   django-csp
@@ -142,6 +143,8 @@ django-appconf==1.0.6
 django-axes==6.5.1
     # via open-api-framework
 django-better-admin-arrayfield==1.4.2
+    # via -r requirements/base.in
+django-cachalot==2.7.0
     # via -r requirements/base.in
 django-celery-beat==2.7.0
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -190,6 +190,7 @@ django==5.1.7
     #   django-admin-index
     #   django-appconf
     #   django-axes
+    #   django-cachalot
     #   django-celery-beat
     #   django-cors-headers
     #   django-csp
@@ -245,6 +246,10 @@ django-axes==6.5.1
     #   -r requirements/base.txt
     #   open-api-framework
 django-better-admin-arrayfield==1.4.2
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+django-cachalot==2.7.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -224,6 +224,7 @@ django==5.1.7
     #   django-admin-index
     #   django-appconf
     #   django-axes
+    #   django-cachalot
     #   django-celery-beat
     #   django-cors-headers
     #   django-csp
@@ -282,6 +283,10 @@ django-axes==6.5.1
     #   -r requirements/ci.txt
     #   open-api-framework
 django-better-admin-arrayfield==1.4.2
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+django-cachalot==2.7.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/openzaak/components/autorisaties/tests/admin/test_autorisaties_admin.py
+++ b/src/openzaak/components/autorisaties/tests/admin/test_autorisaties_admin.py
@@ -1266,6 +1266,8 @@ class ManageAutorisatiesAdmin(NotificationsConfigMixin, TestCase):
         )
 
         # Load the page again to check if the initial data is as expected
+        import pdb; pdb.set_trace()
+
         response = self.client.get(self.url)
 
         expected_initial = [

--- a/src/openzaak/components/autorisaties/tests/admin/test_autorisaties_admin.py
+++ b/src/openzaak/components/autorisaties/tests/admin/test_autorisaties_admin.py
@@ -12,6 +12,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 import requests_mock
+from cachalot.api import cachalot_disabled
 from django_webtest import WebTest
 from freezegun import freeze_time
 from maykin_2fa.test import disable_admin_mfa

--- a/src/openzaak/components/besluiten/tests/test_caching.py
+++ b/src/openzaak/components/besluiten/tests/test_caching.py
@@ -4,12 +4,17 @@
 Test that the caching mechanisms are in place.
 """
 
+from django.test import override_settings
+
 from rest_framework import status
 from rest_framework.test import APITestCase
 from vng_api_common.tests import CacheMixin, JWTAuthMixin, reverse
 
-from openzaak.tests.utils import get_spec
+from openzaak.components.catalogi.tests.factories import BesluitTypeFactory
+from openzaak.tests.utils import JWTAuthMixin, get_spec
 
+from ..constants import VervalRedenen
+from ..models import Besluit
 from .factories import BesluitFactory, BesluitInformatieObjectFactory
 
 
@@ -91,3 +96,45 @@ class BesluitInformatieObjectCacheTests(CacheMixin, JWTAuthMixin, APITestCase):
         response = self.client.get(reverse(bio), headers={"if-none-match": '"old"'})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+@override_settings(ALLOWED_HOSTS=["testserver", "openzaak.nl"])
+class BesluitCreateTests(JWTAuthMixin, APITestCase):
+
+    heeft_alle_autorisaties = True
+
+    def test_besluit_cachalot(self):
+        """
+        Assert that the zaak list cache is invalidated when a new Zaak is created
+        """
+        url = reverse(Besluit)
+        besluittype = BesluitTypeFactory.create(concept=False)
+        besluittype_url = reverse(besluittype)
+        BesluitFactory.create()
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+        response = self.client.post(
+            url,
+            {
+                "verantwoordelijke_organisatie": "517439943",  # RSIN
+                "identificatie": "123123",
+                "besluittype": f"http://testserver{besluittype_url}",
+                "datum": "2018-09-06",
+                "toelichting": "Vergunning verleend.",
+                "ingangsdatum": "2018-10-01",
+                "vervaldatum": "2018-11-01",
+                "vervalreden": VervalRedenen.tijdelijk,
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # re-request list
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)

--- a/src/openzaak/components/catalogi/tests/admin/test_admin_publish.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_admin_publish.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from django.utils.translation import gettext as _, ngettext_lazy
 
 import requests_mock
+from cachalot.api import cachalot_disabled
 from django_webtest import WebTest
 from freezegun import freeze_time
 from maykin_2fa.test import disable_admin_mfa
@@ -60,6 +61,7 @@ class ZaaktypeAdminTests(
     @tag("notifications")
     @override_settings(NOTIFICATIONS_DISABLED=False)
     @freeze_time("2022-01-01")
+    @cachalot_disabled()
     @patch("notifications_api_common.viewsets.send_notification.delay")
     def test_publish_zaaktype(self, m, mock_notif):
         procestype_url = (

--- a/src/openzaak/components/catalogi/tests/admin/test_notifications.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_notifications.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from django.test import override_settings, tag
 from django.urls import reverse
 
+from cachalot.api import cachalot_disabled
 from django_webtest import WebTest
 from freezegun import freeze_time
 from maykin_2fa.test import disable_admin_mfa
@@ -186,6 +187,7 @@ class NotificationAdminTests(
             }
         )
 
+    @cachalot_disabled()
     def test_besluit_notify_on_change(self, mock_notif):
         besluittype = BesluitTypeFactory.create(
             concept=True, omschrijving="test", catalogus=self.catalogus

--- a/src/openzaak/components/catalogi/tests/admin/test_zaaktype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_zaaktype_admin.py
@@ -8,6 +8,7 @@ from django.urls import reverse, reverse_lazy
 from django.utils.translation import gettext, gettext_lazy as _, ngettext_lazy
 
 import requests_mock
+from cachalot.api import cachalot_disabled
 from dateutil.relativedelta import relativedelta
 from django_webtest import WebTest
 from freezegun import freeze_time
@@ -205,6 +206,7 @@ class ZaaktypeAdminTests(
     @tag("notifications")
     @override_settings(NOTIFICATIONS_DISABLED=False)
     @freeze_time("2019-11-01")
+    @cachalot_disabled()
     @patch("notifications_api_common.viewsets.send_notification.delay")
     def test_create_new_version(self, m, mock_notif):
         mock_selectielijst_oas_get(m)

--- a/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject.py
+++ b/src/openzaak/components/documenten/tests/test_enkelvoudiginformatieobject.py
@@ -29,7 +29,6 @@ from .utils import (
 )
 
 
-@freeze_time("2018-06-27 12:12:12")
 @temp_private_root()
 class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APITestCase):
 
@@ -43,6 +42,7 @@ class EnkelvoudigInformatieObjectAPITests(JWTAuthMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.assertEqual(len(response.data["results"]), 4)
 
+    @freeze_time("2018-06-27 12:12:12")
     def test_create(self):
         informatieobjecttype = InformatieObjectTypeFactory.create(concept=False)
         informatieobjecttype_url = reverse(informatieobjecttype)

--- a/src/openzaak/components/zaken/models/identification.py
+++ b/src/openzaak/components/zaken/models/identification.py
@@ -5,6 +5,7 @@ from datetime import date
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
+from cachalot.api import cachalot_disabled
 from vng_api_common.fields import RSINField
 from vng_api_common.utils import generate_unique_identification
 
@@ -35,7 +36,8 @@ class ZaakIdentificatieManager(models.Manager):
         with pg_advisory_lock(LOCK_ID_IDENTIFICATION_GENERATION):
             instance = self.model()
             instance.dummy_date = date
-            identification = generate_unique_identification(instance, "dummy_date")
+            with cachalot_disabled():
+                identification = generate_unique_identification(instance, "dummy_date")
             return self.create(
                 identificatie=identification, bronorganisatie=organisation
             )

--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -83,6 +83,7 @@ INSTALLED_APPS = (
         "sniplates",  # TODO can this be removed?
         "django_better_admin_arrayfield",  # TODO can this be removed?
         "django_loose_fk",
+        "cachalot",
         "drc_cmis",
         "django_celery_beat",
         # Project applications.
@@ -365,6 +366,23 @@ CSP_STYLE_SRC = CSP_STYLE_SRC + ["cdnjs.cloudflare.com", "cdn.jsdelivr.net"]
 # TODO is there a better way to fix this?
 CSP_INCLUDE_NONCE_IN.remove("script-src")  # error with GISModelAdmin.
 CSP_INCLUDE_NONCE_IN.remove("style-src")  # error with redoc.
+
+#
+# Cachalot
+#
+CACHALOT_ENABLED = True
+CACHALOT_CACHE = "default"
+CACHALOT_DATABASES = "supported_only"
+# Caching this table seems to cause unexpected behaviour, such as repeated identifications
+CACHALOT_UNCACHABLE_TABLES = ["zaken_zaakidentificatie"]
+CACHALOT_ONLY_CACHABLE_APPS = [
+    "zaken",
+    "documenten",
+    "autorisaties",
+    "besluiten",
+    "catalogi",
+]
+
 #
 # OpenZaak configuration
 #

--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -371,16 +371,17 @@ CSP_INCLUDE_NONCE_IN.remove("style-src")  # error with redoc.
 # Cachalot
 #
 CACHALOT_ENABLED = True
+CACHALOT_TIMEOUT = 60 * 30  # persist cache keys for half an hour
 CACHALOT_CACHE = "default"
 CACHALOT_DATABASES = "supported_only"
-# Caching this table seems to cause unexpected behaviour, such as repeated identifications
-CACHALOT_UNCACHABLE_TABLES = ["zaken_zaakidentificatie"]
 CACHALOT_ONLY_CACHABLE_APPS = [
     "zaken",
-    "documenten",
+    # "documenten",
     "autorisaties",
-    "besluiten",
+    # "besluiten",
     "catalogi",
+    "vng_api_common",
+    "authorizations",
 ]
 
 #


### PR DESCRIPTION
Closes #1986

TODO:
- [ ] check if generate_identificatie works for other resources
- [ ] apply more sparingly? on specific viewsets, etc
- [ ] cache specific queries with cacheops of which the result wont change often (authorization/catalogi related stuff)

issues:
- applying it globally seems to cause issues (cache not being invalidated?)
- redis issues because keys arent removed? https://django-cachalot.readthedocs.io/en/latest/limits.html#redis

**Changes**

[Describe the changes here]

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [ ] Any experimental features added in this PR are backwards compatible
  - [ ] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how
