### PR TITLE
chore: fixed spelling mistake and added missing space in `deelzaken-not-closed` error message

### DIFF
--- a/src/openzaak/components/zaken/api/validators.py
+++ b/src/openzaak/components/zaken/api/validators.py
@@ -323,7 +323,7 @@ class EndStatusDeelZakenValidator:
 
     code = "deelzaken-not-closed"
     message = _(
-        "Er zijn gerelateerde deelzaken die nog niet zijn afgesloten zijn."
+        "Er zijn gerelateerde deelzaken die nog niet afgesloten zijn. "
         "Deze deelzaken moeten eerst afgesloten worden voordat de zaak afgesloten kan worden."
     )
 


### PR DESCRIPTION


Closes #2151 

**Changes**

Fixed spelling mistake and added missing space in the `deelzaken-not-closed` error message.

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
