### PR TITLE
Refine pgbench example output formatting

### DIFF
--- a/docs/installation/hardware.rst
+++ b/docs/installation/hardware.rst
@@ -82,21 +82,21 @@ Postgresql database minimum requirements
 
 The performance of Open Zaak under load is very much dependant on the performance of the Postgresql database. The number of requests per second, the total number of cases and the number of cases per citizen/employee may affect the duration of the API calls. In order to avoid performance issues in production and aid in resolving performance issues we recommend to optimize the resources available and fine-tune the Postgresql with the help of `pgbench`. This built-in Postgresql tool gives an indication of the performance of the database setup. 
 
-An example run using `pgbench`:
+An example run using `pgbench`::
 
-```pgbench (15.14 (Debian 15.14-0+deb12u1))
-scaling factor: 1
-query mode: simple
-number of clients: 16
-number of threads: 4
-maximum number of tries: 1
-duration: 60 s
-number of transactions actually processed: 65995
-number of failed transactions: 0 (0.000%)
-latency average = 14.543 ms
-latency stddev = 10.885 ms
-initial connection time = 23.771 ms
-tps = 1099.724563 (without initial connection time)```
+  pgbench (15.14 (Debian 15.14-0+deb12u1))
+  scaling factor: 1
+  query mode: simple
+  number of clients: 16
+  number of threads: 4
+  maximum number of tries: 1
+  duration: 60 s
+  number of transactions actually processed: 65995
+  number of failed transactions: 0 (0.000%)
+  latency average = 14.543 ms
+  latency stddev = 10.885 ms
+  initial connection time = 23.771 ms
+  tps = 1099.724563 (without initial connection time)
 
 Using the default settings of pgbench, the following minimum `tps` is necessary for production setups:
 


### PR DESCRIPTION
Updated the example run output for pgbench to use proper formatting and removed unnecessary code block syntax.

Closes Taiga 1228
