### PR TITLE
Came to fix pyproject.toml, found 2 tests that never ran.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,4 @@
 # style: apply ruff isort and format
 9c9375f6b3c16060bee69cbc32cebb212fcb564f
 4b2ea5c19016c85d6021e3bb00f09e52dd9e014a
+328cd4b64e11ba25c1d854524e92081cf1b0fb1c    # fix indentation on tests

--- a/docs/installation/observability/logging.rst
+++ b/docs/installation/observability/logging.rst
@@ -182,6 +182,7 @@ The events below are emitted when API operations are performed.
 * ``zaaktype_updated`` (INFO). Additional context: ``client_id``, ``uuid``, ``partial``.
 * ``zaakverzoek_created`` (INFO). Additional context: ``client_id``, ``uuid``.
 * ``zaakverzoek_deleted`` (INFO). Additional context: ``client_id``, ``uuid``.
+* ``fetching_resultaattypeomschrijving_failed`` (ERROR). Additional context: ``url``.
 
 Convenience endpoints
 ^^^^^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [project]
-requires-python = "== 3.12"
+requires-python = "~= 3.12.12"
+version = "1.26.0"
+name = "open-zaak"
 
 # Bumpversion configuration
 
@@ -18,6 +20,9 @@ serialize = [
 ]
 
 [tool.bumpversion.parts.dev]
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
 
 [[tool.bumpversion.files]]
 filename = "README.rst"

--- a/src/openzaak/components/catalogi/tests/admin/files/vcr_cassettes/ResultaattypeAdminVCRTests/test_resultaattype_detail_with_invalid_resultaattypeomschrijving.yaml
+++ b/src/openzaak/components/catalogi/tests/admin/files/vcr_cassettes/ResultaattypeAdminVCRTests/test_resultaattype_detail_with_invalid_resultaattypeomschrijving.yaml
@@ -1,0 +1,200 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Open Zaak
+    method: GET
+    uri: http://example.com/omschrijving/5678
+  response:
+    body:
+      string: '<!doctype html><html lang="en"><head><title>Example Domain</title><meta
+        name="viewport" content="width=device-width, initial-scale=1"><style>body{background:#eee;width:60vw;margin:15vh
+        auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style><body><div><h1>Example
+        Domain</h1><p>This domain is for use in documentation examples without needing
+        permission. Avoid use in operations.<p><a href="https://iana.org/domains/example">Learn
+        more</a></div></body></html>
+
+        '
+    headers:
+      Age:
+      - '236'
+      CF-Cache-Status:
+      - HIT
+      CF-RAY:
+      - 9bab693118168e2b-AMS
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html
+      Date:
+      - Thu, 08 Jan 2026 11:38:50 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '513'
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Open Zaak
+    method: GET
+    uri: http://example.com/omschrijving/5678
+  response:
+    body:
+      string: '<!doctype html><html lang="en"><head><title>Example Domain</title><meta
+        name="viewport" content="width=device-width, initial-scale=1"><style>body{background:#eee;width:60vw;margin:15vh
+        auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style><body><div><h1>Example
+        Domain</h1><p>This domain is for use in documentation examples without needing
+        permission. Avoid use in operations.<p><a href="https://iana.org/domains/example">Learn
+        more</a></div></body></html>
+
+        '
+    headers:
+      Age:
+      - '236'
+      CF-Cache-Status:
+      - HIT
+      CF-RAY:
+      - 9bab69316dff5847-AMS
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html
+      Date:
+      - Thu, 08 Jan 2026 11:38:50 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '513'
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Open Zaak
+    method: GET
+    uri: https://selectielijst.openzaak.nl/api/v1/procestypen/e1b73b12-b2f6-4c4e-8929-94f84dd2a57d
+  response:
+    body:
+      string: '{"url":"https://selectielijst.openzaak.nl/api/v1/procestypen/e1b73b12-b2f6-4c4e-8929-94f84dd2a57d","nummer":1,"jaar":2017,"naam":"Instellen
+        en inrichten organisatie","omschrijving":"Instellen en inrichten organisatie","toelichting":"Dit
+        procestype betreft het instellen van een nieuw organisatieonderdeel of een
+        nieuwe orgaan waar het orgaan in deelneemt. Dit procestype betreft eveneens
+        het inrichten van het eigen orgaan. Dit kan kleinschalig plaatsvinden bijvoorbeeld
+        het wijzigen van de uitvoering van een wettelijke taak of grootschalig wanneer
+        er een organisatiewijziging wordt doorgevoerd.","procesobject":"De vastgestelde
+        organisatie inrichting"}'
+    headers:
+      API-version:
+      - 1.0.0
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '654'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Jan 2026 11:38:50 GMT
+      Feature-Policy:
+      - autoplay 'none'; camera 'none'
+      Referrer-Policy:
+      - same-origin
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - 1; mode=block
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Open Zaak
+    method: GET
+    uri: https://selectielijst.openzaak.nl/api/v1/resultaten/cc5ae4e3-a9e6-4386-bcee-46be4986a829
+  response:
+    body:
+      string: '{"url":"https://selectielijst.openzaak.nl/api/v1/resultaten/cc5ae4e3-a9e6-4386-bcee-46be4986a829","procesType":"https://selectielijst.openzaak.nl/api/v1/procestypen/e1b73b12-b2f6-4c4e-8929-94f84dd2a57d","nummer":1,"volledigNummer":"1.1","generiek":true,"specifiek":false,"naam":"Ingericht","omschrijving":"","herkomst":"Risicoanalyse","waardering":"vernietigen","procestermijn":"nihil","procestermijnWeergave":"Nihil","bewaartermijn":"P10Y","toelichting":"Invoering
+        nieuwe werkwijze","algemeenBestuurEnInrichtingOrganisatie":false,"bedrijfsvoeringEnPersoneel":true,"publiekeInformatieEnRegistratie":false,"burgerzaken":false,"veiligheid":false,"verkeerEnVervoer":false,"economie":false,"onderwijs":false,"sportCultuurEnRecreatie":false,"sociaalDomein":false,"volksgezonheidEnMilieu":false,"vhrosv":false,"heffenBelastingen":false,"alleTaakgebieden":false,"procestermijnOpmerking":""}'
+    headers:
+      API-version:
+      - 1.0.0
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '883'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Jan 2026 11:38:50 GMT
+      Feature-Policy:
+      - autoplay 'none'; camera 'none'
+      Referrer-Policy:
+      - same-origin
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - 1; mode=block
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openzaak/components/catalogi/tests/admin/test_resultaattype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_resultaattype_admin.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
-import unittest
 from unittest.mock import patch
 from urllib.parse import urlencode
 
@@ -13,6 +12,7 @@ import requests_mock
 from ape_pie.exceptions import InvalidURLError
 from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
+from maykin_common.vcr import VCRMixin
 from vng_api_common.constants import (
     BrondatumArchiefprocedureAfleidingswijze,
     VertrouwelijkheidsAanduiding,
@@ -37,7 +37,9 @@ from ..factories import ResultaatTypeFactory, ZaakTypeFactory
 
 @disable_admin_mfa()
 @requests_mock.Mocker()
-class ResultaattypeAdminTests(ReferentieLijstServiceMixin, ClearCachesMixin, WebTest):
+class ResultaattypeAdminTests(
+    VCRMixin, ReferentieLijstServiceMixin, ClearCachesMixin, WebTest
+):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -625,39 +627,6 @@ class ResultaattypeAdminTests(ReferentieLijstServiceMixin, ClearCachesMixin, Web
         )
         assert expected_error in response.text
 
-    @unittest.expectedFailure
-    @tag("gh-1962")
-    def test_resultaattype_detail_with_invalid_resultaattypeomschrijving(self, m):
-        user = UserFactory.create(is_staff=True)
-        view_resultaattype = Permission.objects.get(codename="view_resultaattype")
-        user.user_permissions.add(view_resultaattype)
-        self.app.set_user(user)
-
-        procestype_url = (
-            f"{self.service.api_root}procestypen/e1b73b12-b2f6-4c4e-8929-94f84dd2a57d"
-        )
-        invalid_omschrijving_url = "http://invalid-domain.local/omschrijving/5678"
-        m.get(invalid_omschrijving_url, status_code=404, json={})
-
-        mock_selectielijst_oas_get(m)
-        mock_resource_get(m, "procestypen", procestype_url)
-
-        # TODO This setup already fails in ResultaatType.save
-        resultaattype = ResultaatTypeFactory.create(
-            zaaktype__selectielijst_procestype=procestype_url,
-            selectielijstklasse=f"{self.service.api_root}resultaten/some-valid-resultaat",
-            resultaattypeomschrijving=invalid_omschrijving_url,
-        )
-
-        url = reverse("admin:catalogi_resultaattype_change", args=(resultaattype.pk,))
-        response = self.app.get(url)
-
-        assert response.status_code == 200
-        expected_error = _(
-            "De resultaattypeomschrijving is niet afkomstig uit de Selectielijst API-service"
-        )
-        assert expected_error in response.text
-
     @tag("gh-1962")
     @patch("openzaak.selectielijst.admin_fields.retrieve_resultaattype_omschrijvingen")
     def test_get_resultaattype_omschrijving_invalid_url(self, m, mock_retrieve):
@@ -671,3 +640,39 @@ class ResultaattypeAdminTests(ReferentieLijstServiceMixin, ClearCachesMixin, Web
             result
             == "De resultaattypeomschrijving is niet afkomstig uit de Selectielijst API-service"
         )
+
+
+@disable_admin_mfa()
+class ResultaattypeAdminVCRTests(
+    VCRMixin, ReferentieLijstServiceMixin, ClearCachesMixin, WebTest
+):
+    def setUp(self):
+        super().setUp()
+        # Turn off mocker from ReferentieLijstServiceMixin.setUp
+        self.requests_mocker.stop()  # type: ignore
+
+    @tag("gh-1962")
+    def test_resultaattype_detail_with_invalid_resultaattypeomschrijving(self):
+        user = UserFactory.create(is_staff=True)
+        view_resultaattype = Permission.objects.get(codename="view_resultaattype")
+        user.user_permissions.add(view_resultaattype)
+        self.app.set_user(user)
+
+        procestype_url = (
+            f"{self.service.api_root}procestypen/e1b73b12-b2f6-4c4e-8929-94f84dd2a57d"
+        )
+        invalid_omschrijving_url = "http://example.com/omschrijving/5678"
+        resultaattype = ResultaatTypeFactory.create(
+            zaaktype__selectielijst_procestype=procestype_url,
+            selectielijstklasse=f"{self.service.api_root}resultaten/cc5ae4e3-a9e6-4386-bcee-46be4986a829",
+            resultaattypeomschrijving=invalid_omschrijving_url,
+        )
+
+        url = reverse("admin:catalogi_resultaattype_change", args=(resultaattype.pk,))
+        response = self.app.get(url)
+
+        assert response.status_code == 200
+        expected_error = _(
+            "De resultaattypeomschrijving is niet afkomstig uit de Selectielijst API-service"
+        )
+        assert expected_error in response.text

--- a/src/openzaak/components/catalogi/tests/admin/test_resultaattype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_resultaattype_admin.py
@@ -627,6 +627,7 @@ class ResultaattypeAdminTests(ReferentieLijstServiceMixin, ClearCachesMixin, Web
 
 @tag("gh-1962")
 def test_resultaattype_detail_with_invalid_resultaattypeomschrijving(self, m):
+    assert False
     user = UserFactory.create(is_staff=True)
     view_resultaattype = Permission.objects.get(codename="view_resultaattype")
     user.user_permissions.add(view_resultaattype)
@@ -659,6 +660,7 @@ def test_resultaattype_detail_with_invalid_resultaattypeomschrijving(self, m):
 @tag("gh-1962")
 @patch("openzaak.selectielijst.admin_fields.retrieve_resultaattype_omschrijvingen")
 def test_get_resultaattype_omschrijving_invalid_url(mock_retrieve):
+    assert False
     mock_retrieve.side_effect = InvalidURLError()
 
     url = "http://invalid-url.local"

--- a/src/openzaak/components/catalogi/tests/admin/test_resultaattype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_resultaattype_admin.py
@@ -624,50 +624,46 @@ class ResultaattypeAdminTests(ReferentieLijstServiceMixin, ClearCachesMixin, Web
         )
         assert expected_error in response.text
 
+    @tag("gh-1962")
+    def test_resultaattype_detail_with_invalid_resultaattypeomschrijving(self, m):
+        user = UserFactory.create(is_staff=True)
+        view_resultaattype = Permission.objects.get(codename="view_resultaattype")
+        user.user_permissions.add(view_resultaattype)
+        self.app.set_user(user)
 
-@tag("gh-1962")
-def test_resultaattype_detail_with_invalid_resultaattypeomschrijving(self, m):
-    assert False
-    user = UserFactory.create(is_staff=True)
-    view_resultaattype = Permission.objects.get(codename="view_resultaattype")
-    user.user_permissions.add(view_resultaattype)
-    self.app.set_user(user)
+        procestype_url = (
+            f"{self.service.api_root}procestypen/e1b73b12-b2f6-4c4e-8929-94f84dd2a57d"
+        )
+        invalid_omschrijving_url = "http://invalid-domain.local/omschrijving/5678"
 
-    procestype_url = (
-        f"{self.service.api_root}procestypen/e1b73b12-b2f6-4c4e-8929-94f84dd2a57d"
-    )
-    invalid_omschrijving_url = "http://invalid-domain.local/omschrijving/5678"
+        mock_selectielijst_oas_get(m)
+        mock_resource_get(m, "procestypen", procestype_url)
 
-    mock_selectielijst_oas_get(m)
-    mock_resource_get(m, "procestypen", procestype_url)
+        resultaattype = ResultaatTypeFactory.create(
+            zaaktype__selectielijst_procestype=procestype_url,
+            selectielijstklasse=f"{self.service.api_root}resultaten/some-valid-resultaat",
+            resultaattypeomschrijving=invalid_omschrijving_url,
+        )
 
-    resultaattype = ResultaatTypeFactory.create(
-        zaaktype__selectielijst_procestype=procestype_url,
-        selectielijstklasse=f"{self.service.api_root}resultaten/some-valid-resultaat",
-        resultaattypeomschrijving=invalid_omschrijving_url,
-    )
+        url = reverse("admin:catalogi_resultaattype_change", args=(resultaattype.pk,))
+        response = self.app.get(url)
 
-    url = reverse("admin:catalogi_resultaattype_change", args=(resultaattype.pk,))
-    response = self.app.get(url)
+        assert response.status_code == 200
+        expected_error = _(
+            "De resultaattypeomschrijving is niet afkomstig uit de Selectielijst API-service"
+        )
+        assert expected_error in response.text
 
-    assert response.status_code == 200
-    expected_error = _(
-        "De resultaattypeomschrijving is niet afkomstig uit de Selectielijst API-service"
-    )
-    assert expected_error in response.text
+    @tag("gh-1962")
+    @patch("openzaak.selectielijst.admin_fields.retrieve_resultaattype_omschrijvingen")
+    def test_get_resultaattype_omschrijving_invalid_url(mock_retrieve):
+        mock_retrieve.side_effect = InvalidURLError()
 
+        url = "http://invalid-url.local"
 
-@tag("gh-1962")
-@patch("openzaak.selectielijst.admin_fields.retrieve_resultaattype_omschrijvingen")
-def test_get_resultaattype_omschrijving_invalid_url(mock_retrieve):
-    assert False
-    mock_retrieve.side_effect = InvalidURLError()
+        result = get_resultaattype_omschrijving_readonly_field(url)
 
-    url = "http://invalid-url.local"
-
-    result = get_resultaattype_omschrijving_readonly_field(url)
-
-    assert (
-        result
-        == "De resultaattypeomschrijving is niet afkomstig uit de Selectielijst API-service"
-    )
+        assert (
+            result
+            == "De resultaattypeomschrijving is niet afkomstig uit de Selectielijst API-service"
+        )


### PR DESCRIPTION
Re-opens #1962 ?

**Changes**
I wanted to just fixt the pyproject.toml, but I found 2 tests that weren't run by CI. One I fixed, the other marked as expected fail.

I'm unsure what the test is trying to do. The setup already fails in a `.save()` call, so I don't know whether this is an error case that can never happen (any more) and the test should be deleted, or whether the issue isn't completely solved.
