### PR TITLE
:arrow_up: [maykinmedia/open-api-framework#128] upgrade celery to 5.5.3 and kombu to 5.5.4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ attrs==21.4.0
     #   glom
     #   jsonschema
     #   requests-cache
-billiard==4.2.0
+billiard==4.2.1
     # via celery
 bleach==6.1.0
     # via open-api-framework
@@ -35,7 +35,7 @@ cattrs==23.1.2
     # via requests-cache
 cbor2==5.6.3
     # via webauthn
-celery==5.4.0
+celery==5.5.3
     # via
     #   django-celery-beat
     #   django-structlog
@@ -297,7 +297,7 @@ jsonschema==4.7.2
     # via
     #   -r requirements/base.in
     #   drf-spectacular
-kombu==5.4.0
+kombu==5.5.4
     # via celery
 markdown==3.3.6
     # via -r requirements/base.in
@@ -318,7 +318,9 @@ orderedmultidict==1.0.1
 oyaml==1.0
     # via commonground-api-common
 packaging==24.0
-    # via redis
+    # via
+    #   kombu
+    #   redis
 phonenumberslite==8.13.35
     # via django-two-factor-auth
 platformdirs==4.3.8
@@ -443,10 +445,10 @@ typing-extensions==4.12.2
     #   qrcode
     #   zgw-consumers
     #   zgw-consumers-oas
-tzdata==2024.1
+tzdata==2025.2
     # via
-    #   celery
     #   django-celery-beat
+    #   kombu
 uritemplate==4.1.1
     # via
     #   coreapi

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -44,7 +44,7 @@ babel==2.16.0
     # via sphinx
 beautifulsoup4==4.10.0
     # via webtest
-billiard==4.2.0
+billiard==4.2.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -69,7 +69,7 @@ cbor2==5.6.3
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   webauthn
-celery==5.4.0
+celery==5.5.3
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -550,7 +550,7 @@ jsonschema==4.7.2
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   drf-spectacular
-kombu==5.4.0
+kombu==5.5.4
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -607,6 +607,7 @@ packaging==24.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   kombu
     #   pytest
     #   redis
     #   sphinx
@@ -904,12 +905,12 @@ typing-extensions==4.12.2
     #   qrcode
     #   zgw-consumers
     #   zgw-consumers-oas
-tzdata==2024.1
+tzdata==2025.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   celery
     #   django-celery-beat
+    #   kombu
 uritemplate==4.1.1
     # via
     #   -c requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -61,7 +61,7 @@ beautifulsoup4==4.10.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   webtest
-billiard==4.2.0
+billiard==4.2.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -94,7 +94,7 @@ cbor2==5.6.3
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   webauthn
-celery==5.4.0
+celery==5.5.3
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -638,7 +638,7 @@ jsonschema==4.7.2
     #   -r requirements/ci.txt
     #   drf-spectacular
     #   kubernetes-validate
-kombu==5.4.0
+kombu==5.5.4
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -717,6 +717,7 @@ packaging==24.0
     #   -r requirements/ci.txt
     #   ansible-core
     #   build
+    #   kombu
     #   pytest
     #   redis
     #   sphinx
@@ -1131,12 +1132,12 @@ typing-extensions==4.12.2
     #   rich-click
     #   zgw-consumers
     #   zgw-consumers-oas
-tzdata==2024.1
+tzdata==2025.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   celery
     #   django-celery-beat
+    #   kombu
 uritemplate==4.1.1
     # via
     #   -c requirements/ci.txt


### PR DESCRIPTION
Closes https://github.com/maykinmedia/open-api-framework/issues/128

**Changes**

- upgrades celery to 5.5.3
- upgrades kombu to 5.5.4

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
