### PR TITLE
:bug: [#1940] Fix data migrations for large number of objects

### DIFF
--- a/src/openzaak/components/documenten/migrations/0009_auto_20220727_1517.py
+++ b/src/openzaak/components/documenten/migrations/0009_auto_20220727_1517.py
@@ -10,7 +10,7 @@ def rewrite_file_size(apps, schema_editor):
         "documenten.EnkelvoudigInformatieObject"
     )
 
-    docs = EnkelvoudigInformatieObject.objects.all()
+    docs = EnkelvoudigInformatieObject.objects.iterator()
     for doc in docs:
         # file gone - don't crash the migration
         if not doc.inhoud.storage.exists(doc.inhoud.name):

--- a/src/openzaak/components/documenten/migrations/0027_auto_20230417_1415.py
+++ b/src/openzaak/components/documenten/migrations/0027_auto_20230417_1415.py
@@ -8,7 +8,7 @@ from django.db import migrations
 def populate_private_voltooid_attribute(apps, schema_editor):
     BestandsDeel = apps.get_model("documenten", "BestandsDeel")
 
-    for bestandsdeel in BestandsDeel.objects.all():
+    for bestandsdeel in BestandsDeel.objects.iterator():
         bestandsdeel._voltooid = bestandsdeel.inhoud.size == bestandsdeel.omvang
         bestandsdeel.save()
 

--- a/src/openzaak/components/zaken/tests/test_migrations.py
+++ b/src/openzaak/components/zaken/tests/test_migrations.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
+from uuid import uuid4
+
 from django.utils import timezone
 
 from vng_api_common.constants import (
@@ -131,6 +133,20 @@ class MigrateCompositeUrlsForwardTest(TestMigrations):
             betrokkene="https//personen.nl/1",
             betrokkene_type=RolTypes.medewerker,
             roltoelichting="unknown rol",
+        )
+        # create extra Rollen to verify that migrating many objects works
+        Rol.objects.bulk_create(
+            [
+                Rol(
+                    zaak=self.zaak_unknown,
+                    uuid=uuid4(),
+                    _roltype_url="https://andere.catalogus.nl/api/v1/roltypen/7ebd86f8-ce22-4ecf-972b-b2ac20b219c0",
+                    betrokkene="https//personen.nl/1",
+                    betrokkene_type=RolTypes.medewerker,
+                    roltoelichting="unknown rol",
+                )
+                for i in range(4001)
+            ]
         )
         self.zaak_eigenschap_unknown = ZaakEigenschap.objects.create(
             zaak=self.zaak_unknown,

--- a/src/openzaak/utils/migrations.py
+++ b/src/openzaak/utils/migrations.py
@@ -68,8 +68,12 @@ def fill_service_urls(
     """
     Service = apps.get_model("zgw_consumers", "Service")
     cache_get_service = {}
-
-    for instance in model.objects.exclude(**{url_field: ""}):
+    BATCH_SIZE = 2000
+    instances_to_update = []
+    objects = model.objects.exclude(**{url_field: ""})
+    total_updated = 0
+    total_objects = objects.count()
+    for instance in objects.iterator():
         url = getattr(instance, url_field)
 
         if url in cache_get_service:
@@ -101,7 +105,34 @@ def fill_service_urls(
         if fake_etag and not hasattr(instance, "calculate_etag_value"):
             instance.calculate_etag_value = lambda: None
 
-        instance.save()
+        instances_to_update.append(instance)
+
+        # Bulk save every BATCH_SIZE items
+        if len(instances_to_update) >= BATCH_SIZE:
+            model.objects.bulk_update(
+                instances_to_update, [service_base_field, service_relative_field]
+            )
+            total_updated += BATCH_SIZE
+            logger.info(
+                "Processed %d of %d %s instances",
+                total_updated,
+                total_objects,
+                model.__name__,
+            )
+            instances_to_update.clear()
+
+    # Final batch update
+    if instances_to_update:
+        model.objects.bulk_update(
+            instances_to_update, [service_base_field, service_relative_field]
+        )
+        total_updated += len(instances_to_update)
+        logger.info(
+            "Processed %d of %d %s instances",
+            total_updated,
+            total_objects,
+            model.__name__,
+        )
 
     logger.debug("%s service urls are migrated", model.__name__)
 


### PR DESCRIPTION
This migration was part of bugfix release 1.9.1 and proved to fix the migration issue, so I want to forward port it to main to make sure this is also part of 1.20.0 and after

Closes #1940

**Changes**
* Fix data migrations for large number of objects

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
