### PR TITLE
:sparkles: [#2161] Add option to generate natuurlijkpersonen with generate_data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,9 @@ jobs:
           uv pip install --system -r requirements/ci.txt
           src/manage.py migrate
           SCRIPTPATH=bin UWSGI_PROCESSES=4 UWSGI_THREADS=4 bin/docker_start.sh &
-          echo "yes" | src/manage.py generate_data --zaken=3500 --generate-superuser-credentials --generate-non-superuser-credentials --without-zaakgeometrie
+          echo "yes" | src/manage.py generate_data \
+                       --zaken=3500 --generate-superuser-credentials --generate-non-superuser-credentials \
+                       --without-zaakgeometrie --generate-natuurlijk-personen 000000000:100 111222333:1000
         env:
           RUN_SETUP_CONFIG: false
           DB_PASSWORD: ""

--- a/src/openzaak/components/zaken/tests/factories.py
+++ b/src/openzaak/components/zaken/tests/factories.py
@@ -132,6 +132,13 @@ class RolFactory(FkOrServiceUrlFactoryMixin, factory.django.DjangoModelFactory):
         )
 
 
+class NatuurlijkPersoonFactory(factory.django.DjangoModelFactory):
+    rol = factory.SubFactory(RolFactory)
+
+    class Meta:
+        model = "zaken.NatuurlijkPersoon"
+
+
 class StatusFactory(FkOrServiceUrlFactoryMixin, factory.django.DjangoModelFactory):
     zaak = factory.SubFactory(ZaakFactory)
     statustype = factory.SubFactory(StatusTypeFactory)


### PR DESCRIPTION
Closes #2161 partially

TODO:
- [ ] tests
- [ ] update perftests

**Changes**

* Add option to generate natuurlijkpersonen with generate_data
* Filter by BSN in performance tests

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [ ] Any experimental features added in this PR are backwards compatible
  - [ ] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how
