### PR TITLE
:construction_worker: [#2008] Run tests in CI if templates changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,14 @@ jobs:
         id: changed-requirements
         run: bin/check_changed_files.sh ^requirements/.*\.txt$
 
+      - name: Get changed templates
+        id: changed-templates
+        run: bin/check_changed_files.sh ^src/.*\.html$
+
     outputs:
       changed-py-files: ${{ steps.changed-py-files.outputs.any_changed }}
       changed-requirements: ${{ steps.changed-requirements.outputs.any_changed }}
+      changed-templates: ${{ steps.changed-templates.outputs.any_changed }}
 
   cmis-init:  # regression check for #972
     runs-on: ubuntu-latest
@@ -100,7 +105,7 @@ jobs:
       - changed-files
 
     # only run tests if source files have changed (e.g. skip for PRs that only update docs)
-    if: ${{ needs.changed-files.outputs.changed-py-files == 'true'|| needs.changed-files.outputs.changed-requirements == 'true'|| github.event_name == 'push' }}
+    if: ${{ needs.changed-files.outputs.changed-py-files == 'true'|| needs.changed-files.outputs.changed-requirements == 'true'|| needs.changed-files.outputs.changed-templates|| github.event_name == 'push' }}
 
     strategy:
       matrix:


### PR DESCRIPTION
issue #2008 caused failures on master, a template for the admin changed and this was not tested because CI skipped tests

**Changes**

* Run tests in CI if templates changed

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
