### PR TITLE
:zap: [#1999] Optimize current_status serialization by storing prefetch result on instance

### DIFF
--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -262,7 +262,12 @@ class ZaakViewSet(
             "resultaat",
             "zaakeigenschap_set",
             models.Prefetch(
-                "status_set", queryset=Status.objects.order_by("-datum_status_gezet")
+                "status_set",
+                queryset=Status.objects.order_by("-datum_status_gezet"),
+                # explicitly store result on this attribute, that way we can retrieve
+                # the first status by simple list indexing, which is faster than calling
+                # `.first()`, because the latter instantiates a new queryset
+                to_attr="prefetched_statuses",
             ),
             "rol_set",
             "zaakinformatieobject_set",


### PR DESCRIPTION
and taking the first item from the prefetch result. This means we can avoid constructing a queryset for each Zaak in the result list, which reduces overhead

Baseline: https://github.com/open-zaak/open-zaak/actions/runs/14510665340/job/40708398457#step:4:756
After changes: https://github.com/open-zaak/open-zaak/actions/runs/14517707000/job/40730699309?pr=1998#step:5:63

Reduces mean/median response time for both regular and superusers by 5-10%

Closes #1999 

**Changes**
* Optimize current_status serialization by storing prefetch result on instance

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
