### PR TITLE
:arrow_up: Upgrade autopep8 to 2.3.2 to fix Django Silk

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -54,7 +54,7 @@ attrs==21.4.0
     #   glom
     #   jsonschema
     #   requests-cache
-autopep8==1.5.2
+autopep8==2.3.2
     # via django-silk
 babel==2.16.0
     # via


### PR DESCRIPTION
autopep8 v1.5.2 was relying on lib2to3, which was scheduled for removal in Python3.13, though it seems that it effectively did not work anymore with 3.12 either

**Changes**

* Upgrade autopep8 to 2.3.2 to fix Django Silk

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
