### PR TITLE
Issue/2041 hoofdzaak with deelzaken 500 error

### DIFF
--- a/src/openzaak/components/zaken/brondatum.py
+++ b/src/openzaak/components/zaken/brondatum.py
@@ -24,13 +24,13 @@ class BrondatumCalculator:
 
     def calculate(self) -> Union[None, date]:
         if self.zaak.archiefactiedatum:
-            return
+            return None
 
         resultaattype = self.zaak.resultaat.resultaattype
 
         archiefactietermijn = resultaattype.archiefactietermijn
         if not archiefactietermijn:
-            return
+            return None
 
         # if zaak.startdatum_bewaartermijn is filled -> use as brondatum
         if self.zaak.startdatum_bewaartermijn:
@@ -56,7 +56,7 @@ class BrondatumCalculator:
             )
 
         if not brondatum:
-            return
+            return None
         self.brondatum = brondatum
         return brondatum + archiefactietermijn
 
@@ -72,7 +72,7 @@ def get_brondatum(
     objecttype: str = None,
     procestermijn: relativedelta = None,
     einddatum: date = None,
-) -> date:
+) -> Union[None, date]:
     """
     To calculate the Archiefactiedatum, we first need the "brondatum" which is like the start date of the storage
     period.
@@ -98,6 +98,7 @@ def get_brondatum(
 
     elif afleidingswijze == BrondatumArchiefprocedureAfleidingswijze.hoofdzaak:
         # TODO: Document that hoofdzaak can not an external zaak
+        # TODO: will always return None because deelzaken have to be closed before the hoofdzaak.
         return zaak.hoofdzaak.einddatum if zaak.hoofdzaak else None
 
     elif afleidingswijze == BrondatumArchiefprocedureAfleidingswijze.eigenschap:

--- a/src/openzaak/components/zaken/tests/test_brondatum.py
+++ b/src/openzaak/components/zaken/tests/test_brondatum.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2025 Dimpact
 from datetime import datetime
+from unittest.mock import patch
 
 from django.test import TestCase
 
@@ -8,11 +9,16 @@ from openzaak.components.zaken.brondatum import BrondatumCalculator
 from openzaak.components.zaken.tests.factories import ResultaatFactory, ZaakFactory
 
 
+@patch(
+    "openzaak.components.catalogi.models.resultaattype.ResultaatType.get_selectielijstklasse",
+    return_value={"bewaartermijn": None},
+)
 class BronDatumTests(TestCase):
-    def test_calculate_brondatum_without_archiefactietermijn(self):
+    def test_calculate_brondatum_without_archiefactietermijn(
+        self, mock_get_selectielijstklasse
+    ):
         zaak = ZaakFactory()
-        resultaat = ResultaatFactory(zaak=zaak)
         # when archiefactietermijn is not set it is set by the selectielijstklasse
-        resultaat.resultaattype.archiefactietermijn = None
+        ResultaatFactory(zaak=zaak, resultaattype__archiefactietermijn=None)
         calculator = BrondatumCalculator(zaak, datetime.now())
         self.assertIsNone(calculator.calculate())

--- a/src/openzaak/components/zaken/tests/test_brondatum.py
+++ b/src/openzaak/components/zaken/tests/test_brondatum.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+from django.test import TestCase
+
+from openzaak.components.zaken.brondatum import BrondatumCalculator
+from openzaak.components.zaken.tests.factories import ResultaatFactory, ZaakFactory
+
+
+class BronDatumTests(TestCase):
+    def test_calculate_brondatum_without_archiefactietermijn(self):
+        zaak = ZaakFactory()
+        resultaat = ResultaatFactory(zaak=zaak)
+        # when archiefactietermijn is not set it is set by the selectielijstklasse
+        resultaat.resultaattype.archiefactietermijn = None
+        calculator = BrondatumCalculator(zaak, datetime.now())
+        self.assertIsNone(calculator.calculate())

--- a/src/openzaak/components/zaken/tests/test_brondatum.py
+++ b/src/openzaak/components/zaken/tests/test_brondatum.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2025 Dimpact
 from datetime import datetime
 
 from django.test import TestCase

--- a/src/openzaak/components/zaken/tests/test_hoofdzaak_afsluiting.py
+++ b/src/openzaak/components/zaken/tests/test_hoofdzaak_afsluiting.py
@@ -779,11 +779,3 @@ class HoofdzaakAfsluitingTests(JWTAuthMixin, APITestCase):
         self.assertEqual(
             self.zaak.startdatum_bewaartermijn, date(2024, 4, 5)
         )  # afgehandeld == eind_datum
-
-        self.assertEqual(deelzaak.archiefnominatie, Archiefnominatie.vernietigen)
-        self.assertIsNone(deelzaak.zaak.archiefactiedatum)
-        self.assertIsNone(deelzaak.startdatum_bewaartermijn)
-
-        self.assertEqual(ext_deelzaak.archiefnominatie, Archiefnominatie.vernietigen)
-        self.assertIsNone(ext_deelzaak.zaak.archiefactiedatum)
-        self.assertIsNone(ext_deelzaak.startdatum_bewaartermijn)

--- a/src/openzaak/components/zaken/tests/test_hoofdzaak_afsluiting.py
+++ b/src/openzaak/components/zaken/tests/test_hoofdzaak_afsluiting.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2025 Dimpact
+from datetime import date
+
 from django.test import override_settings, tag
 
 import requests_mock
@@ -142,6 +144,59 @@ class HoofdzaakAfsluitingTests(JWTAuthMixin, APITestCase):
         # the same between running whole test class & tests separately.
         OpenIDConnectConfig.clear_cache()
         OutgoingRequestsLogConfig.clear_cache()
+
+    def test_deelzaak(self):
+        deelzaak = ZaakFactory.create(zaaktype=self.int_zaaktype, hoofdzaak=self.zaak)
+
+        ResultaatFactory.create(
+            zaak=deelzaak,
+            resultaattype=ResultaatTypeFactory.create(
+                zaaktype=self.int_zaaktype,
+                archiefactietermijn=relativedelta(years=10),
+                archiefnominatie=Archiefnominatie.vernietigen,
+                brondatum_archiefprocedure_afleidingswijze=BrondatumArchiefprocedureAfleidingswijze.hoofdzaak,
+            ),
+        )
+
+        deelzaak_url = reverse("zaak-detail", kwargs={"uuid": deelzaak.uuid})
+
+        with self.subTest("close deelzaak"):
+            response = self.client.post(
+                self.status_list_url,
+                {
+                    "zaak": deelzaak_url,
+                    "statustype": f"http://testserver{self.int_statustype2_url}",
+                    "datumStatusGezet": utcdatetime(
+                        2018, 10, 22, 16, 00, 00
+                    ).isoformat(),
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+            deelzaak.refresh_from_db()
+
+            self.assertEqual(deelzaak.archiefnominatie, Archiefnominatie.vernietigen)
+            self.assertIsNone(deelzaak.archiefactiedatum)
+            self.assertIsNone(deelzaak.startdatum_bewaartermijn)
+
+        with self.subTest("reopen deelzaak"):
+            response = self.client.post(
+                self.status_list_url,
+                {
+                    "zaak": deelzaak_url,
+                    "statustype": f"http://testserver{self.int_statustype1_url}",
+                    "datumStatusGezet": utcdatetime(
+                        2018, 10, 25, 16, 00, 00
+                    ).isoformat(),
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+            deelzaak.refresh_from_db()
+
+            self.assertIsNone(deelzaak.archiefnominatie)
+            self.assertIsNone(deelzaak.archiefactiedatum)
+            self.assertIsNone(deelzaak.startdatum_bewaartermijn)
 
     def test_validation_with_internal_deelzaak_catalogi(self):
         deelzaak = ZaakFactory.create(zaaktype=self.int_zaaktype, hoofdzaak=self.zaak)
@@ -649,3 +704,86 @@ class HoofdzaakAfsluitingTests(JWTAuthMixin, APITestCase):
                 },
             )
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    @tag("external-urls")
+    @override_settings(ALLOWED_HOSTS=["testserver"])
+    def test_close_and_reopen_hoofdzaak(self):
+        deelzaak = ZaakFactory.create(zaaktype=self.int_zaaktype, hoofdzaak=self.zaak)
+        ext_deelzaak = ZaakFactory.create(
+            zaaktype=self.ext_zaaktype, hoofdzaak=self.zaak
+        )
+
+        ResultaatFactory.create(
+            zaak=deelzaak,
+            resultaattype=ResultaatTypeFactory.create(
+                zaaktype=self.int_zaaktype,
+                archiefactietermijn=relativedelta(years=20),
+                archiefnominatie=Archiefnominatie.vernietigen,
+                brondatum_archiefprocedure_afleidingswijze=BrondatumArchiefprocedureAfleidingswijze.hoofdzaak,
+            ),
+        )
+        ResultaatFactory.create(
+            zaak=ext_deelzaak, resultaattype=self.ext_resultaattype1
+        )
+
+        # close deelzaak
+        response = self.client.post(
+            self.status_list_url,
+            {
+                "zaak": reverse("zaak-detail", kwargs={"uuid": deelzaak.uuid}),
+                "statustype": f"http://testserver{self.int_statustype2_url}",
+                "datumStatusGezet": utcdatetime(2024, 4, 5).isoformat(),
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # close ext deelzaak
+        response = self.client.post(
+            self.status_list_url,
+            {
+                "zaak": reverse("zaak-detail", kwargs={"uuid": ext_deelzaak.uuid}),
+                "statustype": self.ext_statustype2,
+                "datumStatusGezet": utcdatetime(2024, 4, 6).isoformat(),
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # close hoofdzaak
+        response = self.client.post(
+            self.status_list_url,
+            {
+                "zaak": self.zaak_url,
+                "statustype": f"http://testserver{self.int_statustype2_url}",
+                "datumStatusGezet": utcdatetime(2024, 4, 5).isoformat(),
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # reopen hoofdzaak
+        response = self.client.post(
+            self.status_list_url,
+            {
+                "zaak": self.zaak_url,
+                "statustype": f"http://testserver{self.int_statustype1_url}",
+                "datumStatusGezet": utcdatetime(2024, 4, 6).isoformat(),
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        self.zaak.refresh_from_db()
+        deelzaak.refresh_from_db()
+        ext_deelzaak.refresh_from_db()
+
+        self.assertIsNone(self.zaak.archiefnominatie)
+        self.assertIsNone(self.zaak.archiefactiedatum)
+        self.assertEqual(
+            self.zaak.startdatum_bewaartermijn, date(2024, 4, 5)
+        )  # afgehandeld == eind_datum
+
+        self.assertEqual(deelzaak.archiefnominatie, Archiefnominatie.vernietigen)
+        self.assertIsNone(deelzaak.zaak.archiefactiedatum)
+        self.assertIsNone(deelzaak.startdatum_bewaartermijn)
+
+        self.assertEqual(ext_deelzaak.archiefnominatie, Archiefnominatie.vernietigen)
+        self.assertIsNone(ext_deelzaak.zaak.archiefactiedatum)
+        self.assertIsNone(ext_deelzaak.startdatum_bewaartermijn)


### PR DESCRIPTION
Closes #2041

**Changes**
- Fixes issue that caused a 500 error when hoofdzaak with deelzaken changes to non eind status.
- I would like to change the logic so that brondatum_bewaartermijn of the hoofdzaak and the deelzaken fields get reset when the hoofdzaak reopens, see #2072 

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
