### PR TITLE
:arrow_up: [#2278] Upgrade commonground-api-common to 2.10.6

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -28,7 +28,8 @@ drf-extra-fields
 drf-writable-nested
 humanize
 
-commonground-api-common[setup-configuration, testutils, oas]
+# commonground-api-common[setup-configuration, testutils, oas]
+git+https://github.com/maykinmedia/commonground-api-common.git@issue/explicit-ordering-for-models[setup-configuration, testutils, oas]
 maykin-common[axes,mfa,otel]
 psycopg[pool, binary]
 zgw-consumers[oauth2]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -66,7 +66,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-commonground-api-common==2.10.5
+commonground-api-common @ git+https://github.com/maykinmedia/commonground-api-common.git@28418a3b6407c4a2c81e085776af7c3ce1de267e
     # via
     #   -r requirements/base.in
     #   open-api-framework

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -121,7 +121,7 @@ click-repl==0.2.0
     #   celery
 codecov==2.1.13
     # via -r requirements/test-tools.in
-commonground-api-common==2.10.5
+commonground-api-common @ git+https://github.com/maykinmedia/commonground-api-common.git@28418a3b6407c4a2c81e085776af7c3ce1de267e
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -148,7 +148,7 @@ codecov==2.1.13
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-commonground-api-common==2.10.5
+commonground-api-common @ git+https://github.com/maykinmedia/commonground-api-common.git@28418a3b6407c4a2c81e085776af7c3ce1de267e
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Closes #2278

Requires https://github.com/maykinmedia/commonground-api-common/pull/139 to be merged first

TODO:
- [ ] upgrade to pypi version of library

**Changes**

* Upgrade commonground-api-common to 2.10.6 to add explicit ordering to AuditTrail model and fix flaky test

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
