### PR TITLE
:sparkles: [#2263] Allow afleidingswijze termijn for all procestermijnen except nihil

### DIFF
--- a/docs/api/experimental.rst
+++ b/docs/api/experimental.rst
@@ -213,6 +213,16 @@ Attributes
 
     * ``beginObject`` and ``eindeObject`` are made read-only. `The reason <https://github.com/VNG-Realisatie/gemma-zaken/issues/2332>`__
 
+Validation
+----------
+
+* ``ResultaatType``:
+
+    * ``brondatumArchiefprocedure.afleidingswijze``: ``termijn`` is allowed for all selectielijstklasse procestermijnen except ``nihil``.
+      This differs from the Catalogi API specification, because there ``termijn`` is only
+      allowed for ``procestermijn`` ``ingeschatte_bestaansduur_procesobject``
+      (see `Catalogi API runtime behavior (ztc-003) <https://vng-realisatie.github.io/gemma-zaken/standaard/catalogi/>`_)
+
 Query parameters
 ----------------
 

--- a/docs/manual/archiving.rst
+++ b/docs/manual/archiving.rst
@@ -40,17 +40,17 @@ De andere afleidingswijzen zijn toegestaan bij de andere procestermijnen
      - afgehandeld
    * - bestaansduur_processobject
      - | ander_datumkenmerk, eigenschap, gerelateerde_zaak (deprecated),
-       | hoofdzaak, ingangsdatum_besluit, vervaldatum_besluit,
+       | hoofdzaak, ingangsdatum_besluit, termijn, vervaldatum_besluit,
        | zaakobject
    * - ingeschatte_bestaansduur_procesobject
      - | termijn
    * - vast_te_leggen_datum
      - | ander_datumkenmerk, eigenschap, gerelateerde_zaak (deprecated),
-       | hoofdzaak, ingangsdatum_besluit, vervaldatum_besluit,
+       | hoofdzaak, ingangsdatum_besluit, termijn, vervaldatum_besluit,
        | zaakobject
    * - samengevoegd_met_bewaartermijn
      - | ander_datumkenmerk, eigenschap, gerelateerde_zaak (deprecated),
-       | hoofdzaak, ingangsdatum_besluit, vervaldatum_besluit,
+       | hoofdzaak, ingangsdatum_besluit, termijn, vervaldatum_besluit,
        | zaakobject
 
 Daarnaast zijn bij de bepaling van de brondatum archiefprocedure per afleidingswijze een aantal velden verplicht:

--- a/src/openzaak/components/catalogi/admin/forms.py
+++ b/src/openzaak/components/catalogi/admin/forms.py
@@ -251,8 +251,10 @@ class ResultaatTypeForm(forms.ModelForm):
     def clean(self):
         super().clean()
 
+        # TODO we should probably reuse `ProcesTypeValidator` to have consistency with the API
         self._clean_selectielijstklasse()
         self._clean_brondatum_archiefprocedure_afleidingswijze()
+        # TODO we should probably reuse `BrondatumArchiefprocedureValidator` to have consistency with the API
         self._clean_brondatum_archiefprocedure()
 
     def _get_field_label(self, field: str) -> str:

--- a/src/openzaak/components/catalogi/api/serializers/resultaattype.py
+++ b/src/openzaak/components/catalogi/api/serializers/resultaattype.py
@@ -20,11 +20,11 @@ from vng_api_common.utils import get_help_text
 from openzaak.utils.validators import ResourceValidator, UniqueTogetherValidator
 
 from ...models import ResultaatType
+from ...validators import ProcestermijnAfleidingswijzeValidator
 from ..validators import (
     BrondatumArchiefprocedureValidator,
     M2MConceptCreateValidator,
     M2MConceptUpdateValidator,
-    ProcestermijnAfleidingswijzeValidator,
     ProcesTypeValidator,
     RelationCatalogValidator,
     StartBeforeEndValidator,

--- a/src/openzaak/components/catalogi/api/validators.py
+++ b/src/openzaak/components/catalogi/api/validators.py
@@ -219,9 +219,6 @@ class ProcestermijnAfleidingswijzeValidator:
         elif (
             procestermijn == Procestermijn.ingeschatte_bestaansduur_procesobject
             and afleidingswijze != Afleidingswijze.termijn
-        ) or (
-            procestermijn != Procestermijn.ingeschatte_bestaansduur_procesobject
-            and afleidingswijze == Afleidingswijze.termijn
         ):
             error = True
 

--- a/src/openzaak/components/catalogi/api/validators.py
+++ b/src/openzaak/components/catalogi/api/validators.py
@@ -2,19 +2,17 @@
 # Copyright (C) 2019 - 2020 Dimpact
 from django.utils.translation import gettext_lazy as _
 
-from rest_framework.exceptions import ErrorDetail
-from rest_framework.serializers import Serializer, ValidationError
+from rest_framework.exceptions import ErrorDetail, ValidationError
+from rest_framework.serializers import Serializer
 from rest_framework.settings import api_settings
 from vng_api_common.constants import (
     Archiefnominatie,
-    BrondatumArchiefprocedureAfleidingswijze as Afleidingswijze,
 )
 
 from openzaak.client import fetch_object
 from openzaak.components.catalogi.api.scopes import SCOPE_CATALOGI_FORCED_WRITE
 from openzaak.utils.serializers import get_from_serializer_data_or_instance
 
-from ..constants import SelectielijstKlasseProcestermijn as Procestermijn
 from ..utils import has_overlapping_objects
 from ..validators import (
     validate_brondatumarchiefprocedure,
@@ -175,56 +173,6 @@ class ProcesTypeValidator:
             raise ValidationError(
                 self.message.format(self.relation_field, self.zaaktype_field),
                 code=self.code,
-            )
-
-
-class ProcestermijnAfleidingswijzeValidator:
-    code = "invalid-afleidingswijze-for-procestermijn"
-    message = _(
-        "afleidingswijze cannot be {} when selectielijstklasse.procestermijn is {}"
-    )
-
-    def __init__(
-        self,
-        selectielijstklasse_field: str,
-        archiefprocedure_field="brondatum_archiefprocedure",
-    ):
-        self.selectielijstklasse_field = selectielijstklasse_field
-        self.archiefprocedure_field = archiefprocedure_field
-
-    def __call__(self, attrs: dict):
-        selectielijstklasse_url = attrs.get(self.selectielijstklasse_field)
-        archiefprocedure = attrs.get(self.archiefprocedure_field)
-
-        if not selectielijstklasse_url or not archiefprocedure:
-            return
-
-        selectielijstklasse = fetch_object(selectielijstklasse_url)
-        procestermijn = selectielijstklasse["procestermijn"]
-        afleidingswijze = archiefprocedure["afleidingswijze"]
-
-        error = False
-
-        if not procestermijn:
-            return
-
-        if (  # noqa
-            procestermijn == Procestermijn.nihil
-            and afleidingswijze != Afleidingswijze.afgehandeld
-        ) or (
-            procestermijn != Procestermijn.nihil
-            and afleidingswijze == Afleidingswijze.afgehandeld
-        ):
-            error = True
-        elif (
-            procestermijn == Procestermijn.ingeschatte_bestaansduur_procesobject
-            and afleidingswijze != Afleidingswijze.termijn
-        ):
-            error = True
-
-        if error:
-            raise ValidationError(
-                self.message.format(afleidingswijze, procestermijn), code=self.code
             )
 
 

--- a/src/openzaak/components/catalogi/constants.py
+++ b/src/openzaak/components/catalogi/constants.py
@@ -19,6 +19,30 @@ class SelectielijstKlasseProcestermijn(models.TextChoices):
             "procestermijn en bewaartermijn samen een bewaartermijn vormen die direct kan gaan lopen na de procesfase."
         ),
     )
+    bestaansduur_procesobject = (
+        "bestaansduur_procesobject",
+        _(
+            "De lengte van de procestermijn is afhankelijk van het procesobject. "
+            "Nadat het procesobject haar geldigheid heeft verloren of niet meer "
+            "bestaat, gaat de bewaartermijn lopen."
+        ),
+    )
+    vast_te_leggen_datum = (
+        "vast_te_leggen_datum",
+        _(
+            "Tijdens de procesuitvoering wordt de datum bepaald wanneer het "
+            "procesobject haar geldigheid zal verliezen. Tot dat moment loopt de "
+            "procestermijn."
+        ),
+    )
+    samengevoegd_met_bewaartermijn = (
+        "samengevoegd_met_bewaartermijn",
+        _(
+            "De proces- en bewaartermijn zijn samengevoegd als totaalwaarde bij de "
+            "bewaartermijn. De datum waarop deze termijn moet gaan lopen is benoemd in "
+            "de toelichting bij de categorie en kan in het verleden liggen."
+        ),
+    )
 
 
 class FormaatChoices(models.TextChoices):

--- a/src/openzaak/components/catalogi/tests/test_resultaattype.py
+++ b/src/openzaak/components/catalogi/tests/test_resultaattype.py
@@ -187,13 +187,10 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
     def test_create_resultaattype(self, mock_shape, mock_fetch, m):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
         zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})
-        resultaattypeomschrijving_url = (
-            "https://selectielijst.openzaak.nl/api/v1/omschrijving/1"
-        )
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "illum",
-            "resultaattypeomschrijving": resultaattypeomschrijving_url,
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
             "archiefnominatie": "blijvend_bewaren",
             "archiefactietermijn": "P10Y",
@@ -217,7 +214,7 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
                 "procestermijn": Procestermijn.nihil,
             },
         )
-        m.get(resultaattypeomschrijving_url, json={"omschrijving": "test"})
+        m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "test"})
 
         response = self.client.post(self.list_url, data)
 
@@ -242,13 +239,10 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
     ):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
         zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})
-        resultaattypeomschrijving_url = (
-            "https://selectielijst.openzaak.nl/api/v1/omschrijving/1"
-        )
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "illum",
-            "resultaattypeomschrijving": resultaattypeomschrijving_url,
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
             "archiefnominatie": "blijvend_bewaren",
             "archiefactietermijn": "P10Y",
@@ -262,7 +256,7 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
                 "procestermijn": Procestermijn.nihil,
             },
         )
-        m.get(resultaattypeomschrijving_url, json={"omschrijving": "test"})
+        m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "test"})
 
         response = self.client.post(self.list_url, data)
 
@@ -300,13 +294,10 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
     ):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
         zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})
-        resultaattypeomschrijving_url = (
-            "https://selectielijst.openzaak.nl/api/v1/omschrijving/1"
-        )
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "illum",
-            "resultaattypeomschrijving": resultaattypeomschrijving_url,
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
             "archiefnominatie": "vernietigen",
             "archiefactietermijn": "P10Y",
@@ -320,7 +311,7 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
                 "procestermijn": Procestermijn.nihil,
             },
         )
-        m.get(resultaattypeomschrijving_url, json={"omschrijving": "test"})
+        m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "test"})
 
         response = self.client.post(self.list_url, data)
 
@@ -361,13 +352,10 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
             selectielijst_procestype=PROCESTYPE_URL, concept=False
         )
         zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})
-        resultaattypeomschrijving_url = (
-            "https://selectielijst.openzaak.nl/api/v1/omschrijving/1"
-        )
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "illum",
-            "resultaattypeomschrijving": resultaattypeomschrijving_url,
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
             "archiefnominatie": "blijvend_bewaren",
             "archiefactietermijn": "P10Y",
@@ -388,7 +376,7 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
                 "procestermijn": Procestermijn.nihil,
             },
         )
-        m.get(resultaattypeomschrijving_url, json={"omschrijving": "test"})
+        m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "test"})
 
         response = self.client.post(self.list_url, data)
 
@@ -405,13 +393,10 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
     ):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
         zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})
-        resultaattypeomschrijving_url = (
-            "https://selectielijst.openzaak.nl/api/v1/omschrijving/1"
-        )
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "illum",
-            "resultaattypeomschrijving": resultaattypeomschrijving_url,
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
             "archiefnominatie": "blijvend_bewaren",
             "archiefactietermijn": "P10Y",
@@ -435,7 +420,7 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
                 "procestermijn": Procestermijn.nihil,
             },
         )
-        m.get(resultaattypeomschrijving_url, json={"omschrijving": "test"})
+        m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "test"})
 
         response = self.client.post(self.list_url, data)
 
@@ -473,13 +458,10 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
     def test_derive_archiefactiedatum_from_selectielijstklasse(self, *mocks):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
         zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})
-        resultaattypeomschrijving_url = (
-            "https://selectielijst.openzaak.nl/api/v1/omschrijving/1"
-        )
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "illum",
-            "resultaattypeomschrijving": resultaattypeomschrijving_url,
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
             "archiefnominatie": "blijvend_bewaren",
             "brondatumArchiefprocedure": {
@@ -501,7 +483,7 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
                     "procestermijn": Procestermijn.nihil,
                 },
             )
-            m.get(resultaattypeomschrijving_url, json={"omschrijving": "test"})
+            m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "test"})
 
             response = self.client.post(self.list_url, data)
 
@@ -517,13 +499,10 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
         resultaattype = ResultaatTypeFactory.create(zaaktype=zaaktype)
         resultaattype_url = reverse(resultaattype)
 
-        resultaattypeomschrijving_url = (
-            "https://selectielijst.openzaak.nl/api/v1/omschrijving/1"
-        )
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "aangepast",
-            "resultaattypeomschrijving": resultaattypeomschrijving_url,
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
             "archiefnominatie": "blijvend_bewaren",
             "archiefactietermijn": "P10Y",
@@ -546,7 +525,7 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
                     "procestermijn": Procestermijn.nihil,
                 },
             )
-            m.get(resultaattypeomschrijving_url, json={"omschrijving": "test"})
+            m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "test"})
 
             response = self.client.put(resultaattype_url, data)
 
@@ -563,13 +542,10 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
         resultaattype = ResultaatTypeFactory.create(zaaktype=zaaktype)
         resultaattype_url = reverse(resultaattype)
 
-        resultaattypeomschrijving_url = (
-            "https://selectielijst.openzaak.nl/api/v1/omschrijving/1"
-        )
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "aangepast",
-            "resultaattypeomschrijving": resultaattypeomschrijving_url,
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
             "archiefnominatie": "blijvend_bewaren",
             "archiefactietermijn": "P10Y",
@@ -592,7 +568,7 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
                     "procestermijn": Procestermijn.nihil,
                 },
             )
-            m.get(resultaattypeomschrijving_url, json={"omschrijving": "test"})
+            m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "test"})
 
             response = self.client.put(resultaattype_url, data)
 
@@ -613,13 +589,10 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
         resultaattype = ResultaatTypeFactory.create()
         resultaattype_url = reverse(resultaattype)
 
-        resultaattypeomschrijving_url = (
-            "https://selectielijst.openzaak.nl/api/v1/omschrijving/1"
-        )
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "aangepast",
-            "resultaattypeomschrijving": resultaattypeomschrijving_url,
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
             "archiefnominatie": "blijvend_bewaren",
             "archiefactietermijn": "P10Y",
@@ -642,7 +615,7 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
                     "procestermijn": Procestermijn.nihil,
                 },
             )
-            m.get(resultaattypeomschrijving_url, json={"omschrijving": "test"})
+            m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "test"})
 
             response = self.client.put(resultaattype_url, data)
 
@@ -723,14 +696,11 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
         zaaktype_url = reverse(zaaktype)
 
-        resultaattypeomschrijving_url = (
-            "https://selectielijst.openzaak.nl/api/v1/omschrijving/1"
-        )
         with requests_mock.Mocker() as m:
-            m.get(resultaattypeomschrijving_url, json={"omschrijving": "init"})
+            m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "init"})
             resultaattype = ResultaatTypeFactory.create(
                 zaaktype=zaaktype,
-                resultaattypeomschrijving=resultaattypeomschrijving_url,
+                resultaattypeomschrijving=RESULTAATTYPEOMSCHRIJVING_URL,
             )
         self.assertEqual(resultaattype.omschrijving_generiek, "init")
 
@@ -739,11 +709,11 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "aangepast",
-            "resultaattypeomschrijving": resultaattypeomschrijving_url,
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
         }
 
         with requests_mock.Mocker() as m:
-            m.get(resultaattypeomschrijving_url, json={"omschrijving": "test"})
+            m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "test"})
             response = self.client.patch(resultaattype_url, data)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -758,13 +728,10 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
         zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})
         iotype = InformatieObjectTypeFactory.create(catalogus=zaaktype.catalogus)
-        resultaattypeomschrijving_url = (
-            "https://selectielijst.openzaak.nl/api/v1/omschrijving/1"
-        )
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "illum",
-            "resultaattypeomschrijving": resultaattypeomschrijving_url,
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
             "archiefnominatie": "blijvend_bewaren",
             "archiefactietermijn": "P10Y",
@@ -787,7 +754,7 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
                 "procestermijn": Procestermijn.nihil,
             },
         )
-        m.get(resultaattypeomschrijving_url, json={"omschrijving": "test"})
+        m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "test"})
 
         response = self.client.post(self.list_url, data)
 
@@ -812,13 +779,10 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
         zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})
         iotype = InformatieObjectTypeFactory.create()
-        resultaattypeomschrijving_url = (
-            "https://selectielijst.openzaak.nl/api/v1/omschrijving/1"
-        )
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "illum",
-            "resultaattypeomschrijving": resultaattypeomschrijving_url,
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
             "archiefnominatie": "blijvend_bewaren",
             "archiefactietermijn": "P10Y",
@@ -841,7 +805,7 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
                 "procestermijn": Procestermijn.nihil,
             },
         )
-        m.get(resultaattypeomschrijving_url, json={"omschrijving": "test"})
+        m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "test"})
 
         response = self.client.post(self.list_url, data)
 
@@ -915,13 +879,10 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
         zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})
         besluittype = BesluitTypeFactory.create(catalogus=zaaktype.catalogus)
-        resultaattypeomschrijving_url = (
-            "https://selectielijst.openzaak.nl/api/v1/omschrijving/1"
-        )
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "illum",
-            "resultaattypeomschrijving": resultaattypeomschrijving_url,
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
             "archiefnominatie": "blijvend_bewaren",
             "archiefactietermijn": "P10Y",
@@ -944,7 +905,7 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
                 "procestermijn": Procestermijn.nihil,
             },
         )
-        m.get(resultaattypeomschrijving_url, json={"omschrijving": "test"})
+        m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "test"})
 
         response = self.client.post(self.list_url, data)
 
@@ -969,13 +930,10 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
         zaaktype = ZaakTypeFactory.create(selectielijst_procestype=PROCESTYPE_URL)
         zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})
         besluittype = BesluitTypeFactory.create()
-        resultaattypeomschrijving_url = (
-            "https://selectielijst.openzaak.nl/api/v1/omschrijving/1"
-        )
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "illum",
-            "resultaattypeomschrijving": resultaattypeomschrijving_url,
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
             "archiefnominatie": "blijvend_bewaren",
             "archiefactietermijn": "P10Y",
@@ -998,7 +956,7 @@ class ResultaatTypeAPITests(SelectieLijstMixin, TypeCheckMixin, APITestCase):
                 "procestermijn": Procestermijn.nihil,
             },
         )
-        m.get(resultaattypeomschrijving_url, json={"omschrijving": "test"})
+        m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "test"})
 
         response = self.client.post(self.list_url, data)
 
@@ -1280,14 +1238,11 @@ class ResultaatTypeValidationTests(SelectieLijstMixin, APITestCase):
     def test_validate_wrong_resultaattypeomschrijving(self, mock_shape, mock_fetch):
         zaaktype = ZaakTypeFactory.create(concept=False)
         zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})
-        resultaattypeomschrijving_url = (
-            "https://selectielijst.openzaak.nl/api/v1/omschrijving/1"
-        )
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "illum",
-            "resultaattypeomschrijving": resultaattypeomschrijving_url,
-            "selectielijstklasse": "https://garcia.org/",
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
+            "selectielijstklasse": RESULTAATTYPEOMSCHRIJVING_URL,
             "archiefnominatie": "blijvend_bewaren",
             "archiefactietermijn": "P10Y",
             "brondatumArchiefprocedure": {
@@ -1301,7 +1256,7 @@ class ResultaatTypeValidationTests(SelectieLijstMixin, APITestCase):
         }
 
         with requests_mock.Mocker() as m:
-            m.get(resultaattypeomschrijving_url, json={"omschrijving": "test"})
+            m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "test"})
             response = self.client.post(self.list_url, data)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -1316,7 +1271,7 @@ class ResultaatTypeValidationTests(SelectieLijstMixin, APITestCase):
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "illum",
-            "resultaattypeomschrijving": "https://garcia.org/",
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": "https://selectielijst.openzaak.nl/api/v1/resultaten/1234",
             "archiefnominatie": "blijvend_bewaren",
             "archiefactietermijn": "P10Y",
@@ -1357,7 +1312,7 @@ class ResultaatTypeValidationTests(SelectieLijstMixin, APITestCase):
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "illum",
-            "resultaattypeomschrijving": "https://garcia.org/",
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
             "archiefnominatie": "blijvend_bewaren",
             "archiefactietermijn": "P10Y",
@@ -1401,7 +1356,7 @@ class ResultaatTypeValidationTests(SelectieLijstMixin, APITestCase):
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "illum",
-            "resultaattypeomschrijving": "https://garcia.org/",
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
             "archiefnominatie": "blijvend_bewaren",
             "archiefactietermijn": "P10Y",
@@ -1442,7 +1397,7 @@ class ResultaatTypeValidationTests(SelectieLijstMixin, APITestCase):
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "illum",
-            "resultaattypeomschrijving": "https://garcia.org/",
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
             "archiefnominatie": "blijvend_bewaren",
             "archiefactietermijn": "P10Y",
@@ -1458,7 +1413,7 @@ class ResultaatTypeValidationTests(SelectieLijstMixin, APITestCase):
 
         with requests_mock.Mocker() as m:
             mock_selectielijst_oas_get(m)
-            m.get("https://garcia.org/", json={"omschrijving": "bla"})
+            m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "bla"})
             m.get(
                 SELECTIELIJSTKLASSE_URL,
                 json={
@@ -1484,12 +1439,12 @@ class ResultaatTypeValidationTests(SelectieLijstMixin, APITestCase):
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "illum",
-            "resultaattypeomschrijving": "https://garcia.org/",
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
             "archiefnominatie": "blijvend_bewaren",
             "archiefactietermijn": "P10Y",
             "brondatumArchiefprocedure": {
-                "afleidingswijze": Afleidingswijze.afgehandeld,
+                "afleidingswijze": Afleidingswijze.ingangsdatum_besluit,
                 "einddatumBekend": False,
                 "procestermijn": None,
                 "datumkenmerk": "",
@@ -1517,6 +1472,58 @@ class ResultaatTypeValidationTests(SelectieLijstMixin, APITestCase):
         self.assertEqual(error["code"], "invalid-afleidingswijze-for-procestermijn")
 
     @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
+    @patch("openzaak.utils.validators.obj_has_shape", return_value=True)
+    def test_afleidingswijze_termijn_allowed_for_all_procestermijnen_except_nihil(
+        self, *mocks
+    ):
+        zaaktype = ZaakTypeFactory.create(
+            selectielijst_procestype=PROCESTYPE_URL, concept=False
+        )
+        zaaktype_url = reverse("zaaktype-detail", kwargs={"uuid": zaaktype.uuid})
+
+        for procestermijn in Procestermijn.values:
+            with self.subTest(procestermijn=procestermijn):
+                data = {
+                    "zaaktype": f"http://testserver{zaaktype_url}",
+                    "omschrijving": procestermijn[:30],
+                    "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
+                    "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
+                    "archiefnominatie": "blijvend_bewaren",
+                    "archiefactietermijn": "P10Y",
+                    "brondatumArchiefprocedure": {
+                        "afleidingswijze": Afleidingswijze.termijn,
+                        "einddatumBekend": False,
+                        "procestermijn": "P1M",
+                        "datumkenmerk": "",
+                        "objecttype": "",
+                        "registratie": "",
+                    },
+                }
+
+                with requests_mock.Mocker() as m:
+                    mock_selectielijst_oas_get(m)
+                    m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "bla"})
+                    m.get(
+                        SELECTIELIJSTKLASSE_URL,
+                        json={
+                            "url": SELECTIELIJSTKLASSE_URL,
+                            "procesType": PROCESTYPE_URL,
+                            "procestermijn": procestermijn,
+                        },
+                    )
+
+                    response = self.client.post(self.list_url, data)
+
+                if procestermijn == Procestermijn.nihil:
+                    self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+                    error = get_validation_errors(response, "nonFieldErrors")
+                    self.assertEqual(
+                        error["code"], "invalid-afleidingswijze-for-procestermijn"
+                    )
+                else:
+                    self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    @override_settings(LINK_FETCHER="vng_api_common.mocks.link_fetcher_200")
     @patch_resource_validator
     def test_procestermijn_empty_and_afleidingswijze_niet_termijn(self, *mocks):
         zaaktype = ZaakTypeFactory.create(
@@ -1526,7 +1533,7 @@ class ResultaatTypeValidationTests(SelectieLijstMixin, APITestCase):
         data = {
             "zaaktype": f"http://testserver{zaaktype_url}",
             "omschrijving": "illum",
-            "resultaattypeomschrijving": "https://garcia.org/",
+            "resultaattypeomschrijving": RESULTAATTYPEOMSCHRIJVING_URL,
             "selectielijstklasse": SELECTIELIJSTKLASSE_URL,
             "archiefnominatie": "blijvend_bewaren",
             "archiefactietermijn": "P10Y",
@@ -1542,7 +1549,7 @@ class ResultaatTypeValidationTests(SelectieLijstMixin, APITestCase):
 
         with requests_mock.Mocker() as m:
             mock_selectielijst_oas_get(m)
-            m.get("https://garcia.org/", json={"omschrijving": "bla"})
+            m.get(RESULTAATTYPEOMSCHRIJVING_URL, json={"omschrijving": "bla"})
             m.get(
                 SELECTIELIJSTKLASSE_URL,
                 json={

--- a/src/openzaak/utils/dict.py
+++ b/src/openzaak/utils/dict.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2026 Dimpact
+from typing import Any
+
+
+def get_by_path(d: dict[str, Any], path: str, default: Any = None) -> Any:
+    """
+    Function to get a value from a nested dict at a specified path
+
+    :param d: Dict to get the value from
+    :type d: dict[str, Any]
+    :param path: Dotted path to get the value from
+    :type path: str
+    :param default: Default value to return
+    :type default: Any
+    :return: The value found at the specified path
+    :rtype: Any
+    """
+    keys = path.split(".")
+    for key in keys:
+        try:
+            d = d[key]
+        except (KeyError, TypeError):
+            return default
+    return d


### PR DESCRIPTION
Closes #2263

**Changes**

* Allow afleidingswijze termijn for all procestermijnen except nihil
* Refactor Resultaattype form to reuse API validator for afleidingswijze validation

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
