### PR TITLE
:heavy_plus_sign: Add psycopg-binary to dependencies

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -30,4 +30,4 @@ drc-cmis
 
 commonground-api-common[setup-configuration, testutils, oas]
 
-psycopg[pool]
+psycopg[pool, binary]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -331,6 +331,8 @@ prompt-toolkit==3.0.31
     # via click-repl
 psycopg==3.2.9
     # via -r requirements/base.in
+psycopg-binary==3.2.9
+    # via psycopg
 psycopg-pool==3.2.6
     # via psycopg
 psycopg2==2.9.9

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -649,6 +649,10 @@ psycopg==3.2.9
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+psycopg-binary==3.2.9
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
 psycopg-pool==3.2.6
     # via
     #   -c requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -775,6 +775,10 @@ psycopg==3.2.9
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+psycopg-binary==3.2.9
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 psycopg-pool==3.2.6
     # via
     #   -c requirements/ci.txt


### PR DESCRIPTION
this package includes optimizations for psycopg, improves performance:

before: https://github.com/open-zaak/open-zaak/actions/runs/15974414199#summary-45053011938
after: https://github.com/open-zaak/open-zaak/actions/runs/15992941551?pr=2087#summary-45109747269

**Changes**

* Add psycopg-binary to dependencies

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
