### PR TITLE
:zap: [#1937] Remove redundant filter in authorizations filter query

### DIFF
--- a/src/openzaak/components/documenten/query/django.py
+++ b/src/openzaak/components/documenten/query/django.py
@@ -1,14 +1,18 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
+from collections import defaultdict
 from typing import Dict, Tuple
+from urllib.parse import urlparse
 
 from django.apps import apps
 from django.conf import settings
 from django.db import models
+from django.db.models import Case, IntegerField, Q, When
 
 from django_loose_fk.virtual_models import ProxyMixin
 from vng_api_common.constants import VertrouwelijkheidsAanduiding
 from vng_api_common.scopes import Scope
+from vng_api_common.utils import get_resources_for_paths
 
 from openzaak.components.besluiten.models import BesluitInformatieObject
 from openzaak.components.zaken.models import ZaakInformatieObject
@@ -51,15 +55,112 @@ class InformatieobjectAuthorizationsFilterMixin(LooseFkAuthorizationsFilterMixin
     def prefix(self):
         return ""
 
+    def get_filters(
+        self,
+        scope,
+        authorizations,
+        catalogus_authorizations=None,
+        local=True,
+        use_va=True,
+    ) -> dict | Q:
+        """
+        This method was copied over from LooseFkAuthorizationsFilterMixin, because
+        changes to optimize the filters made in #1937 seem to break filtering for CMIS.
+        Since CMIS is scheduled for removal, we won't spend time to optimize filtering
+        for CMIS and preserve the old behavior instead
+        """
+        if not settings.CMIS_ENABLED:
+            return super().get_filters(
+                scope,
+                authorizations,
+                catalogus_authorizations=catalogus_authorizations,
+                local=local,
+                use_va=use_va,
+            )
+
+        prefix = self.prefix
+        loose_fk_field = (
+            f"_{self.loose_fk_field}" if local else f"_{self.loose_fk_field}_url"
+        )
+
+        # resource URLs to either use as-is or resolve to database records
+        resource_urls = [
+            getattr(authorization, self.loose_fk_field)
+            for authorization in authorizations
+        ]
+
+        # keep a list of allowed loose-fk objects
+        loose_fk_objecten = []
+        # build the case/when to map the max_vertrouwelijkheidaanduiding based
+        # on the ``zaaktype``
+        va_mapping = defaultdict(list)
+
+        if not local:
+            loose_fk_object_map = dict(zip(resource_urls, resource_urls))
+        else:
+            # prepare to get the loose_fk_objects in bulk from the DB
+            loose_fk_object_paths = [urlparse(url).path for url in resource_urls]
+            loose_fk_objects = get_resources_for_paths(loose_fk_object_paths)
+            # nothing to resolve
+            if loose_fk_objects is None:
+                loose_fk_object_map = {}
+            else:
+                # keep the sorting so we can zip them correctly
+                sorted_objects = sorted(
+                    loose_fk_objects, key=lambda o: o.get_absolute_api_url()
+                )
+                loose_fk_object_map = dict(zip(sorted(resource_urls), sorted_objects))
+
+        for authorization in authorizations:
+            resource_url = getattr(authorization, self.loose_fk_field)
+            loose_fk_object = loose_fk_object_map[resource_url]
+            loose_fk_objecten.append(loose_fk_object)
+
+            # extract the order and map it to the database value
+            if authorization.max_vertrouwelijkheidaanduiding:
+                choice_item_order = VertrouwelijkheidsAanduiding.get_choice_order(
+                    authorization.max_vertrouwelijkheidaanduiding
+                )
+                va_mapping[choice_item_order].append(loose_fk_object)
+
+        if catalogus_authorizations:
+            for catalogus_authorisation in catalogus_authorizations:
+                resources = getattr(
+                    catalogus_authorisation.catalogus, f"{self.loose_fk_field}_set"
+                ).all()
+
+                for instance in resources:
+                    loose_fk_objecten.append(instance)
+
+                    # extract the order and map it to the database value
+                    if catalogus_authorisation.max_vertrouwelijkheidaanduiding:
+                        choice_item_order = (
+                            VertrouwelijkheidsAanduiding.get_choice_order(
+                                catalogus_authorisation.max_vertrouwelijkheidaanduiding
+                            )
+                        )
+                        va_mapping[choice_item_order].append(instance)
+
+        # Group the When clauses by vertrouwelijkheidaanduiding, to avoid a lot of
+        # duplicate `THEN ...` statements
+        vertrouwelijkheidaanduiding_whens = [
+            When(**{f"{prefix}{loose_fk_field}__in": instances}, then=max_va)
+            for max_va, instances in va_mapping.items()
+        ]
+
+        # filtering:
+        # * only allow the white-listed loose-fk objects, explicitly
+        # * apply the filtering to limit cases within case-types to the maximal
+        #   confidentiality level
+        filters = {
+            f"{prefix}{loose_fk_field}__in": loose_fk_objecten,
+            "_va_order__lte": Case(
+                *vertrouwelijkheidaanduiding_whens, output_field=IntegerField()
+            ),
+        }
+        return filters
+
     def build_queryset(self, local_filters, external_filters) -> models.QuerySet:
-        _local_filters = models.Q()
-        for k, v in local_filters.items():
-            _local_filters &= models.Q(**{k: v})
-
-        _external_filters = models.Q()
-        for k, v in external_filters.items():
-            _external_filters &= models.Q(**{k: v})
-
         order_case = VertrouwelijkheidsAanduiding.get_order_expression(
             "vertrouwelijkheidaanduiding"
         )
@@ -73,19 +174,19 @@ class InformatieobjectAuthorizationsFilterMixin(LooseFkAuthorizationsFilterMixin
             model = apps.get_model("documenten", "EnkelvoudigInformatieObject")
             if settings.CMIS_ENABLED:
                 filtered = model.objects.annotate(**annotations).filter(
-                    _local_filters | _external_filters
+                    local_filters | external_filters
                 )
             else:
                 filtered = (
                     model.objects.annotate(**annotations)
-                    .filter(_local_filters | _external_filters)
+                    .filter(local_filters | external_filters)
                     .values("canonical")
                 )
             queryset = self.filter(informatieobject__in=filtered)
             # bring it all together now to build the resulting queryset
         else:
             queryset = self.annotate(**annotations).filter(
-                _local_filters | _external_filters
+                local_filters | external_filters
             )
 
         return queryset
@@ -107,7 +208,7 @@ class InformatieobjectAuthorizationsFilterMixin(LooseFkAuthorizationsFilterMixin
             else:
                 filtered = (
                     model.objects.annotate(**annotations)
-                    .filter(**filters)
+                    .filter(filters)
                     .values("canonical")
                 )
             queryset = self.filter(informatieobject__in=filtered)
@@ -125,6 +226,7 @@ class InformatieobjectAuthorizationsFilterMixin(LooseFkAuthorizationsFilterMixin
             authorizations,
             catalogus_authorizations=catalogus_authorizations,
             local=local,
+            use_va=self.vertrouwelijkheidaanduiding_use,
         )
         queryset = self.build_queryset_cmis(filters)
         return queryset.values_list("pk", flat=True)


### PR DESCRIPTION
Closes #1937 partially

previously there were two separate filters: one to filter by all of the loose FK objects and another to specify the minimum required vertrouwelijkheidaanduiding per type. This has now been simplified by replacing the CASE clause and filtering on combinations of the loose FK objects and vertrouwelijkheidaanduiding. 

Example of the queries (slightly simplified)

Previous query:
```sql

WHERE ("zaken_zaak"."_zaaktype_id" IN (1,
                                       2,
                                       3,
                                       4,
                                       5,
                                       6)
       AND zaken_zaak.vertrouwelijkheidaanduiding <= (
                  CASE
                       WHEN "zaken_zaak"."_zaaktype_id" IN (1, 2, 3) 
                       THEN 1
                       WHEN "zaken_zaak"."_zaaktype_id" IN (4, 5, 6) 
                       THEN 2
```

New query:
```sql
 WHERE 
    (zaken_zaak._zaaktype_id IN (1,2,3) 
    AND zaken_zaak.vertrouwelijkheidaanduiding <= 1)
    OR
    (zaken_zaak._zaaktype_id IN (4,5,6) 
    AND zaken_zaak.vertrouwelijkheidaanduiding <= 2)
```

Doesn't make a huge difference in terms of performance yet, but this simplifies the underlying query and will make it easier to apply indexes once the `vertrouwelijkheidaanduiding` is stored as an integer instead of a string (#1956)

Baseline: https://github.com/open-zaak/open-zaak/actions/runs/14710127138/job/41280138426?pr=2007#step:5:64
After changes: https://github.com/open-zaak/open-zaak/actions/runs/14710335076/job/41280846896?pr=1997#step:5:68

**Changes**

* Remove redundant filter in authorizations filter query

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
