### PR TITLE
Adhere to NRC specification when sending test notification

### DIFF
--- a/src/openzaak/management/commands/send_test_notification.py
+++ b/src/openzaak/management/commands/send_test_notification.py
@@ -48,7 +48,7 @@ class Command(BaseCommand):
         }
 
         try:
-            nrc_client.request(url="notificaties", method="POST", data=data)
+            nrc_client.request(url="notificaties", method="POST", json=data)
             self.stdout.write(
                 self.style.SUCCESS(
                     f"Notification successfully sent to {nrc_client.base_url}"


### PR DESCRIPTION
Closes #...

**Changes**

When sending a test notification, I noticed that it was sent as `applicaton/x-www-form-urlencoded`, which does not match the NRC API specification. The [real implementation](https://github.com/maykinmedia/notifications-api-common/blob/cc982d6aa1159a4ea5ed9b7ae323816e11cd90cb/notifications_api_common/tasks.py#L29) in `notifications-api-common` does send it properly as json so this change aligns the test notification to be the same.

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
