### PR TITLE
:zap: [#2025] add component_type check for unnecessary db query's

### DIFF
--- a/src/openzaak/tests/test_enabled_middleware.py
+++ b/src/openzaak/tests/test_enabled_middleware.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2025 Dimpact
+
+from django.http import HttpResponseNotFound
+from django.test import RequestFactory, TestCase
+
+from vng_api_common.constants import ComponentTypes
+
+from openzaak.config.models import InternalService
+from openzaak.utils.middleware import EnabledMiddleware
+
+
+class EnabledMiddlewareDatabaseQueryTest(TestCase):
+    def setUp(self):
+        self.middleware = EnabledMiddleware(lambda r: None)
+        self.factory = RequestFactory()
+
+    def test_no_db_query_if_no_component_type(self):
+        request = self.factory.get("/")
+
+        with self.assertNumQueries(0):
+            result = self.middleware.process_view(request, None, None, None)
+
+        self.assertIsNone(result)
+
+    def test_query_and_returns_404_if_disabled(self):
+        InternalService.objects.update_or_create(
+            api_type=ComponentTypes.zrc, defaults={"enabled": False}
+        )
+
+        request = self.factory.get("/zaken/api/v1/")
+
+        with self.assertNumQueries(1):
+            response = self.middleware.process_view(request, None, None, None)
+
+        self.assertIsInstance(response, HttpResponseNotFound)
+
+    def test_request_allowed_if_service_enabled(self):
+        InternalService.objects.update_or_create(
+            api_type=ComponentTypes.zrc, defaults={"enabled": True}
+        )
+
+        request = self.factory.get("/zaken/api/v1/")
+
+        with self.assertNumQueries(1):
+            response = self.middleware.process_view(request, None, None, None)
+
+        self.assertIsNone(response)

--- a/src/openzaak/utils/middleware.py
+++ b/src/openzaak/utils/middleware.py
@@ -143,6 +143,10 @@ class EnabledMiddleware:
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         component_type = self.get_component_type(request)
+
+        if not component_type:
+            return None
+
         disabled = InternalService.objects.filter(
             api_type=component_type, enabled=False
         ).exists()


### PR DESCRIPTION
Closes #2025 

**Changes**

Added check in EnableMiddleware to to return None before InternalService db query if there is no component_type.

Added tests.

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
