### PR TITLE
:recycle:  [maykinmedia/open-api-framework#172] clean up unneeded mock_service_oas_get calls

### DIFF
--- a/src/openzaak/components/besluiten/tests/test_audittrails_cmis.py
+++ b/src/openzaak/components/besluiten/tests/test_audittrails_cmis.py
@@ -7,7 +7,6 @@ from vng_api_common.audittrails.models import AuditTrail
 from vng_api_common.tests import reverse
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.test.factories import ServiceFactory
-from zgw_consumers_oas.mocks import mock_service_oas_get
 
 from openzaak.components.catalogi.tests.factories import BesluitTypeFactory
 from openzaak.components.documenten.tests.factories import (
@@ -52,9 +51,6 @@ class AuditTrailCMISTests(JWTAuthMixin, APICMISTestCase):
             label="external besluiten",
             auth_type=AuthTypes.no_auth,
         )
-        mock_service_oas_get(self.adapter, base_zaak, APITypes.zrc)
-        mock_service_oas_get(self.adapter, base_zaaktype, APITypes.ztc)
-        mock_service_oas_get(self.adapter, base_besluit, APITypes.brc)
 
         zaak = ZaakFactory.create(zaaktype__concept=False)
 

--- a/src/openzaak/components/besluiten/tests/test_besluit_with_external_zaak.py
+++ b/src/openzaak/components/besluiten/tests/test_besluit_with_external_zaak.py
@@ -10,7 +10,6 @@ from rest_framework.test import APITestCase
 from vng_api_common.tests import TypeCheckMixin, get_validation_errors, reverse
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.test.factories import ServiceFactory
-from zgw_consumers_oas.mocks import mock_service_oas_get
 
 from openzaak.components.catalogi.tests.factories import (
     BesluitTypeFactory,
@@ -77,7 +76,6 @@ class BesluitCreateExternalZaakTests(TypeCheckMixin, JWTAuthMixin, APITestCase):
         url = get_operation_url("besluit_create")
 
         with requests_mock.Mocker() as m:
-            mock_service_oas_get(m, self.base, APITypes.zrc)
             m.get(zaak, json=get_zaak_response(zaak, zaaktype_url))
             m.post(f"{zaak}/besluiten", json=zaakbesluit_data, status_code=201)
 
@@ -121,7 +119,6 @@ class BesluitCreateExternalZaakTests(TypeCheckMixin, JWTAuthMixin, APITestCase):
         url = get_operation_url("besluit_create")
 
         with requests_mock.Mocker() as m:
-            mock_service_oas_get(m, self.base, APITypes.zrc)
             m.get(zaak, json=get_zaak_response(zaak, zaaktype_url))
             m.post(f"{zaak}/besluiten", status_code=404, text="Not Found")
 
@@ -160,7 +157,6 @@ class BesluitCreateExternalZaakTests(TypeCheckMixin, JWTAuthMixin, APITestCase):
         besluit_url = f"http://testserver{reverse(besluit)}"
 
         with requests_mock.Mocker() as m:
-            mock_service_oas_get(m, self.base, APITypes.zrc)
             m.get(zaak_old, json=get_zaak_response(zaak_old, zaaktype_url))
             m.get(zaak_new, json=get_zaak_response(zaak_new, zaaktype_url))
             m.delete(old_zaakbesluit_url, status_code=204)
@@ -204,7 +200,6 @@ class BesluitCreateExternalZaakTests(TypeCheckMixin, JWTAuthMixin, APITestCase):
         besluit_url = f"http://testserver{reverse(besluit)}"
 
         with requests_mock.Mocker() as m:
-            mock_service_oas_get(m, self.base, APITypes.zrc)
             m.get(zaak_old, json=get_zaak_response(zaak_old, zaaktype_url))
             m.get(zaak_new, json=get_zaak_response(zaak_new, zaaktype_url))
             m.delete(old_zaakbesluit_url, status_code=404, text="not found")
@@ -228,7 +223,6 @@ class BesluitCreateExternalZaakTests(TypeCheckMixin, JWTAuthMixin, APITestCase):
         zaaktype_url = f"http://testserver{reverse(zaaktype)}"
 
         with requests_mock.Mocker() as m:
-            mock_service_oas_get(m, self.base, APITypes.zrc)
             m.get(zaak, json=get_zaak_response(zaak, zaaktype_url))
             m.delete(zaakbesluit_url, status_code=204)
 
@@ -255,7 +249,6 @@ class BesluitCreateExternalZaakTests(TypeCheckMixin, JWTAuthMixin, APITestCase):
         zaaktype_url = f"http://testserver{reverse(zaaktype)}"
 
         with requests_mock.Mocker() as m:
-            mock_service_oas_get(m, self.base, APITypes.zrc)
             m.get(zaak, json=get_zaak_response(zaak, zaaktype_url))
             m.delete(zaakbesluit_url, status_code=404, text="Not found")
 

--- a/src/openzaak/components/besluiten/tests/test_besluitinformatieobjecten.py
+++ b/src/openzaak/components/besluiten/tests/test_besluitinformatieobjecten.py
@@ -13,7 +13,6 @@ from rest_framework.test import APITestCase, APITransactionTestCase
 from vng_api_common.tests import get_validation_errors, reverse, reverse_lazy
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.test.factories import ServiceFactory
-from zgw_consumers_oas.mocks import mock_service_oas_get
 
 from openzaak.components.catalogi.tests.factories import InformatieObjectTypeFactory
 from openzaak.components.documenten.models import ObjectInformatieObject
@@ -652,7 +651,6 @@ class ExternalDocumentDestroyTests(JWTAuthMixin, APITestCase):
         informatieobjecttype = InformatieObjectTypeFactory.create()
 
         with requests_mock.Mocker() as m:
-            mock_service_oas_get(m, self.base, APITypes.drc)
             m.get(
                 self.document,
                 json=get_eio_response(
@@ -687,7 +685,6 @@ class ExternalDocumentDestroyTests(JWTAuthMixin, APITestCase):
         informatieobjecttype = InformatieObjectTypeFactory.create()
 
         with requests_mock.Mocker() as m:
-            mock_service_oas_get(m, self.base, APITypes.drc)
             m.get(
                 self.document,
                 json=get_eio_response(

--- a/src/openzaak/components/documenten/tests/test_cmis_url_mapping.py
+++ b/src/openzaak/components/documenten/tests/test_cmis_url_mapping.py
@@ -15,7 +15,6 @@ from rest_framework import status
 from vng_api_common.tests import reverse
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.test.factories import ServiceFactory
-from zgw_consumers_oas.mocks import mock_service_oas_get
 
 from openzaak.components.catalogi.tests.factories import InformatieObjectTypeFactory
 from openzaak.tests.utils import APICMISTestCase, JWTAuthMixin, require_cmis
@@ -254,10 +253,6 @@ class URLMappingAPITests(JWTAuthMixin, APICMISTestCase):
         zaaktype = "https://externe.catalogus.nl/api/v1/zaaktypen/b71f72ef-198d-44d8-af64-ae1932df830a"
         catalogus = "https://externe.catalogus.nl/api/v1/catalogussen/5c4c492b-3548-4258-b17f-0e2e31dcfe25"
 
-        mock_service_oas_get(
-            self.adapter, "https://externe.catalogus.nl/api/v1/", APITypes.zrc
-        )
-
         self.adapter.get(zaak, json=get_zaak_response(zaak, zaaktype))
         self.adapter.get(zaaktype, json=get_zaak_response(catalogus, zaaktype))
 
@@ -299,10 +294,6 @@ class URLMappingAPITests(JWTAuthMixin, APICMISTestCase):
         zaak = "https://externe.catalogus.nl/api/v1/zaken/1c8e36be-338c-4c07-ac5e-1adf55bec04a"
         zaaktype = "https://externe.catalogus.nl/api/v1/zaaktypen/b71f72ef-198d-44d8-af64-ae1932df830a"
         catalogus = "https://externe.catalogus.nl/api/v1/catalogussen/5c4c492b-3548-4258-b17f-0e2e31dcfe25"
-
-        mock_service_oas_get(
-            self.adapter, "https://externe.catalogus.nl/api/v1/", APITypes.zrc
-        )
 
         self.adapter.get(zaak, json=get_zaak_response(zaak, zaaktype))
         self.adapter.get(zaaktype, json=get_zaak_response(catalogus, zaaktype))

--- a/src/openzaak/components/documenten/tests/test_objectinformatieobject.py
+++ b/src/openzaak/components/documenten/tests/test_objectinformatieobject.py
@@ -16,7 +16,6 @@ from vng_api_common.tests import (
 )
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.test.factories import ServiceFactory
-from zgw_consumers_oas.mocks import mock_service_oas_get
 
 from openzaak.components.besluiten.tests.factories import (
     BesluitFactory,
@@ -865,7 +864,6 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         )
         url = reverse(oio)
 
-        mock_service_oas_get(m, url=self.zrc_service.api_root, service="zrc")
         m.get(zaak, json=get_zaak_response(zaak, zaaktype))
         m.get(
             f"https://extern.zrc.nl/api/v1/zaakinformatieobjecten?zaak={zaak}&informatieobject={eio_url}",
@@ -888,7 +886,6 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         )
         url = reverse(oio)
 
-        mock_service_oas_get(m, url=self.brc_service.api_root, service="brc")
         m.get(besluit, json=get_besluit_response(besluit, besluittype))
         m.get(
             "https://extern.brc.nl/api/v1/besluitinformatieobjecten"
@@ -914,7 +911,6 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         )
         url = reverse(oio)
 
-        mock_service_oas_get(m, url=self.vrc_service.api_root, service="vrc")
         m.get(verzoek, json=get_verzoek_response(verzoek))
         m.get(
             (furl(self.vrc_service.api_root) / "verzoekinformatieobjecten")
@@ -940,8 +936,6 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APITestCase):
         )
         url = reverse(oio)
 
-        # set up mocks
-        mock_service_oas_get(m, url=self.zrc_service.api_root, service="zrc")
         m.get(zaak, json=get_zaak_response(zaak, zaaktype))
         m.get(
             f"https://extern.zrc.nl/api/v1/zaakinformatieobjecten?zaak={zaak}&informatieobject={eio_url}",

--- a/src/openzaak/components/documenten/tests/test_objectinformatieobject_cmis.py
+++ b/src/openzaak/components/documenten/tests/test_objectinformatieobject_cmis.py
@@ -16,7 +16,6 @@ from vng_api_common.tests import (
 )
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.test.factories import ServiceFactory
-from zgw_consumers_oas.mocks import mock_service_oas_get
 
 from openzaak.components.besluiten.tests.factories import BesluitInformatieObjectFactory
 from openzaak.components.besluiten.tests.utils import (
@@ -445,22 +444,6 @@ class OIOCreateExternalURLsTests(JWTAuthMixin, APICMISTestCase):
                 short_pattern="https://xvrc.nl",
                 config=config,
             )
-
-    def setUp(self):
-        super().setUp()
-
-        mock_service_oas_get(
-            self.adapter, "https://extern.zrc.nl/api/v1/", APITypes.zrc
-        )
-        mock_service_oas_get(
-            self.adapter, "https://externe.catalogus.nl/api/v1/", APITypes.ztc
-        )
-        mock_service_oas_get(
-            self.adapter, "https://extern.brc.nl/api/v1/", APITypes.brc
-        )
-        mock_service_oas_get(
-            self.adapter, "https://extern.vrc.nl/api/v1/", APITypes.vrc
-        )
 
     def test_create_external_zaak(self):
         self.adapter.get(self.zaak, json=get_zaak_response(self.zaak, self.zaaktype))

--- a/src/openzaak/components/zaken/tests/test_audittrails_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_audittrails_cmis.py
@@ -8,7 +8,6 @@ from vng_api_common.constants import VertrouwelijkheidsAanduiding
 from vng_api_common.tests import reverse
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.test.factories import ServiceFactory
-from zgw_consumers_oas.mocks import mock_service_oas_get
 
 from openzaak.components.catalogi.tests.factories import (
     ZaakTypeFactory,
@@ -53,8 +52,6 @@ class AuditTrailCMISTests(JWTAuthMixin, APICMISTestCase):
             api_root="http://testserver/documenten/",
             api_type=APITypes.drc,
         )
-        mock_service_oas_get(self.adapter, base_zaak, APITypes.zrc)
-        mock_service_oas_get(self.adapter, base_zaaktype, APITypes.ztc)
 
         url = reverse(Zaak)
         zaaktype = ZaakTypeFactory.create(concept=False)

--- a/src/openzaak/components/zaken/tests/test_zaak_archive.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_archive.py
@@ -20,7 +20,6 @@ from vng_api_common.constants import (
 from vng_api_common.tests import get_validation_errors, reverse
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.test.factories import ServiceFactory
-from zgw_consumers_oas.mocks import mock_service_oas_get
 
 from openzaak.components.besluiten.tests.factories import BesluitFactory
 from openzaak.components.catalogi.tests.factories import (
@@ -566,7 +565,6 @@ class US345TestCase(JWTAuthMixin, APITestCase):
                 label="BAG",
                 auth_type=AuthTypes.no_auth,
             )
-            mock_service_oas_get(m, api_root, service="empty")
 
         resultaattype = ResultaatTypeFactory.create(
             archiefactietermijn="P10Y",
@@ -680,7 +678,6 @@ class US345TestCase(JWTAuthMixin, APITestCase):
                 label="BAG",
                 auth_type=AuthTypes.no_auth,
             )
-            mock_service_oas_get(m, api_root, service="empty")
 
         resultaattype = ResultaatTypeFactory.create(
             archiefactietermijn="P10Y",
@@ -739,7 +736,6 @@ class US345TestCase(JWTAuthMixin, APITestCase):
                 label="BAG",
                 auth_type=AuthTypes.no_auth,
             )
-            mock_service_oas_get(m, api_root, service="empty")
 
         resultaattype = ResultaatTypeFactory.create(
             archiefactietermijn="P10Y",

--- a/src/openzaak/components/zaken/tests/test_zaak_closed_cmis.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_closed_cmis.py
@@ -4,8 +4,6 @@ from django.test import override_settings, tag
 
 from vng_api_common.constants import ComponentTypes
 from vng_api_common.tests import reverse
-from zgw_consumers.constants import APITypes
-from zgw_consumers_oas.mocks import mock_service_oas_get
 
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
@@ -45,9 +43,6 @@ class ClosedZaakRelatedDataNotAllowedCMISTests(
         super().setUpTestData()
 
     def _mock_zaak(self):
-        mock_service_oas_get(self.adapter, self.base_zaak, APITypes.zrc)
-        mock_service_oas_get(self.adapter, self.base_zaaktype, APITypes.ztc)
-
         self.adapter.get(
             build_absolute_url(reverse(self.zaak)),
             json={

--- a/src/openzaak/components/zaken/tests/test_zaak_delete.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_delete.py
@@ -10,7 +10,6 @@ from rest_framework.test import APITestCase
 from vng_api_common.tests import get_validation_errors, reverse
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.test.factories import ServiceFactory
-from zgw_consumers_oas.mocks import mock_service_oas_get
 
 from openzaak.components.besluiten.tests.factories import BesluitFactory
 from openzaak.components.catalogi.tests.factories import (
@@ -148,7 +147,6 @@ class ExternalDocumentsDeleteZaakTests(JWTAuthMixin, APITestCase):
             zaaktypen=[zaaktype], catalogus=zaaktype.catalogus
         )
         zaak = ZaakFactory.create(zaaktype=zaaktype)
-        mock_service_oas_get(m, self.base, APITypes.drc)
         document_data = get_eio_response(
             document_url, informatieobjecttype=f"http://testserver{reverse(iotype)}"
         )

--- a/src/openzaak/components/zaken/tests/test_zaakcontactmoment.py
+++ b/src/openzaak/components/zaken/tests/test_zaakcontactmoment.py
@@ -8,7 +8,6 @@ from rest_framework.test import APITestCase
 from vng_api_common.tests import JWTAuthMixin, get_validation_errors, reverse
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.test.factories import ServiceFactory
-from zgw_consumers_oas.mocks import mock_service_oas_get
 
 from openzaak.tests.utils import patch_resource_validator
 
@@ -17,10 +16,6 @@ from .factories import ZaakContactMomentFactory, ZaakFactory
 
 CONTACTMOMENTEN_BASE = "https://contactmomenten.nl/api/v1/"
 CONTACTMOMENT = f"{CONTACTMOMENTEN_BASE}contactmomenten/1234"
-
-
-def mock_contactmomenten_oas_get(m, base: str):
-    mock_service_oas_get(m, url=base, service="contactmomenten")
 
 
 @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
@@ -44,7 +39,6 @@ class ZaakContactMomentTests(JWTAuthMixin, APITestCase):
         url = reverse("zaakcontactmoment-list")
 
         with requests_mock.Mocker() as m:
-            mock_contactmomenten_oas_get(m, CONTACTMOMENTEN_BASE)
             m.post(
                 f"{CONTACTMOMENTEN_BASE}objectcontactmomenten",
                 json={
@@ -73,7 +67,6 @@ class ZaakContactMomentTests(JWTAuthMixin, APITestCase):
         url = reverse("zaakcontactmoment-list")
 
         with requests_mock.Mocker() as m:
-            mock_contactmomenten_oas_get(m, CONTACTMOMENTEN_BASE)
             m.post(
                 f"{CONTACTMOMENTEN_BASE}objectcontactmomenten",
                 status_code=400,
@@ -97,7 +90,6 @@ class ZaakContactMomentTests(JWTAuthMixin, APITestCase):
         url = reverse(zaak_contactmoment)
 
         with requests_mock.Mocker() as m:
-            mock_contactmomenten_oas_get(m, CONTACTMOMENTEN_BASE)
             m.delete(
                 zaak_contactmoment._objectcontactmoment,
                 status_code=204,
@@ -114,7 +106,6 @@ class ZaakContactMomentTests(JWTAuthMixin, APITestCase):
         url = reverse(zaak_contactmoment)
 
         with requests_mock.Mocker() as m:
-            mock_contactmomenten_oas_get(m, CONTACTMOMENTEN_BASE)
             m.post(
                 f"{CONTACTMOMENTEN_BASE}objectcontactmomenten",
                 status_code=400,

--- a/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten.py
+++ b/src/openzaak/components/zaken/tests/test_zaakinformatieobjecten.py
@@ -19,7 +19,6 @@ from vng_api_common.validators import IsImmutableValidator
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.models import Service
 from zgw_consumers.test.factories import ServiceFactory
-from zgw_consumers_oas.mocks import mock_service_oas_get
 
 from openzaak.components.catalogi.tests.factories import (
     InformatieObjectTypeFactory,
@@ -270,7 +269,6 @@ class ZaakInformatieObjectAPITests(JWTAuthMixin, APITestCase):
 
         with requests_mock.Mocker() as m:
             mock_drc_oas_get(m)
-            mock_service_oas_get(m, base, "drc")
             m.get(document1, json=eio1_response)
             m.post(
                 "https://external.documenten.nl/api/v1/objectinformatieobjecten",
@@ -466,7 +464,6 @@ class ExternalDocumentsAPITests(JWTAuthMixin, APITestCase):
 
         with self.subTest(section="zio-create"):
             with requests_mock.Mocker() as m:
-                mock_service_oas_get(m, self.base, "drc")
                 m.get(document, json=eio_response)
                 m.post(
                     "https://external.documenten.nl/api/v1/objectinformatieobjecten",
@@ -755,7 +752,6 @@ class ExternalInformatieObjectAPITests(JWTAuthMixin, APITestCase):
         zaaktype_data["informatieobjecttypen"] = [informatieobjecttype]
 
         with requests_mock.Mocker() as m:
-            mock_service_oas_get(m, self.base, "drc")
             m.get(zaaktype, json=zaaktype_data)
             m.get(
                 informatieobjecttype,
@@ -909,7 +905,6 @@ class ExternalDocumentDestroyTests(JWTAuthMixin, APITestCase):
         informatieobjecttype = InformatieObjectTypeFactory.create()
 
         with requests_mock.Mocker() as m:
-            mock_service_oas_get(m, self.base, "drc")
             m.get(
                 self.document,
                 json=get_eio_response(
@@ -943,7 +938,6 @@ class ExternalDocumentDestroyTests(JWTAuthMixin, APITestCase):
         informatieobjecttype = InformatieObjectTypeFactory.create()
 
         with requests_mock.Mocker() as m:
-            mock_service_oas_get(m, self.base, "drc")
             m.get(
                 self.document,
                 json=get_eio_response(

--- a/src/openzaak/components/zaken/tests/test_zaakverzoek.py
+++ b/src/openzaak/components/zaken/tests/test_zaakverzoek.py
@@ -8,7 +8,6 @@ from rest_framework.test import APITestCase
 from vng_api_common.tests import JWTAuthMixin, get_validation_errors, reverse
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.test.factories import ServiceFactory
-from zgw_consumers_oas.mocks import mock_service_oas_get
 
 from openzaak.components.zaken.models import ZaakVerzoek
 from openzaak.components.zaken.tests.factories import ZaakFactory, ZaakVerzoekFactory
@@ -16,10 +15,6 @@ from openzaak.tests.utils import patch_resource_validator
 
 VERZOEKEN_BASE = "https://verzoeken.nl/api/v1/"
 VERZOEK = f"{VERZOEKEN_BASE}verzoeken/1234"
-
-
-def mock_verzoeken_oas_get(m, base):
-    mock_service_oas_get(m, url=base, service="verzoeken")
 
 
 @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
@@ -43,7 +38,6 @@ class ZaakVerzoekTests(JWTAuthMixin, APITestCase):
         url = reverse("zaakverzoek-list")
 
         with requests_mock.Mocker() as m:
-            mock_verzoeken_oas_get(m, VERZOEKEN_BASE)
             m.post(
                 f"{VERZOEKEN_BASE}objectverzoeken",
                 json={
@@ -72,7 +66,6 @@ class ZaakVerzoekTests(JWTAuthMixin, APITestCase):
         url = reverse("zaakverzoek-list")
 
         with requests_mock.Mocker() as m:
-            mock_verzoeken_oas_get(m, VERZOEKEN_BASE)
             m.post(
                 f"{VERZOEKEN_BASE}objectverzoeken",
                 status_code=400,
@@ -96,7 +89,6 @@ class ZaakVerzoekTests(JWTAuthMixin, APITestCase):
         url = reverse(zaak_verzoek)
 
         with requests_mock.Mocker() as m:
-            mock_verzoeken_oas_get(m, VERZOEKEN_BASE)
             m.delete(
                 zaak_verzoek._objectverzoek,
                 status_code=204,
@@ -113,7 +105,6 @@ class ZaakVerzoekTests(JWTAuthMixin, APITestCase):
         url = reverse(zaak_verzoek)
 
         with requests_mock.Mocker() as m:
-            mock_verzoeken_oas_get(m, VERZOEKEN_BASE)
             m.delete(
                 f"{VERZOEKEN_BASE}objectverzoeken",
                 status_code=400,


### PR DESCRIPTION
Closes maykinmedia/open-api-framework#172

**Changes**

[Describe the changes here]

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [ ] Any experimental features added in this PR are backwards compatible
  - [ ] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how
