### PR TITLE
:bug: [#2011] Show appropriate betalingsindicatieWeergave via serializer

### DIFF
--- a/src/openzaak/components/documenten/tests/models/test_last_version.py
+++ b/src/openzaak/components/documenten/tests/models/test_last_version.py
@@ -2,12 +2,15 @@
 # Copyright (C) 2019 - 2020 Dimpact
 from django.test import TestCase, override_settings
 
+from privates.test import temp_private_root
+
 from ..factories import (
     EnkelvoudigInformatieObjectCanonicalFactory,
     EnkelvoudigInformatieObjectFactory,
 )
 
 
+@temp_private_root()
 @override_settings(CMIS_ENABLED=False)
 class LastVersionTests(TestCase):
     def test_canonical_last_version(self):

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -275,7 +275,7 @@ class ZaakSerializer(
         "beter kan via `ZaakObject`.",
     )
 
-    betalingsindicatie_weergave = serializers.CharField(
+    betalingsindicatie_weergave = serializers.SerializerMethodField(
         source="get_betalingsindicatie_display",
         read_only=True,
         help_text=_("Uitleg bij `betalingsindicatie`."),
@@ -481,6 +481,18 @@ class ZaakSerializer(
             ZaakArchiveIOsArchivedValidator(),
             HoofdZaaktypeRelationValidator(),
         ]
+
+    def get_betalingsindicatie_weergave(self, obj: Zaak) -> str:
+        """
+        Display the label of the betalingsindicatie choice for the Zaak
+        """
+        if (
+            not obj.betalingsindicatie
+            or obj.betalingsindicatie not in BetalingsIndicatie
+        ):
+            return ""
+
+        return BetalingsIndicatie[obj.betalingsindicatie].label
 
     def get_fields(self):
         fields = super().get_fields()

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -15255,8 +15255,8 @@ components:
           - $ref: '#/components/schemas/BlankEnum'
         betalingsindicatieWeergave:
           type: string
-          readOnly: true
           description: Uitleg bij `betalingsindicatie`.
+          readOnly: true
         laatsteBetaaldatum:
           type: string
           format: date-time

--- a/src/openzaak/management/commands/generate_data.py
+++ b/src/openzaak/management/commands/generate_data.py
@@ -619,7 +619,7 @@ class Command(BaseCommand):
 
         num_authorized_zaaktypen = min(ZaakType.objects.count(), 15)
         request = APIRequestFactory().get("/", HTTP_HOST=get_openzaak_domain())
-        for zaaktype in ZaakType.objects.all()[:num_authorized_zaaktypen]:
+        for zaaktype in ZaakType.objects.order_by("pk")[:num_authorized_zaaktypen]:
             AutorisatieFactory.create(
                 applicatie=applicatie,
                 component=ComponentTypes.zrc,
@@ -638,7 +638,7 @@ class Command(BaseCommand):
 
         num_authorized_zaaktypen = max(ZaakType.objects.count() - 5, 1)
         request = APIRequestFactory().get("/", HTTP_HOST=get_openzaak_domain())
-        for zaaktype in ZaakType.objects.all()[:num_authorized_zaaktypen]:
+        for zaaktype in ZaakType.objects.order_by("pk")[:num_authorized_zaaktypen]:
             AutorisatieFactory.create(
                 applicatie=applicatie,
                 component=ComponentTypes.zrc,

--- a/src/openzaak/tests/management/test_generate_data.py
+++ b/src/openzaak/tests/management/test_generate_data.py
@@ -119,7 +119,7 @@ class GenerateDataTests(SelectieLijstMixin, APITestCase):
 
         # assert that some attributes are filled
         # catalogi
-        zaaktype = ZaakType.objects.first()
+        zaaktype = ZaakType.objects.order_by("pk").first()
         self.assertTrue(zaaktype.identificatie.startswith("ZAAKTYPE_"))
         self.assertEqual(
             zaaktype.selectielijst_procestype,
@@ -153,7 +153,7 @@ class GenerateDataTests(SelectieLijstMixin, APITestCase):
             self.assertEqual(applicatie.heeft_alle_autorisaties, False)
             self.assertEqual(applicatie.autorisaties.count(), 15)
 
-            autorisatie = applicatie.autorisaties.first()
+            autorisatie = applicatie.autorisaties.order_by("pk").first()
             self.assertEqual(autorisatie.component, ComponentTypes.zrc)
             self.assertEqual(autorisatie.scopes, [str(SCOPE_ZAKEN_ALLES_LEZEN)])
             self.assertEqual(
@@ -175,7 +175,7 @@ class GenerateDataTests(SelectieLijstMixin, APITestCase):
             self.assertEqual(applicatie.heeft_alle_autorisaties, False)
             self.assertEqual(applicatie.autorisaties.count(), 25)
 
-            autorisatie = applicatie.autorisaties.first()
+            autorisatie = applicatie.autorisaties.order_by("pk").first()
             self.assertEqual(autorisatie.component, ComponentTypes.zrc)
             self.assertEqual(autorisatie.scopes, [str(SCOPE_ZAKEN_ALLES_LEZEN)])
             self.assertEqual(


### PR DESCRIPTION
Fixes #2011

this field was read only and was never populated, even if betalingsindicatie was set. Now it has been changed to show the label that corresponds with the betalingsindicatie value that the Zaak has

Baseline: https://github.com/open-zaak/open-zaak/actions/runs/14726552958/job/41330465681#step:5:62
After changes: https://github.com/open-zaak/open-zaak/actions/runs/14726565385/job/41330508336?pr=2001#step:5:62

**Changes**

* Show appropriate betalingsindicatieWeergave via serializer

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
