### PR TITLE
Feature/1839 hoofdzaak deelzaken brondatum

### DIFF
--- a/src/openzaak/components/zaken/api/validators.py
+++ b/src/openzaak/components/zaken/api/validators.py
@@ -8,7 +8,7 @@ from typing import Iterable, Optional
 
 from django.conf import settings
 from django.db import models
-from django.db.models import Max, Subquery
+from django.db.models import F, IntegerField, Max, OuterRef, Subquery
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -31,8 +31,9 @@ from openzaak.components.documenten.models import (
 from openzaak.utils.auth import get_auth
 from openzaak.utils.serializers import get_from_serializer_data_or_instance
 
+from ...catalogi.models import StatusType
 from ..constants import AardZaakRelatie, IndicatieMachtiging
-from ..models import Zaak
+from ..models import Status, Zaak
 
 logger = logging.getLogger(__name__)
 
@@ -277,6 +278,94 @@ class EndStatusIOsUnlockedValidator:
         )
         for zio in remote_zios:
             if zio.informatieobject.locked:
+                raise serializers.ValidationError(self.message, code=self.code)
+
+
+class DeelzaakReopenValidator:
+    """
+    Validate that the hoofdzaak is not closed  when a deelzaak is reopened.
+    """
+
+    code = "hoofdzaak-closed"
+    message = (
+        "De hoofdzaak is afgesloten."
+        "Een deelzaak kan pas worden geopend als de hoofzaak dat al is."
+    )
+
+    def __call__(self, attrs: dict):
+        if attrs.get("__is_eindstatus"):
+            return
+
+        zaak = attrs.get("zaak")
+        if not zaak or not zaak.hoofdzaak or not zaak.hoofdzaak.current_status:
+            return
+
+        if zaak.hoofdzaak.current_status.statustype.is_eindstatus():
+            raise serializers.ValidationError(self.message, code=self.code)
+
+
+class EndStatusDeelZakenValidator:
+    """
+    Validate that related deelzaken are closed when the end status is
+    being set.
+
+    The serializer sets the __is_eindstatus attribute in the data dict as
+    part of the ``to_internal_value`` method.
+    """
+
+    code = "deelzaken-closed"
+    message = (
+        "Er zijn gerelateerde deelzaken die nog niet zijn afgesloten zijn."
+        "Deze deelzaken moeten eerst afgesloten worden voordat de zaak afgesloten kan worden."
+    )
+
+    def __call__(self, attrs: dict):
+        if not attrs.get("__is_eindstatus"):
+            return
+
+        zaak = attrs.get("zaak")
+        # earlier validation failed possibly
+        if not zaak:
+            return
+
+        self.check_status_exists(zaak.deelzaken)
+        self.check_internal_status_types(zaak.deelzaken.filter(_zaaktype__isnull=False))
+        self.check_external_status_types(
+            zaak.deelzaken.filter(_zaaktype_relative_url__isnull=False)
+        )
+
+    def check_status_exists(self, qs):
+        if qs.filter(status__isnull=True).exists():
+            raise serializers.ValidationError(self.message, code=self.code)
+
+    def check_internal_status_types(self, qs):
+        eind_statustypevolgnummer = (
+            StatusType.objects.filter(zaaktype=OuterRef("_zaaktype"))
+            .order_by("-statustypevolgnummer")
+            .values("statustypevolgnummer")[:1]
+        )
+
+        current_status_volgnummer = (
+            Status.objects.filter(zaak=OuterRef("pk"))
+            .select_related("statustype")
+            .values("_statustype__statustypevolgnummer")[:1]
+        )
+
+        qs = qs.annotate(
+            eind_statustype_max=Subquery(
+                eind_statustypevolgnummer, output_field=IntegerField()
+            ),
+            current_status_volgnummer=Subquery(
+                current_status_volgnummer, output_field=IntegerField()
+            ),
+        ).exclude(current_status_volgnummer=F("eind_statustype_max"))
+
+        if qs.exists():
+            raise serializers.ValidationError(self.message, code=self.code)
+
+    def check_external_status_types(self, qs):
+        for deelzaak in qs.iterator():
+            if not deelzaak.current_status.statustype._initial_data["is_eindstatus"]:
                 raise serializers.ValidationError(self.message, code=self.code)
 
 

--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -478,9 +478,9 @@ class ZaakViewSet(
             "\n"
             "**Opmerkingen**\n"
             "- Indien het statustype de eindstatus is (volgens het ZTC), dan wordt de "
-            "zaak afgesloten door de einddatum te zetten."
-            "-Bij deelzaken met de afleidingswijze `hoofdzaak` word de brondatum van de hoofdzaak "
-            "ingevuld nadat de hoofdzaak is afgesloten."
+            "zaak afgesloten door de einddatum te zetten.\n"
+            "- Bij deelzaken met een `Resultaat.resultaattype.brondatumArchiefprocedure.afleidingswijze` `hoofdzaak` "
+            "word de brondatum van de hoofdzaak ingevuld nadat de hoofdzaak is afgesloten."
         ),
     ),
 )

--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -472,10 +472,15 @@ class ZaakViewSet(
             "- indien het de eindstatus betreft, dan moet het attribuut "
             "`indicatieGebruiksrecht` gezet zijn op alle informatieobjecten die aan "
             "de zaak gerelateerd zijn\n"
+            "- indien de zaak deelzaken heeft moeten de deelzaken gesloten zijn voordat de hoofdzaak kan "
+            "worden afgesloten met de eindstatus\n"
+            "- indien een zaak wordt heropend en een hoofdzaak heeft, dan mag de hoofdzaak niet gesloten zijn\n"
             "\n"
             "**Opmerkingen**\n"
             "- Indien het statustype de eindstatus is (volgens het ZTC), dan wordt de "
             "zaak afgesloten door de einddatum te zetten."
+            "-Bij deelzaken met de afleidingswijze `hoofdzaak` word de brondatum van de hoofdzaak "
+            "ingevuld nadat de hoofdzaak is afgesloten."
         ),
     ),
 )

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -2906,7 +2906,8 @@ paths:
         - indien een zaak wordt heropend en een hoofdzaak heeft, dan mag de hoofdzaak niet gesloten zijn
 
         **Opmerkingen**
-        - Indien het statustype de eindstatus is (volgens het ZTC), dan wordt de zaak afgesloten door de einddatum te zetten.-Bij deelzaken met de afleidingswijze `hoofdzaak` word de brondatum van de hoofdzaak ingevuld nadat de hoofdzaak is afgesloten.
+        - Indien het statustype de eindstatus is (volgens het ZTC), dan wordt de zaak afgesloten door de einddatum te zetten.
+        - Bij deelzaken met een `Resultaat.resultaattype.brondatumArchiefprocedure.afleidingswijze` `hoofdzaak` word de brondatum van de hoofdzaak ingevuld nadat de hoofdzaak is afgesloten.
       summary: Maak een STATUS aan voor een ZAAK.
       parameters:
       - in: header

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -2902,9 +2902,11 @@ paths:
         - geldigheid URL naar de ZAAK
         - geldigheid URL naar het STATUSTYPE
         - indien het de eindstatus betreft, dan moet het attribuut `indicatieGebruiksrecht` gezet zijn op alle informatieobjecten die aan de zaak gerelateerd zijn
+        - indien de zaak deelzaken heeft moeten de deelzaken gesloten zijn voordat de hoofdzaak kan worden afgesloten met de eindstatus
+        - indien een zaak wordt heropend en een hoofdzaak heeft, dan mag de hoofdzaak niet gesloten zijn
 
         **Opmerkingen**
-        - Indien het statustype de eindstatus is (volgens het ZTC), dan wordt de zaak afgesloten door de einddatum te zetten.
+        - Indien het statustype de eindstatus is (volgens het ZTC), dan wordt de zaak afgesloten door de einddatum te zetten.-Bij deelzaken met de afleidingswijze `hoofdzaak` word de brondatum van de hoofdzaak ingevuld nadat de hoofdzaak is afgesloten.
       summary: Maak een STATUS aan voor een ZAAK.
       parameters:
       - in: header

--- a/src/openzaak/components/zaken/tests/test_hoofdzaak_afsluiting.py
+++ b/src/openzaak/components/zaken/tests/test_hoofdzaak_afsluiting.py
@@ -106,6 +106,8 @@ class HoofdzaakAfsluitingTests(JWTAuthMixin, APITestCase):
             ),
         )
 
+        cls.addClassCleanup(cls.mocker.stop)
+
     def setUp(self):
         super().setUp()
 

--- a/src/openzaak/components/zaken/tests/test_hoofdzaak_afsluiting.py
+++ b/src/openzaak/components/zaken/tests/test_hoofdzaak_afsluiting.py
@@ -1,0 +1,426 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2025 Dimpact
+from django.test import override_settings, tag
+
+import requests_mock
+from dateutil.relativedelta import relativedelta
+from freezegun.api import freeze_time
+from rest_framework import status
+from rest_framework.test import APITestCase
+from vng_api_common.constants import (
+    Archiefnominatie,
+    BrondatumArchiefprocedureAfleidingswijze,
+)
+from vng_api_common.tests import reverse, reverse_lazy
+from zgw_consumers.constants import APITypes
+from zgw_consumers.test.factories import ServiceFactory
+
+from openzaak.components.catalogi.tests.factories import (
+    ResultaatTypeFactory,
+    StatusTypeFactory,
+    ZaakTypeFactory,
+)
+from openzaak.components.zaken.tests.factories import (
+    ResultaatFactory,
+    StatusFactory,
+    ZaakFactory,
+)
+from openzaak.components.zaken.tests.utils import (
+    get_resultaattype_response,
+    get_statustype_response,
+    get_zaaktype_response,
+    utcdatetime,
+)
+from openzaak.tests.utils import JWTAuthMixin, mock_ztc_oas_get
+
+
+@freeze_time("2025-04-04")
+class HoofdzaakAfsluitingTests(JWTAuthMixin, APITestCase):
+    heeft_alle_autorisaties = True
+    status_list_url = reverse_lazy("status-list")
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.int_zaaktype = ZaakTypeFactory.create(concept=False)
+
+        cls.int_statustype1 = StatusTypeFactory.create(zaaktype=cls.int_zaaktype)
+        cls.int_statustype1_url = reverse(cls.int_statustype1)
+
+        cls.int_statustype2 = StatusTypeFactory.create(zaaktype=cls.int_zaaktype)
+        cls.int_statustype2_url = reverse(cls.int_statustype2)
+
+        cls.int_resultaattype = ResultaatTypeFactory.create(
+            zaaktype=cls.int_zaaktype,
+            archiefactietermijn=relativedelta(years=10),
+            archiefnominatie=Archiefnominatie.blijvend_bewaren,
+            brondatum_archiefprocedure_afleidingswijze=BrondatumArchiefprocedureAfleidingswijze.afgehandeld,
+        )
+
+        ServiceFactory.create(
+            api_root="https://externe.catalogus.nl/api/v1/", api_type=APITypes.ztc
+        )
+
+        base_url = "https://externe.catalogus.nl/api/v1"
+        cls.ext_catalogus = (
+            f"{base_url}/catalogussen/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
+        )
+        cls.ext_zaaktype = f"{base_url}/zaaktypen/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
+        cls.ext_statustype1 = (
+            f"{base_url}/statustypen/b71f72ef-198d-44d8-af64-ae1932df830a"
+        )
+        cls.ext_statustype2 = (
+            f"{base_url}/statustypen/b71f72ef-198d-44d8-af64-ae1932df123b"
+        )
+        cls.ext_resultaattype = (
+            f"{base_url}/resultaattypen/b71f72ef-198d-44d8-af64-ae1932df830a"
+        )
+
+        cls.mocker = requests_mock.Mocker()
+        cls.mocker.start()
+
+        mock_ztc_oas_get(cls.mocker)
+        cls.mocker.get(
+            cls.ext_zaaktype,
+            json=get_zaaktype_response(cls.ext_catalogus, cls.ext_zaaktype),
+        )
+        cls.mocker.get(
+            cls.ext_statustype1,
+            json=get_statustype_response(cls.ext_statustype1, cls.ext_zaaktype),
+        )
+        cls.mocker.get(
+            cls.ext_statustype2,
+            json=get_statustype_response(
+                cls.ext_statustype2, cls.ext_zaaktype, isEindstatus=True
+            ),
+        )
+        cls.mocker.get(
+            cls.ext_resultaattype,
+            json=get_resultaattype_response(
+                cls.ext_resultaattype,
+                cls.ext_zaaktype,
+                brondatumArchiefprocedure={
+                    "afleidingswijze": "hoofdzaak",
+                },
+            ),
+        )
+
+    def setUp(self):
+        super().setUp()
+
+        self.zaak = ZaakFactory.create(zaaktype=self.int_zaaktype)
+        StatusFactory.create(
+            zaak=self.zaak,
+            statustype=self.int_statustype1,
+            datum_status_gezet=utcdatetime(2024, 4, 4),
+        )
+        ResultaatFactory.create(zaak=self.zaak, resultaattype=self.int_resultaattype)
+
+        self.zaak_url = reverse("zaak-detail", kwargs={"uuid": self.zaak.uuid})
+
+    def test_validation_with_internal_deelzaak_catalogi(self):
+        deelzaak = ZaakFactory.create(zaaktype=self.int_zaaktype, hoofdzaak=self.zaak)
+
+        with self.subTest("deelzaak without status"):
+            response = self.client.post(
+                self.status_list_url,
+                {
+                    "zaak": self.zaak_url,
+                    "statustype": f"http://testserver{self.int_statustype2_url}",
+                    "datumStatusGezet": utcdatetime(
+                        2018, 10, 22, 10, 00, 00
+                    ).isoformat(),
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(
+                response.data["invalid_params"][0]["code"], "deelzaken-closed"
+            )
+
+        with self.subTest("deelzaak with open status"):
+            StatusFactory.create(
+                zaak=deelzaak,
+                statustype=self.int_statustype1,
+                datum_status_gezet=utcdatetime(2024, 4, 4),
+            )
+
+            response = self.client.post(
+                self.status_list_url,
+                {
+                    "zaak": self.zaak_url,
+                    "statustype": f"http://testserver{self.int_statustype2_url}",
+                    "datumStatusGezet": utcdatetime(
+                        2018, 10, 22, 10, 00, 00
+                    ).isoformat(),
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(
+                response.data["invalid_params"][0]["code"], "deelzaken-closed"
+            )
+
+        with self.subTest("deelzaak with end status without resultaat"):
+            StatusFactory.create(
+                zaak=deelzaak,
+                statustype=self.int_statustype2,
+                datum_status_gezet=utcdatetime(2024, 4, 5),
+            )
+            response = self.client.post(
+                self.status_list_url,
+                {
+                    "zaak": self.zaak_url,
+                    "statustype": f"http://testserver{self.int_statustype2_url}",
+                    "datumStatusGezet": utcdatetime(
+                        2018, 10, 22, 10, 00, 00
+                    ).isoformat(),
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(
+                response.data["invalid_params"][0]["code"],
+                "deelzaak-resultaat-does-not-exist",
+            )
+
+    def test_validation_with_internal_deelzaak_catalogi_multiple(self):
+        deelzaak1 = ZaakFactory.create(zaaktype=self.int_zaaktype, hoofdzaak=self.zaak)
+
+        StatusFactory.create(
+            zaak=deelzaak1,
+            statustype=self.int_statustype1,
+            datum_status_gezet=utcdatetime(2024, 4, 4),
+        )
+
+        int_zaaktype = ZaakTypeFactory.create(concept=False)
+        StatusTypeFactory.create(zaaktype=int_zaaktype)
+        StatusTypeFactory.create(zaaktype=int_zaaktype)
+        deelzaak2 = ZaakFactory.create(zaaktype=int_zaaktype, hoofdzaak=self.zaak)
+
+        StatusFactory.create(
+            zaak=deelzaak2,
+            statustype=StatusTypeFactory.create(zaaktype=int_zaaktype),
+            datum_status_gezet=utcdatetime(2024, 4, 4),
+        )
+
+        response = self.client.post(
+            self.status_list_url,
+            {
+                "zaak": self.zaak_url,
+                "statustype": f"http://testserver{self.int_statustype2_url}",
+                "datumStatusGezet": utcdatetime(2018, 10, 22, 10, 00, 00).isoformat(),
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["invalid_params"][0]["code"], "deelzaken-closed")
+
+    @tag("external-urls")
+    @override_settings(ALLOWED_HOSTS=["testserver"])
+    def test_validation_with_external_deelzaak_catalogi(self):
+        deelzaak = ZaakFactory.create(zaaktype=self.ext_zaaktype, hoofdzaak=self.zaak)
+
+        with self.subTest("deelzaak without status"):
+            response = self.client.post(
+                self.status_list_url,
+                {
+                    "zaak": self.zaak_url,
+                    "statustype": f"http://testserver{self.int_statustype2_url}",
+                    "datumStatusGezet": utcdatetime(
+                        2018, 10, 22, 10, 00, 00
+                    ).isoformat(),
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(
+                response.data["invalid_params"][0]["code"], "deelzaken-closed"
+            )
+
+        with self.subTest("deelzaak with open status"):
+            StatusFactory.create(
+                zaak=deelzaak,
+                statustype=self.ext_statustype1,
+                datum_status_gezet=utcdatetime(2024, 4, 4),
+            )
+            response = self.client.post(
+                self.status_list_url,
+                {
+                    "zaak": self.zaak_url,
+                    "statustype": f"http://testserver{self.int_statustype2_url}",
+                    "datumStatusGezet": utcdatetime(2024, 4, 5).isoformat(),
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(
+                response.data["invalid_params"][0]["code"], "deelzaken-closed"
+            )
+
+        with self.subTest("deelzaak with end status without resultaat"):
+            StatusFactory.create(
+                zaak=deelzaak,
+                statustype=self.ext_statustype2,
+                datum_status_gezet=utcdatetime(2024, 4, 5),
+            )
+            response = self.client.post(
+                self.status_list_url,
+                {
+                    "zaak": self.zaak_url,
+                    "statustype": f"http://testserver{self.int_statustype2_url}",
+                    "datumStatusGezet": utcdatetime(2024, 4, 5).isoformat(),
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(
+                response.data["invalid_params"][0]["code"],
+                "deelzaak-resultaat-does-not-exist",
+            )
+
+    def test_with_internal_deelzaak_catalogi(self):
+        deelzaak = ZaakFactory.create(zaaktype=self.int_zaaktype, hoofdzaak=self.zaak)
+        StatusFactory.create(
+            zaak=deelzaak,
+            statustype=self.int_statustype2,
+            datum_status_gezet=utcdatetime(2024, 4, 5),
+        )
+        ResultaatFactory.create(
+            zaak=deelzaak,
+            resultaattype=ResultaatTypeFactory.create(
+                zaaktype=self.int_zaaktype,
+                archiefactietermijn=relativedelta(years=20),
+                brondatum_archiefprocedure_afleidingswijze=BrondatumArchiefprocedureAfleidingswijze.hoofdzaak,
+            ),
+        )
+
+        response = self.client.post(
+            self.status_list_url,
+            {
+                "zaak": self.zaak_url,
+                "statustype": f"http://testserver{self.int_statustype2_url}",
+                "datumStatusGezet": utcdatetime(2024, 4, 5).isoformat(),
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.zaak.refresh_from_db()
+        deelzaak.refresh_from_db()
+        self.assertEqual(
+            self.zaak.archiefactiedatum, self.zaak.einddatum + relativedelta(years=10)
+        )
+        self.assertEqual(
+            deelzaak.archiefactiedatum, self.zaak.einddatum + relativedelta(years=10)
+        )
+
+    @tag("external-urls")
+    @override_settings(ALLOWED_HOSTS=["testserver"])
+    def test_zaak_afsluiten_with_closed_deelzaak_with_external_catalogi(self):
+        deelzaak = ZaakFactory.create(zaaktype=self.ext_zaaktype, hoofdzaak=self.zaak)
+        StatusFactory.create(
+            zaak=deelzaak,
+            statustype=self.ext_statustype2,
+            datum_status_gezet=utcdatetime(2024, 4, 5),
+        )
+        ResultaatFactory.create(zaak=deelzaak, resultaattype=self.ext_resultaattype)
+
+        response = self.client.post(
+            self.status_list_url,
+            {
+                "zaak": self.zaak_url,
+                "statustype": f"http://testserver{self.int_statustype2_url}",
+                "datumStatusGezet": utcdatetime(2024, 4, 5).isoformat(),
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.zaak.refresh_from_db()
+        deelzaak.refresh_from_db()
+        self.assertEqual(
+            self.zaak.archiefactiedatum, self.zaak.einddatum + relativedelta(years=10)
+        )
+        self.assertEqual(
+            deelzaak.archiefactiedatum, self.zaak.einddatum + relativedelta(years=10)
+        )
+
+    def test_reopen_deelzaak_with_internal_catalogi(self):
+        deelzaak = ZaakFactory.create(zaaktype=self.int_zaaktype, hoofdzaak=self.zaak)
+        StatusFactory.create(
+            zaak=deelzaak,
+            statustype=self.int_statustype2,
+            datum_status_gezet=utcdatetime(2024, 4, 5),
+        )
+        ResultaatFactory.create(
+            zaak=deelzaak,
+            resultaattype=ResultaatTypeFactory.create(
+                zaaktype=self.int_zaaktype,
+                archiefactietermijn=relativedelta(years=20),
+                brondatum_archiefprocedure_afleidingswijze=BrondatumArchiefprocedureAfleidingswijze.hoofdzaak,
+            ),
+        )
+
+        with self.subTest("opened hoofdzaak"):
+            response = self.client.post(
+                self.status_list_url,
+                {
+                    "zaak": reverse("zaak-detail", kwargs={"uuid": deelzaak.uuid}),
+                    "statustype": f"http://testserver{self.int_statustype1_url}",
+                    "datumStatusGezet": utcdatetime(2024, 4, 6).isoformat(),
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        with self.subTest("closed hoofdzaak"):
+            StatusFactory.create(
+                zaak=self.zaak,
+                statustype=self.int_statustype2,
+                datum_status_gezet=utcdatetime(2024, 4, 5),
+            )
+
+            response = self.client.post(
+                self.status_list_url,
+                {
+                    "zaak": reverse("zaak-detail", kwargs={"uuid": deelzaak.uuid}),
+                    "statustype": f"http://testserver{self.int_statustype1_url}",
+                    "datumStatusGezet": utcdatetime(2024, 4, 7).isoformat(),
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(
+                response.data["invalid_params"][0]["code"], "hoofdzaak-closed"
+            )
+
+    @tag("external-urls")
+    @override_settings(ALLOWED_HOSTS=["testserver"])
+    def test_reopen_deelzaak_with_external_catalogi(self):
+        deelzaak = ZaakFactory.create(zaaktype=self.ext_zaaktype, hoofdzaak=self.zaak)
+        StatusFactory.create(
+            zaak=deelzaak,
+            statustype=self.ext_statustype2,
+            datum_status_gezet=utcdatetime(2024, 4, 5),
+        )
+        ResultaatFactory.create(zaak=deelzaak, resultaattype=self.ext_resultaattype)
+
+        with self.subTest("opened hoofdzaak"):
+            response = self.client.post(
+                self.status_list_url,
+                {
+                    "zaak": reverse("zaak-detail", kwargs={"uuid": deelzaak.uuid}),
+                    "statustype": self.ext_statustype1,
+                    "datumStatusGezet": utcdatetime(2024, 4, 6).isoformat(),
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        with self.subTest("closed hoofdzaak"):
+            StatusFactory.create(
+                zaak=self.zaak,
+                statustype=self.int_statustype2,
+                datum_status_gezet=utcdatetime(2024, 4, 5),
+            )
+
+            response = self.client.post(
+                self.status_list_url,
+                {
+                    "zaak": reverse("zaak-detail", kwargs={"uuid": deelzaak.uuid}),
+                    "statustype": self.ext_statustype1,
+                    "datumStatusGezet": utcdatetime(2024, 4, 7).isoformat(),
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(
+                response.data["invalid_params"][0]["code"], "hoofdzaak-closed"
+            )

--- a/src/openzaak/components/zaken/tests/test_hoofdzaak_afsluiting.py
+++ b/src/openzaak/components/zaken/tests/test_hoofdzaak_afsluiting.py
@@ -502,11 +502,10 @@ class HoofdzaakAfsluitingTests(JWTAuthMixin, APITestCase):
     @override_settings(ALLOWED_HOSTS=["testserver"])
     def test_queries_with_one_deelzaak_with_external_catalogi(self):
         """
-        An Deelzaak with an external catalogi has 16 extra queries compared to a deelzaak with an internal catalogi.
+        An Deelzaak with an external catalogi has 12 extra queries compared to a deelzaak with an internal catalogi.
 
         (1) 45: Lookup the current status
         (2-3) 46-47: select from zgw_consumers_service
-        (3-7) 48-51: outgoing requests log (Done once)
         (8) 75: lookup the deelzaak resultaat
         (9-10)  76-77: select from zgw_consumers_service
         (11) 78: update the deelzaak
@@ -514,7 +513,7 @@ class HoofdzaakAfsluitingTests(JWTAuthMixin, APITestCase):
 
         """
         self._generate_deelzaken(1, False)
-        with self.assertNumQueries(88):
+        with self.assertNumQueries(84):
             response = self.client.post(
                 self.status_list_url,
                 {
@@ -542,13 +541,11 @@ class HoofdzaakAfsluitingTests(JWTAuthMixin, APITestCase):
     @override_settings(ALLOWED_HOSTS=["testserver"])
     def test_queries_with_many_deelzaken_with_external_catalogi(self):
         """
-        A single deelzaak with external catalogi has 16 extra queries over an internal catalogi.
-        The 4 queries for outgoing request logging are done once which means every deelzaak
-        (with an external catalogi) adds 12 queries.
-        72 + 4 + (10*12) = 196
+        A single deelzaak with external catalogi has 12 extra queries over an internal catalogi.
+        72 + (10*12) = 192
         """
         self._generate_deelzaken(10, False)
-        with self.assertNumQueries(196):  # TODO
+        with self.assertNumQueries(192):
             response = self.client.post(
                 self.status_list_url,
                 {
@@ -564,7 +561,7 @@ class HoofdzaakAfsluitingTests(JWTAuthMixin, APITestCase):
     def test_queries_with_many_deelzaken(self):
         self._generate_deelzaken(10, True)
         self._generate_deelzaken(10, False)
-        with self.assertNumQueries(196):
+        with self.assertNumQueries(192):
             response = self.client.post(
                 self.status_list_url,
                 {

--- a/src/openzaak/components/zaken/tests/test_hoofdzaak_afsluiting.py
+++ b/src/openzaak/components/zaken/tests/test_hoofdzaak_afsluiting.py
@@ -561,7 +561,9 @@ class HoofdzaakAfsluitingTests(JWTAuthMixin, APITestCase):
     def test_queries_with_many_deelzaken(self):
         self._generate_deelzaken(10, True)
         self._generate_deelzaken(10, False)
-        with self.assertNumQueries(192):
+        # compared to test_queries_with_many_deelzaken_with_external_catalogi,
+        # 4 queries for openidconnectconfig are not run within the CI job.
+        with self.assertNumQueries(188):
             response = self.client.post(
                 self.status_list_url,
                 {

--- a/src/openzaak/components/zaken/tests/test_hoofdzaak_afsluiting.py
+++ b/src/openzaak/components/zaken/tests/test_hoofdzaak_afsluiting.py
@@ -105,6 +105,7 @@ class HoofdzaakAfsluitingTests(JWTAuthMixin, APITestCase):
                 brondatumArchiefprocedure={
                     "afleidingswijze": "hoofdzaak",
                 },
+                archiefactietermijn="P20Y",
             ),
         )
 
@@ -318,7 +319,7 @@ class HoofdzaakAfsluitingTests(JWTAuthMixin, APITestCase):
             self.zaak.archiefactiedatum, self.zaak.einddatum + relativedelta(years=10)
         )
         self.assertEqual(
-            deelzaak.archiefactiedatum, self.zaak.einddatum + relativedelta(years=10)
+            deelzaak.archiefactiedatum, self.zaak.einddatum + relativedelta(years=20)
         )
 
     @tag("external-urls")
@@ -347,7 +348,7 @@ class HoofdzaakAfsluitingTests(JWTAuthMixin, APITestCase):
             self.zaak.archiefactiedatum, self.zaak.einddatum + relativedelta(years=10)
         )
         self.assertEqual(
-            deelzaak.archiefactiedatum, self.zaak.einddatum + relativedelta(years=10)
+            deelzaak.archiefactiedatum, self.zaak.einddatum + relativedelta(years=20)
         )
 
     def test_reopen_deelzaak_with_internal_catalogi(self):

--- a/src/openzaak/components/zaken/tests/test_hoofdzaak_afsluiting.py
+++ b/src/openzaak/components/zaken/tests/test_hoofdzaak_afsluiting.py
@@ -124,11 +124,8 @@ class HoofdzaakAfsluitingTests(JWTAuthMixin, APITestCase):
 
         self.zaak_url = reverse("zaak-detail", kwargs={"uuid": self.zaak.uuid})
 
-    def tearDown(self):
-        """
-        Clears singleton model caches to keep query count
-        the same between running whole test class & tests separately.
-        """
+        # Clear singleton model caches to keep query count
+        # the same between running whole test class & tests separately.
         OpenIDConnectConfig.clear_cache()
         OutgoingRequestsLogConfig.clear_cache()
 
@@ -562,9 +559,8 @@ class HoofdzaakAfsluitingTests(JWTAuthMixin, APITestCase):
     def test_queries_with_many_deelzaken(self):
         self._generate_deelzaken(10, True)
         self._generate_deelzaken(10, False)
-        # compared to test_queries_with_many_deelzaken_with_external_catalogi,
-        # 4 queries for openidconnectconfig are not run within the CI job.
-        with self.assertNumQueries(188):
+
+        with self.assertNumQueries(192):
             response = self.client.post(
                 self.status_list_url,
                 {

--- a/src/openzaak/conf/dev.py
+++ b/src/openzaak/conf/dev.py
@@ -111,6 +111,10 @@ if "test" in sys.argv:
 
     warnings.filterwarnings("ignore", r".*", SystemTimeWarning, "urllib3.connection")
 
+    from openzaak.notifications.tests.utils import LOGGING_SETTINGS
+
+    LOGGING = LOGGING_SETTINGS
+
 ELASTIC_APM["DEBUG"] = config("DISABLE_APM_IN_DEV", default=True, add_to_docs=False)
 
 # Override settings with local settings.


### PR DESCRIPTION
Closes #1839

**Changes**
- Adds validator that checks if all deelzaken are closed/in their "end status"
- Adds validator that checks if the hoofdzaak is open when opening a deelzaak. (changing to a non "end status")
- Changes StatusSerializer to update deelzaken if the hoofdzaak is in its end status and the deelzaken have their afleidingswijze set to hoofdzaak.

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [ ] Any experimental features added in this PR are backwards compatible
  - [ ] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
