### PR TITLE
:wrench: Add envvar to disable server side cursors

### DIFF
--- a/docs/installation/config/env_config.rst
+++ b/docs/installation/config/env_config.rst
@@ -42,6 +42,7 @@ Database
 * ``DB_POOL_MAX_IDLE``: Maximum time, in seconds, that a connection can stay unused in the pool before being closed, and the pool shrunk. This only happens to connections more than min_size, if max_size allowed the pool to grow. Defaults to: ``600``.
 * ``DB_POOL_RECONNECT_TIMEOUT``: Maximum time, in seconds, the pool will try to create a connection. If a connection attempt fails, the pool will try to reconnect a few times, using an exponential backoff and some random factor to avoid mass attempts. If repeated attempts fail, after reconnect_timeout second the connection attempt is aborted and the reconnect_failed() callback invoked. Defaults to: ``300``.
 * ``DB_POOL_NUM_WORKERS``: Number of background worker threads used to maintain the pool state. Background workers are used for example to create new connections and to clean up connections when they are returned to the pool. Defaults to: ``3``.
+* ``DB_DISABLE_SERVER_SIDE_CURSORS``: Whether or not server side cursors should be disabled for Postgres connections. Setting this to true is required when using a connection pooler in transaction mode (like PgBouncer). **WARNING:** the effect of disabling server side cursors on performance has not been thoroughly tested yet. Defaults to: ``False``.
 
 
 Logging

--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -32,6 +32,20 @@ if SENTRY_DSN:
 #
 # DATABASE and CACHING setup
 #
+
+DATABASES["default"]["DISABLE_SERVER_SIDE_CURSORS"] = config(
+    "DB_DISABLE_SERVER_SIDE_CURSORS",
+    False,
+    help_text=(
+        "Whether or not server side cursors should be disabled for Postgres connections. "
+        "Setting this to true is required when using a connection pooler in "
+        "transaction mode (like PgBouncer). "
+        "**WARNING:** the effect of disabling server side cursors on performance has not "
+        "been thoroughly tested yet."
+    ),
+    group="Database",
+)
+
 # Define this variable here to ensure it shows up in the envvar documentation
 DATABASES["default"]["ENGINE"] = "django.contrib.gis.db.backends.postgis"
 


### PR DESCRIPTION
to make sure Open Zaak can be used with pgbouncer

Related issue: https://github.com/maykinmedia/open-api-framework/issues/171

**Changes**

* Add envvar to disable server side cursors

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
