### PR TITLE
:memo: [#2002] add procestermijn -> afleidingswijze table to documentation

### DIFF
--- a/docs/manual/archiving.rst
+++ b/docs/manual/archiving.rst
@@ -28,7 +28,7 @@ Afleidingswijze
 ---------------
 
 Naast de selectielijstklasse moet ook een afleidingswijze worden gekozen. In de volgende tabel is te zien welke afleidingswijzen zijn toegestaan per procestermijn.
-nihil + afgehandeld & ingeschatte_bestaansduur_procesobject + termijn kunnen alleen in combinatie met elkaar worden geselecteerd.
+``nihil`` + ``afgehandeld`` & ``ingeschatte_bestaansduur_procesobject`` + ``termijn`` kunnen alleen in combinatie met elkaar worden geselecteerd.
 De andere afleidingswijzen zijn toegestaan bij de andere procestermijnen
 
 .. list-table::
@@ -39,13 +39,19 @@ De andere afleidingswijzen zijn toegestaan bij de andere procestermijnen
    * - nihil
      - afgehandeld
    * - bestaansduur_processobject
-     - ander_datumkenmerk, eigenschap, gerelateerde_zaak, hoofdzaak, ingangsdatum_besluit, vervaldatum_besluit, zaakobject
+     - | ander_datumkenmerk, eigenschap, gerelateerde_zaak,
+       | hoofdzaak, ingangsdatum_besluit, vervaldatum_besluit,
+       | zaakobject
    * - ingeschatte_bestaansduur_procesobject
-     - termijn
+     - | termijn
    * - vast_te_leggen_datum
-     - ander_datumkenmerk, eigenschap, gerelateerde_zaak, hoofdzaak, ingangsdatum_besluit, vervaldatum_besluit, zaakobject
+     - | ander_datumkenmerk, eigenschap, gerelateerde_zaak,
+       | hoofdzaak, ingangsdatum_besluit, vervaldatum_besluit,
+       | zaakobject
    * - samengevoegd_met_bewaartermijn
-     - ander_datumkenmerk, eigenschap, gerelateerde_zaak, hoofdzaak, ingangsdatum_besluit, vervaldatum_besluit, zaakobject
+     - | ander_datumkenmerk, eigenschap, gerelateerde_zaak,
+       | hoofdzaak, ingangsdatum_besluit, vervaldatum_besluit,
+       | zaakobject
 
 Daarnaast zijn bij de bepaling van de brondatum archiefprocedure per afleidingswijze een aantal velden verplicht:
 

--- a/docs/manual/archiving.rst
+++ b/docs/manual/archiving.rst
@@ -27,17 +27,25 @@ Tijdens het aanmaken van een resultaattype, moet een selectielijstklasse worden 
 Afleidingswijze
 ---------------
 
-Naast de selectielijstklasse moet ook een afleidingswijze worden gekozen. De volgende combinaties van een selectielijst klasse en een afleidingswijze kunnen alleen met elkaar worden geselecteerd:
+Naast de selectielijstklasse moet ook een afleidingswijze worden gekozen. In de volgende tabel is te zien welke afleidingswijzen zijn toegestaan per procestermijn.
+nihil + afgehandeld & ingeschatte_bestaansduur_procesobject + termijn kunnen alleen in combinatie met elkaar worden geselecteerd.
+De andere afleidingswijzen zijn toegestaan bij de andere procestermijnen
 
 .. list-table::
-    :header-rows: 1
+   :header-rows: 1
 
-    *   - Procestermijn
-        - Afleidingswijze
-    *   - nihil
-        - afgehandeld
-    *   - ingeschatte_bestaansduur_procesobject
-        - termijn
+   * - procestermijn
+     - toegestane afleidingswijzen
+   * - nihil
+     - afgehandeld
+   * - bestaansduur_processobject
+     - ander_datumkenmerk, eigenschap, gerelateerde_zaak, hoofdzaak, ingangsdatum_besluit, vervaldatum_besluit, zaakobject
+   * - ingeschatte_bestaansduur_procesobject
+     - termijn
+   * - vast_te_leggen_datum
+     - ander_datumkenmerk, eigenschap, gerelateerde_zaak, hoofdzaak, ingangsdatum_besluit, vervaldatum_besluit, zaakobject
+   * - samengevoegd_met_bewaartermijn
+     - ander_datumkenmerk, eigenschap, gerelateerde_zaak, hoofdzaak, ingangsdatum_besluit, vervaldatum_besluit, zaakobject
 
 Daarnaast zijn bij de bepaling van de brondatum archiefprocedure per afleidingswijze een aantal velden verplicht:
 


### PR DESCRIPTION

Closes #2002

**Changes**
- Adds a table to better explain the allowed afleidingswijze for each procestermijn

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
