### PR TITLE
:recycle: [#1621] Use explicit ordering for readonly M2M admin widget

### DIFF
--- a/src/openzaak/components/catalogi/admin/forms.py
+++ b/src/openzaak/components/catalogi/admin/forms.py
@@ -57,7 +57,7 @@ class ReadOnlyWidget(admin.widgets.ManyToManyRawIdWidget):
     def format_value(self, value):
         if not value:
             return ""
-        objects = self.rel.model.objects.filter(pk__in=value)
+        objects = self.rel.model.objects.filter(pk__in=value).order_by("pk")
         return ", ".join(str(obj) for obj in objects) if value else ""
 
 


### PR DESCRIPTION
Noticed this test failed occasionally due to missing ordering: https://github.com/open-zaak/open-zaak/actions/runs/18976046359/job/54195862165#step:5:5640

**Changes**

* Use explicit ordering for readonly M2M admin widget to avoid flakey tests

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
