### PR TITLE
:bug: [#2140] Fix: GET zaaktype does not return broncatalogus and bronzaaktype

### DIFF
--- a/src/openzaak/components/catalogi/api/serializers/zaaktype.py
+++ b/src/openzaak/components/catalogi/api/serializers/zaaktype.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
 from django.conf import settings
-from django.db import transaction
 from django.utils.translation import gettext_lazy as _
 
 from drf_writable_nested import NestedCreateMixin, NestedUpdateMixin
@@ -57,26 +56,16 @@ class ZaakTypenRelatieSerializer(ModelSerializer):
         return fields
 
 
-class BronCatalogusSerializer(ModelSerializer):
+class BronCatalogusSerializer(GegevensGroepSerializer):
     class Meta:
         model = ZaakType
-        fields = ("url", "domein", "rsin")
-        extra_kwargs = {
-            "url": {"source": "broncatalogus_url"},
-            "domein": {"source": "broncatalogus_domein", "required": True},
-            "rsin": {"source": "broncatalogus_rsin", "required": True},
-        }
+        gegevensgroep = "broncatalogus"
 
 
-class BronZaaktypeSerializer(ModelSerializer):
+class BronZaaktypeSerializer(GegevensGroepSerializer):
     class Meta:
         model = ZaakType
-        fields = ("url", "identificatie", "omschrijving")
-        extra_kwargs = {
-            "url": {"source": "bronzaaktype_url"},
-            "identificatie": {"source": "bronzaaktype_identificatie", "required": True},
-            "omschrijving": {"source": "bronzaaktype_omschrijving", "required": True},
-        }
+        gegevensgroep = "bronzaaktype"
 
 
 class ZaakTypeSerializer(
@@ -284,31 +273,6 @@ class ZaakTypeSerializer(
         fields["indicatie_intern_of_extern"].help_text += f"\n\n{value_display_mapping}"
 
         return fields
-
-    @transaction.atomic()
-    def create(self, validated_data):
-        broncatalogus_data = validated_data.pop("broncatalogus", None)
-        bronzaaktype_data = validated_data.pop("bronzaaktype", None)
-
-        zaaktype = super().create(validated_data)
-        if broncatalogus_data:
-            BronCatalogusSerializer().update(zaaktype, broncatalogus_data)
-        if bronzaaktype_data:
-            BronZaaktypeSerializer().update(zaaktype, bronzaaktype_data)
-
-        return zaaktype
-
-    @transaction.atomic()
-    def update(self, instance, validated_data):
-        broncatalogus_data = validated_data.pop("broncatalogus", None)
-        bronzaaktype_data = validated_data.pop("bronzaaktype", None)
-
-        zaaktype = super().update(instance, validated_data)
-        if broncatalogus_data:
-            BronCatalogusSerializer().update(zaaktype, broncatalogus_data)
-        if bronzaaktype_data:
-            BronZaaktypeSerializer().update(zaaktype, bronzaaktype_data)
-        return zaaktype
 
 
 class ZaakTypePublishSerializer(HyperlinkedModelSerializer):

--- a/src/openzaak/components/catalogi/models/zaaktype.py
+++ b/src/openzaak/components/catalogi/models/zaaktype.py
@@ -336,6 +336,22 @@ class ZaakType(ETagMixin, APIMixin, ConceptMixin, GeldigheidMixin, models.Model)
         help_text=_("URL-referentie naar de CATALOGUS waartoe dit ZAAKTYPE behoort."),
     )
 
+    broncatalogus = GegevensGroepType(
+        {
+            "url": broncatalogus_url,
+            "domein": broncatalogus_domein,
+            "rsin": broncatalogus_rsin,
+        },
+    )
+
+    bronzaaktype = GegevensGroepType(
+        {
+            "url": bronzaaktype_url,
+            "identificatie": bronzaaktype_identificatie,
+            "omschrijving": bronzaaktype_omschrijving,
+        },
+    )
+
     objects = SyncAutorisatieManager.from_queryset(GeldigheidQuerySet)()
 
     IDENTIFICATIE_PREFIX = "ZAAKTYPE"

--- a/src/openzaak/components/catalogi/openapi.yaml
+++ b/src/openzaak/components/catalogi/openapi.yaml
@@ -10468,6 +10468,7 @@ components:
       required:
       - domein
       - rsin
+      - url
     BronCatalogusRequest:
       type: object
       properties:
@@ -10489,6 +10490,7 @@ components:
       required:
       - domein
       - rsin
+      - url
     BronZaaktype:
       type: object
       properties:
@@ -10509,6 +10511,7 @@ components:
       required:
       - identificatie
       - omschrijving
+      - url
     BronZaaktypeRequest:
       type: object
       properties:
@@ -10529,6 +10532,7 @@ components:
       required:
       - identificatie
       - omschrijving
+      - url
     BrondatumArchiefprocedure:
       type: object
       properties:


### PR DESCRIPTION
Closes #2140

**Changes**

[Describe the changes here]

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [ ] Any experimental features added in this PR are backwards compatible
  - [ ] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how
