### PR TITLE
:memo: [#2233] Add docs page for cloud events configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,4 +153,8 @@ intersphinx_mapping = {
         "https://open-api-framework.readthedocs.io/en/latest",
         None,
     ),
+    "open-notificaties": (
+        "https://open-notificaties.readthedocs.io/en/latest",
+        None,
+    ),
 }

--- a/docs/installation/config/cloud_events.rst
+++ b/docs/installation/config/cloud_events.rst
@@ -1,0 +1,26 @@
+.. _cloud_events_configuration:
+
+========================
+Configuring cloud events
+========================
+
+Open Zaak has experimental support for sending cloud events (see :ref:`cloud_events` for more information).
+These cloud events can be sent to Open Notificaties, which can route the events to subscribed
+webhooks. In order to make sure these events are sent, some configuration is required in both
+Open Zaak and Open Notificaties
+
+Open Zaak
+---------
+
+1. Make sure the ``ENABLE_CLOUD_EVENTS`` environment variable is set to ``True`` (see :ref:`installation_env_config`).
+2. Make sure the connection with Open Notificaties is configured via ``setup_configuration``.
+   See :ref:`installation_configuration_cli` for more information.
+
+Alternatively, if ``setup_configuration`` is not used for programmatic configuration,
+the connection with Open Notificaties can be configured manually via the admin interface.
+For more information on how to do this, see :ref:`installation_configuration`.
+
+Open Notificaties
+-----------------
+
+For the required configuration in Open Notificaties, see :ref:`cloud_events_configuration_mijn_overheid`

--- a/docs/installation/config/index.rst
+++ b/docs/installation/config/index.rst
@@ -9,3 +9,4 @@ Configuration
    openzaak_config_cli
    openzaak_config
    env_config
+   cloud_events


### PR DESCRIPTION
Closes #2233 partially

**Changes**

* Add docs page for cloud events configuration

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
