### PR TITLE
:memo: [#2105] add how versions are defined for catalogi resources

### DIFF
--- a/src/openzaak/components/catalogi/api/filters.py
+++ b/src/openzaak/components/catalogi/api/filters.py
@@ -35,6 +35,11 @@ STATUS_HELP_TEXT = """filter objects depending on their concept status:
 * `concept`: Toon objecten waarvan het attribuut `concept` true is.
 * `definitief`: Toon objecten waarvan het attribuut `concept` false is (standaard).
 """
+STATUS_VERSION_HELP_TEXT = """
+Object versions are based on `{version_field}` field, which means that objects with the same 
+`{version_field}` can be published (and have `definitief` status) only if they have 
+non-overlapping validity (geldigheids) dates.
+"""
 DATUM_GELDIGHEID_HELP_TEXT = "filter objecten op hun geldigheids datum."
 
 
@@ -198,7 +203,8 @@ class ZaakTypeFilter(FilterSet):
     status = filters.ChoiceFilter(
         field_name="concept",
         method=status_filter,
-        help_text=STATUS_HELP_TEXT,
+        help_text=STATUS_HELP_TEXT
+        + STATUS_VERSION_HELP_TEXT.format(version_field="identificatie"),
         choices=StatusChoices.choices,
     )
     trefwoorden = CharArrayFilter(field_name="trefwoorden", lookup_expr="contains")
@@ -222,7 +228,8 @@ class InformatieObjectTypeFilter(FilterSet):
     status = filters.ChoiceFilter(
         field_name="concept",
         method=status_filter,
-        help_text=STATUS_HELP_TEXT,
+        help_text=STATUS_HELP_TEXT
+        + STATUS_VERSION_HELP_TEXT.format(version_field="omschrijving"),
         choices=StatusChoices.choices,
     )
     datum_geldigheid = filters.DateFilter(
@@ -265,7 +272,8 @@ class BesluitTypeFilter(FilterSet):
     status = filters.ChoiceFilter(
         field_name="concept",
         method=status_filter,
-        help_text=STATUS_HELP_TEXT,
+        help_text=STATUS_HELP_TEXT
+        + STATUS_VERSION_HELP_TEXT.format(version_field="omschrijving"),
         choices=StatusChoices.choices,
     )
     datum_geldigheid = filters.DateFilter(

--- a/src/openzaak/components/catalogi/api/filters.py
+++ b/src/openzaak/components/catalogi/api/filters.py
@@ -30,11 +30,11 @@ from ..models import (
 )
 
 # custom filter to show concept and non-concepts
-STATUS_HELP_TEXT = """filter objects depending on their concept status:
+STATUS_HELP_TEXT = _("""filter objects depending on their concept status:
 * `alles`: Toon objecten waarvan het attribuut `concept` true of false is.
 * `concept`: Toon objecten waarvan het attribuut `concept` true is.
 * `definitief`: Toon objecten waarvan het attribuut `concept` false is (standaard).
-"""
+""")
 STATUS_VERSION_HELP_TEXT = _("""Object versions are based on `{version_field}` field, which means that objects with the same 
 `{version_field}` can be published (and have `definitief` status) only if they have 
 non-overlapping validity (geldigheids) dates.

--- a/src/openzaak/components/catalogi/api/filters.py
+++ b/src/openzaak/components/catalogi/api/filters.py
@@ -35,8 +35,8 @@ STATUS_HELP_TEXT = _("""filter objects depending on their concept status:
 * `concept`: Toon objecten waarvan het attribuut `concept` true is.
 * `definitief`: Toon objecten waarvan het attribuut `concept` false is (standaard).
 """)
-STATUS_VERSION_HELP_TEXT = _("""Object versions are based on `{version_field}` field, which means that objects with the same 
-`{version_field}` can be published (and have `definitief` status) only if they have 
+STATUS_VERSION_HELP_TEXT = _("""Object versions are based on `{version_field}` field, which means that objects with the same
+`{version_field}` can be published (and have `definitief` status) only if they have
 non-overlapping validity (geldigheids) dates.
 """)
 DATUM_GELDIGHEID_HELP_TEXT = "filter objecten op hun geldigheids datum."
@@ -203,6 +203,7 @@ class ZaakTypeFilter(FilterSet):
         field_name="concept",
         method=status_filter,
         help_text=STATUS_HELP_TEXT
+        + "\n"
         + STATUS_VERSION_HELP_TEXT.format(version_field="identificatie"),
         choices=StatusChoices.choices,
     )
@@ -228,6 +229,7 @@ class InformatieObjectTypeFilter(FilterSet):
         field_name="concept",
         method=status_filter,
         help_text=STATUS_HELP_TEXT
+        + "\n"
         + STATUS_VERSION_HELP_TEXT.format(version_field="omschrijving"),
         choices=StatusChoices.choices,
     )
@@ -272,6 +274,7 @@ class BesluitTypeFilter(FilterSet):
         field_name="concept",
         method=status_filter,
         help_text=STATUS_HELP_TEXT
+        + "\n"
         + STATUS_VERSION_HELP_TEXT.format(version_field="omschrijving"),
         choices=StatusChoices.choices,
     )

--- a/src/openzaak/components/catalogi/api/filters.py
+++ b/src/openzaak/components/catalogi/api/filters.py
@@ -35,11 +35,10 @@ STATUS_HELP_TEXT = """filter objects depending on their concept status:
 * `concept`: Toon objecten waarvan het attribuut `concept` true is.
 * `definitief`: Toon objecten waarvan het attribuut `concept` false is (standaard).
 """
-STATUS_VERSION_HELP_TEXT = """
-Object versions are based on `{version_field}` field, which means that objects with the same 
+STATUS_VERSION_HELP_TEXT = _("""Object versions are based on `{version_field}` field, which means that objects with the same 
 `{version_field}` can be published (and have `definitief` status) only if they have 
 non-overlapping validity (geldigheids) dates.
-"""
+""")
 DATUM_GELDIGHEID_HELP_TEXT = "filter objecten op hun geldigheids datum."
 
 

--- a/src/openzaak/components/catalogi/openapi.yaml
+++ b/src/openzaak/components/catalogi/openapi.yaml
@@ -171,13 +171,14 @@ paths:
           - alles
           - concept
           - definitief
-        description: |+
-          filter objects depending on their concept status:
-          * `alles`: Toon objecten waarvan het attribuut `concept` true of false is.
-          * `concept`: Toon objecten waarvan het attribuut `concept` true is.
-          * `definitief`: Toon objecten waarvan het attribuut `concept` false is (standaard).
-
-
+        description: "filter objects depending on their concept status:\n* `alles`:\
+          \ Toon objecten waarvan het attribuut `concept` true of false is.\n* `concept`:\
+          \ Toon objecten waarvan het attribuut `concept` true is.\n* `definitief`:\
+          \ Toon objecten waarvan het attribuut `concept` false is (standaard).\n\n\
+          Object versions are based on `omschrijving` field, which means that objects\
+          \ with the same \n`omschrijving` can be published (and have `definitief`\
+          \ status) only if they have \nnon-overlapping validity (geldigheids) dates.\n\
+          \n\n"
       - in: query
         name: zaaktypen
         schema:
@@ -2858,13 +2859,14 @@ paths:
           - alles
           - concept
           - definitief
-        description: |+
-          filter objects depending on their concept status:
-          * `alles`: Toon objecten waarvan het attribuut `concept` true of false is.
-          * `concept`: Toon objecten waarvan het attribuut `concept` true is.
-          * `definitief`: Toon objecten waarvan het attribuut `concept` false is (standaard).
-
-
+        description: "filter objects depending on their concept status:\n* `alles`:\
+          \ Toon objecten waarvan het attribuut `concept` true of false is.\n* `concept`:\
+          \ Toon objecten waarvan het attribuut `concept` true is.\n* `definitief`:\
+          \ Toon objecten waarvan het attribuut `concept` false is (standaard).\n\n\
+          Object versions are based on `omschrijving` field, which means that objects\
+          \ with the same \n`omschrijving` can be published (and have `definitief`\
+          \ status) only if they have \nnon-overlapping validity (geldigheids) dates.\n\
+          \n\n"
       - in: query
         name: zaaktype
         schema:
@@ -9058,13 +9060,14 @@ paths:
           - alles
           - concept
           - definitief
-        description: |+
-          filter objects depending on their concept status:
-          * `alles`: Toon objecten waarvan het attribuut `concept` true of false is.
-          * `concept`: Toon objecten waarvan het attribuut `concept` true is.
-          * `definitief`: Toon objecten waarvan het attribuut `concept` false is (standaard).
-
-
+        description: "filter objects depending on their concept status:\n* `alles`:\
+          \ Toon objecten waarvan het attribuut `concept` true of false is.\n* `concept`:\
+          \ Toon objecten waarvan het attribuut `concept` true is.\n* `definitief`:\
+          \ Toon objecten waarvan het attribuut `concept` false is (standaard).\n\n\
+          Object versions are based on `identificatie` field, which means that objects\
+          \ with the same \n`identificatie` can be published (and have `definitief`\
+          \ status) only if they have \nnon-overlapping validity (geldigheids) dates.\n\
+          \n\n"
       - in: query
         name: trefwoorden
         schema:

--- a/src/openzaak/components/catalogi/openapi.yaml
+++ b/src/openzaak/components/catalogi/openapi.yaml
@@ -174,7 +174,7 @@ paths:
         description: "filter objects depending on their concept status:\n* `alles`:\
           \ Toon objecten waarvan het attribuut `concept` true of false is.\n* `concept`:\
           \ Toon objecten waarvan het attribuut `concept` true is.\n* `definitief`:\
-          \ Toon objecten waarvan het attribuut `concept` false is (standaard).\n\n\
+          \ Toon objecten waarvan het attribuut `concept` false is (standaard).\n\
           Object versions are based on `omschrijving` field, which means that objects\
           \ with the same \n`omschrijving` can be published (and have `definitief`\
           \ status) only if they have \nnon-overlapping validity (geldigheids) dates.\n\
@@ -2862,7 +2862,7 @@ paths:
         description: "filter objects depending on their concept status:\n* `alles`:\
           \ Toon objecten waarvan het attribuut `concept` true of false is.\n* `concept`:\
           \ Toon objecten waarvan het attribuut `concept` true is.\n* `definitief`:\
-          \ Toon objecten waarvan het attribuut `concept` false is (standaard).\n\n\
+          \ Toon objecten waarvan het attribuut `concept` false is (standaard).\n\
           Object versions are based on `omschrijving` field, which means that objects\
           \ with the same \n`omschrijving` can be published (and have `definitief`\
           \ status) only if they have \nnon-overlapping validity (geldigheids) dates.\n\
@@ -9063,7 +9063,7 @@ paths:
         description: "filter objects depending on their concept status:\n* `alles`:\
           \ Toon objecten waarvan het attribuut `concept` true of false is.\n* `concept`:\
           \ Toon objecten waarvan het attribuut `concept` true is.\n* `definitief`:\
-          \ Toon objecten waarvan het attribuut `concept` false is (standaard).\n\n\
+          \ Toon objecten waarvan het attribuut `concept` false is (standaard).\n\
           Object versions are based on `identificatie` field, which means that objects\
           \ with the same \n`identificatie` can be published (and have `definitief`\
           \ status) only if they have \nnon-overlapping validity (geldigheids) dates.\n\


### PR DESCRIPTION
Closes #2105

**Changes**

changed description of `status` query param for ZaakType, InformatieObjectType and BesluitType in the Catalogi OAS

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
