### PR TITLE
:bug: [#1907] Fix CachedSession backend

### DIFF
--- a/src/openzaak/utils/cache.py
+++ b/src/openzaak/utils/cache.py
@@ -113,9 +113,7 @@ def requests_cache_enabled(*args, **kwargs):
     cache_name = "import_requests"
     backend = DjangoRequestsCache
 
-    class CustomOpenZaakClient(original_client, CachedSession):
-        _cache_name = cache_name
-        _backend = backend
+    class CustomCachedSession(CachedSession):
 
         def __init__(self, *args, **kwargs):
             # Initialize CachedSession with the custom backend
@@ -125,6 +123,14 @@ def requests_cache_enabled(*args, **kwargs):
                 *args,
                 **kwargs,
             )
+
+    class CustomOpenZaakClient(original_client, CustomCachedSession):
+        _cache_name = cache_name
+        _backend = backend
+
+        def __init__(self, *args, **kwargs):
+            # __mro__: original_client -> CustomCachedSession
+            super().__init__(*args, **kwargs)
 
             # FIXME `ape_pie.APIClient` doesn't forward the cache params, causing
             # sqlite to be used by default, so we explicitly set the cache here


### PR DESCRIPTION
Closes #1907 

**Changes**

`ape_pie.APIClient` doesn't forward cache parameters, tried overriding `requests_cache.session.CachedSession` to force the use own backend and cache during the `__init__` of the class

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [ ] Any experimental features added in this PR are backwards compatible
  - [ ] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how
