### PR TITLE
:arrow_up: Bump commonground-api-common to 2.10.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -68,7 +68,7 @@ click-repl==0.2.0
     # via celery
 cmislib-maykin==0.7.4
     # via drc-cmis
-commonground-api-common==2.9.0
+commonground-api-common==2.10.0
     # via
     #   -r requirements/base.in
     #   drc-cmis

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -126,7 +126,7 @@ cmislib-maykin==0.7.4
     #   drc-cmis
 codecov==2.1.13
     # via -r requirements/test-tools.in
-commonground-api-common==2.9.0
+commonground-api-common==2.10.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -153,7 +153,7 @@ codecov==2.1.13
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-commonground-api-common==2.9.0
+commonground-api-common==2.10.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/openzaak/tests/api_strategy/test_error_format.py
+++ b/src/openzaak/tests/api_strategy/test_error_format.py
@@ -41,7 +41,7 @@ class DSOApi50Tests(APITestCase):
                 "code": "invalid",
                 "title": "Invalid input.",
                 "status": 400,
-                "detail": "",
+                "detail": "Invalid input.",
                 "invalid_params": [
                     {
                         "name": "foo",


### PR DESCRIPTION
:arrow_up: Bump `commonground-api-common` to 2.10.0

- Update related to this issue [maykinmedia/open-api-framework#175]: added an exception logging event that includes code, status, and the invalidParams message.