### PR TITLE
:zap: Add missing prefetch/select_related for several viewsets

### DIFF
--- a/src/openzaak/components/catalogi/api/viewsets/besluittype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/besluittype.py
@@ -81,7 +81,7 @@ class BesluitTypeViewSet(
     queryset = (
         BesluitType.objects.all()
         .select_related("catalogus")
-        .prefetch_related("informatieobjecttypen", "zaaktypen")
+        .prefetch_related("informatieobjecttypen", "zaaktypen", "resultaattype_set")
         .with_dates()
         .order_by("-pk")
     )

--- a/src/openzaak/components/catalogi/api/viewsets/informatieobjecttype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/informatieobjecttype.py
@@ -109,6 +109,7 @@ class InformatieObjectTypeViewSet(
     queryset = (
         InformatieObjectType.objects.all()
         .select_related("catalogus")
+        .prefetch_related("zaaktypen", "besluittypen")
         .with_dates()
         .order_by("-pk")
     )

--- a/src/openzaak/components/catalogi/api/viewsets/resultaattype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/resultaattype.py
@@ -76,6 +76,7 @@ class ResultaatTypeViewSet(
     queryset = (
         ResultaatType.objects.all()
         .select_related("zaaktype", "zaaktype__catalogus")
+        .prefetch_related("besluittypen", "informatieobjecttypen")
         .order_by("-pk")
     )
     serializer_class = ResultaatTypeSerializer

--- a/src/openzaak/components/catalogi/api/viewsets/statustype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/statustype.py
@@ -74,7 +74,12 @@ class StatusTypeViewSet(
 
     queryset = (
         StatusType.objects.select_related("zaaktype", "zaaktype__catalogus")
-        .prefetch_related("zaaktype__statustypen")
+        .prefetch_related(
+            "zaaktype__statustypen",
+            "eigenschappen",
+            "zaakobjecttypen",
+            "checklistitem_set",
+        )
         .order_by("-pk")
         .all()
     )

--- a/src/openzaak/components/catalogi/api/viewsets/zaaktype.py
+++ b/src/openzaak/components/catalogi/api/viewsets/zaaktype.py
@@ -107,6 +107,7 @@ class ZaakTypeViewSet(
             "roltype_set",
             "deelzaaktypen",
             "besluittypen",
+            "zaakobjecttype_set",
         )
         .with_dates("identificatie")
         .order_by("-pk")

--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -490,6 +490,7 @@ class StatusViewSet(
 
     queryset = (
         Status.objects.select_related("_statustype", "zaak", "gezetdoor")
+        .prefetch_related("zaakinformatieobjecten")
         .annotate_with_max_datum_status_gezet()
         .order_by("-datum_status_gezet", "-pk")
     )
@@ -615,7 +616,9 @@ class ZaakObjectViewSet(
     Opvragen en bewerken van ZAAKOBJECTen.
     """
 
-    queryset = ZaakObject.objects.select_related("zaak").order_by("-pk")
+    queryset = ZaakObject.objects.select_related("zaak", "_zaakobjecttype").order_by(
+        "-pk"
+    )
     serializer_class = ZaakObjectSerializer
     filterset_class = ZaakObjectFilter
     lookup_field = "uuid"


### PR DESCRIPTION
to speed up base performance of the following endpoints:

* /besluittypen
* /informatieobjecttypen
* /statustypen
* /resultaattypen
* /zaaktypen
* /statussen
* /zaakobjecten

**Changes**

* Add missing prefetch/select_related for several viewsets

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
