### PR TITLE
:loud_sound: Clarify log line for services without configured tokens

### DIFF
--- a/src/openzaak/utils/auth.py
+++ b/src/openzaak/utils/auth.py
@@ -24,5 +24,6 @@ def get_auth(url: str) -> dict:
         auth = ServiceConfigAdapter(service).get_client_session_kwargs()["auth"]
         return {auth.header: auth.key}
 
-    logger.warning("could_not_authenticate_for_url", url=url)
+    logger.debug("no_auth_configured_for_service", url=url)
+
     return {}


### PR DESCRIPTION
in some cases, clients use API gateways to handle auth and therefore do not configure auth on the services. By changing the loglevel from warning to debug and making the log event more clear, it is clearer that this is log line does not necessarily imply a misconfiguration

**Changes**

* Clarify log line for services without configured tokens

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
