### PR TITLE
:arrow_up: [#2219] Upgrade zgw-consumers to 1.1.0 and install oauth2 deps

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -32,3 +32,4 @@ drc-cmis
 commonground-api-common[setup-configuration, testutils, oas]
 maykin-common[axes,mfa]
 psycopg[pool, binary]
+zgw-consumers[oauth2]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -331,6 +331,8 @@ nh3==0.3.0
     # via textile
 notifications-api-common==0.8.2
     # via commonground-api-common
+oauthlib==3.3.1
+    # via requests-oauthlib
 open-api-framework==0.13.1
     # via -r requirements/base.in
 orderedmultidict==1.0.1
@@ -428,11 +430,14 @@ requests==2.32.4
     #   open-api-framework
     #   requests-cache
     #   requests-mock
+    #   requests-oauthlib
     #   zgw-consumers
 requests-cache==1.2.1
     # via -r requirements/base.in
 requests-mock==1.12.1
     # via commonground-api-common
+requests-oauthlib==2.0.0
+    # via zgw-consumers
 ruamel-yaml==0.18.10
     # via django-setup-configuration
 ruamel-yaml-clib==0.2.12
@@ -507,8 +512,9 @@ webencodings==0.5.1
     # via bleach
 wrapt==1.16.0
     # via elastic-apm
-zgw-consumers==1.0.0
+zgw-consumers==1.1.0
     # via
+    #   -r requirements/base.in
     #   commonground-api-common
     #   notifications-api-common
 zgw-consumers-oas==1.1.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -607,6 +607,11 @@ notifications-api-common==0.8.2
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   commonground-api-common
+oauthlib==3.3.1
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   requests-oauthlib
 open-api-framework==0.13.1
     # via
     #   -c requirements/base.txt
@@ -815,6 +820,7 @@ requests==2.32.4
     #   open-api-framework
     #   requests-cache
     #   requests-mock
+    #   requests-oauthlib
     #   sphinx
     #   zgw-consumers
 requests-cache==1.2.1
@@ -826,6 +832,10 @@ requests-mock==1.12.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   -r requirements/test-tools.in
+requests-oauthlib==2.0.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
 ruamel-yaml==0.18.10
     # via
     #   -c requirements/base.txt
@@ -1013,7 +1023,7 @@ wrapt==1.16.0
     #   vcrpy
 yarl==1.17.1
     # via vcrpy
-zgw-consumers==1.0.0
+zgw-consumers==1.1.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -693,6 +693,11 @@ notifications-api-common==0.8.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   commonground-api-common
+oauthlib==3.3.1
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   requests-oauthlib
 open-api-framework==0.13.1
     # via
     #   -c requirements/ci.txt
@@ -943,6 +948,7 @@ requests==2.32.4
     #   open-api-framework
     #   requests-cache
     #   requests-mock
+    #   requests-oauthlib
     #   sphinx
     #   zgw-consumers
 requests-cache==1.2.1
@@ -950,6 +956,10 @@ requests-cache==1.2.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
 requests-mock==1.12.1
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+requests-oauthlib==2.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1208,7 +1218,7 @@ yarl==1.17.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   vcrpy
-zgw-consumers==1.0.0
+zgw-consumers==1.1.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Closes #2219

**Changes**
* Upgrade zgw-consumers to 1.1.0 to add support for oauth2

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
