### PR TITLE
Feature/1946 mogelijkheid tot filteren status van zaken endpoint in api

### DIFF
--- a/docs/api/experimental.rst
+++ b/docs/api/experimental.rst
@@ -155,6 +155,9 @@ Query parameters
 * ``/api/v1/roltypen`` endpoint. Added new parameters:
     * ``omschrijving`` - filter by (a part of the) ``omschrijving`` (case-insensitive match).
 
+* ``/api/v1/zaken`` endpoint. Added new parameters:
+     * ``status__statustype`` – filter Zaken by the current status that has the given statustype. Accepts a statustype URL.
+     * ``resultaat__resultaattype`` – filter Zaken by the result with the specified resultaattype. Accepts a resultaattype URL.
 
 
 Besluiten API

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -7441,6 +7441,11 @@ paths:
           geregistreerd. Indien deze niet opgegeven wordt, wordt de datum van vandaag
           gebruikt.
       - in: query
+        name: resultaat__resultaattype
+        schema:
+          type: string
+        description: '**EXPERIMENTEEL** Filter Zaken with this resultaattype (URL).'
+      - in: query
         name: rol__betrokkene
         schema:
           type: string
@@ -7608,6 +7613,12 @@ paths:
           type: string
           format: date
         description: De datum waarop met de uitvoering van de zaak is gestart
+      - in: query
+        name: status__statustype
+        schema:
+          type: string
+        description: '**EXPERIMENTEEL** Filter Zaken waarbij de huidige status het
+          opgegeven statustype (URL) heeft.'
       - in: query
         name: uiterlijkeEinddatumAfdoening
         schema:
@@ -11157,6 +11168,11 @@ paths:
           geregistreerd. Indien deze niet opgegeven wordt, wordt de datum van vandaag
           gebruikt.
       - in: query
+        name: resultaat__resultaattype
+        schema:
+          type: string
+        description: '**EXPERIMENTEEL** Filter Zaken with this resultaattype (URL).'
+      - in: query
         name: rol__betrokkene
         schema:
           type: string
@@ -11324,6 +11340,12 @@ paths:
           type: string
           format: date
         description: De datum waarop met de uitvoering van de zaak is gestart
+      - in: query
+        name: status__statustype
+        schema:
+          type: string
+        description: '**EXPERIMENTEEL** Filter Zaken waarbij de huidige status het
+          opgegeven statustype (URL) heeft.'
       - in: query
         name: uiterlijkeEinddatumAfdoening
         schema:
@@ -11588,6 +11610,14 @@ paths:
                   description: '**EXPERIMENTEEL** Omschrijving van de aard van ZAAKen
                     van het ZAAKTYPE(bevat de zaaktype omschrijving de gegeven waarden
                     (hoofdletterongevoelig))'
+                status__statustype:
+                  type: string
+                  description: '**EXPERIMENTEEL** Filter Zaken waarbij de huidige
+                    status het opgegeven statustype (URL) heeft.'
+                resultaat__resultaattype:
+                  type: string
+                  description: '**EXPERIMENTEEL** Filter Zaken with this resultaattype
+                    (URL).'
                 maximaleVertrouwelijkheidaanduiding:
                   type: string
                   enum:

--- a/src/openzaak/components/zaken/tests/test_filters.py
+++ b/src/openzaak/components/zaken/tests/test_filters.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
-from django.test import tag
+from datetime import datetime
+
+from django.test import override_settings, tag
+from django.utils import timezone
 
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -13,6 +16,7 @@ from vng_api_common.tests import get_validation_errors, reverse
 
 from openzaak.tests.utils import JWTAuthMixin
 
+from ...catalogi.tests.factories import ResultaatTypeFactory, StatusTypeFactory
 from ..models import Resultaat, Rol, Status, Zaak, ZaakInformatieObject, ZaakObject
 from .factories import (
     ResultaatFactory,
@@ -164,6 +168,7 @@ class ZaakObjectFilterTests(JWTAuthMixin, APITestCase):
                 )
 
 
+@override_settings(ALLOWED_HOSTS=["testserver", "openzaak.nl"])
 class ZaakFilterTests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
 
@@ -327,3 +332,155 @@ class ZaakFilterTests(JWTAuthMixin, APITestCase):
             response, "rol__betrokkeneIdentificatie__medewerker__identificatie"
         )
         self.assertEqual(error["code"], "max_length")
+
+    def test_filter_zaken_by_current_status_statustype_exists(self):
+        statustype_target = StatusTypeFactory.create()
+        statustype_old = StatusTypeFactory.create()
+        statustype_other = StatusTypeFactory.create()
+
+        zaak_a = ZaakFactory.create()
+        StatusFactory.create(
+            zaak=zaak_a,
+            datum_status_gezet=timezone.make_aware(datetime(2023, 1, 1)),
+            statustype=statustype_old,
+        )
+        StatusFactory.create(
+            zaak=zaak_a,
+            datum_status_gezet=timezone.make_aware(datetime(2024, 1, 1)),
+            statustype=statustype_target,
+        )
+
+        zaak_b = ZaakFactory.create()
+        StatusFactory.create(
+            zaak=zaak_b,
+            datum_status_gezet=timezone.make_aware(datetime(2024, 7, 7)),
+            statustype=statustype_other,
+        )
+
+        StatusFactory.create(
+            zaak=zaak_b,
+            datum_status_gezet=timezone.make_aware(datetime(2022, 2, 1)),
+            statustype=statustype_target,
+        )
+
+        zaak_c = ZaakFactory.create()
+
+        url = reverse("zaak-list")
+        response = self.client.get(
+            url,
+            {"status__statustype": f"http://openzaak.nl{reverse(statustype_target)}"},
+            headers={"host": "openzaak.nl"},
+            **ZAAK_READ_KWARGS,
+        )
+
+        results = response.json().get("results", [])
+
+        result_ids = {zaak["uuid"] for zaak in results}
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(str(zaak_a.uuid), result_ids)
+        self.assertNotIn(str(zaak_b.uuid), result_ids)
+        self.assertNotIn(str(zaak_c.uuid), result_ids)
+
+    def test_filter_zaken_by_current_status_statustype_does_not_exist(self):
+        zaak = ZaakFactory.create()
+        StatusFactory.create(
+            zaak=zaak,
+            datum_status_gezet=timezone.make_aware(datetime(2024, 1, 1)),
+            statustype=StatusTypeFactory.create(),
+        )
+
+        statustype = StatusTypeFactory.create()
+
+        url = reverse("zaak-list")
+
+        response = self.client.get(
+            url,
+            {"status__statustype": f"http://openzaak.nl{reverse(statustype)}"},
+            headers={"host": "openzaak.nl"},
+            **ZAAK_READ_KWARGS,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json().get("results"), [])
+
+    def test_filter_zaken_by_current_resultaat_resultaattype_exists(self):
+        rt_target = ResultaatTypeFactory.create()
+        rt_other = ResultaatTypeFactory.create()
+
+        zaak_a = ZaakFactory.create()
+        ResultaatFactory.create(
+            zaak=zaak_a,
+            resultaattype=rt_target,
+        )
+
+        zaak_b = ZaakFactory.create()
+        ResultaatFactory.create(
+            zaak=zaak_b,
+            resultaattype=rt_other,
+        )
+
+        zaak_c = ZaakFactory.create()
+
+        url = reverse("zaak-list")
+        response = self.client.get(
+            url,
+            {"resultaat__resultaattype": f"http://openzaak.nl{reverse(rt_target)}"},
+            headers={"host": "openzaak.nl"},
+            **ZAAK_READ_KWARGS,
+        )
+
+        results = response.json().get("results", [])
+        result_ids = {zaak["uuid"] for zaak in results}
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(str(zaak_a.uuid), result_ids)
+        self.assertNotIn(str(zaak_b.uuid), result_ids)
+        self.assertNotIn(str(zaak_c.uuid), result_ids)
+
+    def test_filter_status_statustype_invalid_url(self):
+        response = self.client.get(
+            reverse("zaak-list"),
+            {"status__statustype": "not-a-valid-url"},
+            **ZAAK_READ_KWARGS,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "status__statustype")
+        self.assertEqual(error["code"], "invalid")
+
+    def test_resultaattype_filter_with_invalid_url_returns_empty_queryset(self):
+        invalid_resultaattype_url = "http://openzaak.nl/api/v1/resultaattypen/99999999-aaaa-bbbb-cccc-deadbeefdead/"
+
+        response = self.client.get(
+            reverse("zaak-list"),
+            {"resultaat__resultaattype": invalid_resultaattype_url},
+            **ZAAK_READ_KWARGS,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+    def test_filter_current_status_statustype_invalid_url_returns_none(self):
+        statustype = StatusTypeFactory.create()
+        zaak = ZaakFactory.create()
+        StatusFactory.create(
+            zaak=zaak,
+            statustype=statustype,
+            datum_status_gezet=timezone.make_aware(datetime(2024, 1, 1)),
+        )
+
+        invalid_url = (
+            "http://openzaak.nl/api/v1/statustypen/99999999-9999-9999-9999-999999999999"
+        )
+
+        response = self.client.get(
+            reverse("zaak-list"),
+            {"status__statustype": invalid_url},
+            headers={"host": "openzaak.nl"},
+            **ZAAK_READ_KWARGS,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)


### PR DESCRIPTION
Closes #1946

**Changes**

 - Add filter to /zaken called status__statustype (show all Zaken for which the current Status has statustype X) (marked as experimental)
- Add filter to /zaken called resultaat__resultaattype (show all Zaken for which the current Resultaat has resultaattype X) (marked as experimental)

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [ ] Any experimental features added in this PR are backwards compatible
  - [ ] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how
