### PR TITLE
:bug: [#2268] replace audit change modal with table

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,10 @@ jobs:
           pg-service: "postgres"
           setup-node: "yes"
 
+      - name: install playwright
+        if: ${{ matrix.postgres == '17' && matrix.postgis == '3.5' && matrix.use_pooling == false  }}
+        run: playwright install --with-deps chromium
+
       - name: Run tests
 
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           --parallel-mode \
           src/manage.py test src \
             --parallel 4 \
-            --verbosity 2
+            --verbosity 2 \
             --exclude playwright
           coverage combine
         env:
@@ -124,11 +124,11 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: install playwright
-        if:  ${{ matrix.postgres == '17' && matrix.postgis == '3.5' && matrix.use_pooling == false  }}
+        if: ${{ matrix.postgres == '17' && matrix.postgis == '3.5' && matrix.use_pooling == false  }}
         run: playwright install --with-deps chromium
 
       - name: Run playwright tests
-        if:  ${{ matrix.postgres == '17' && matrix.postgis == '3.5' && matrix.use_pooling == false  }}
+        if: ${{ matrix.postgres == '17' && matrix.postgis == '3.5' && matrix.use_pooling == false  }}
         run: src/manage.py test src --tag playwright
 
   performance-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,6 @@ jobs:
           pg-service: "postgres"
           setup-node: "yes"
 
-      - name: install playwright
-        if: ${{ matrix.postgres == '17' && matrix.postgis == '3.5' && matrix.use_pooling == false  }}
-        run: playwright install --with-deps chromium
-
       - name: Run tests
 
         run: |
@@ -115,6 +111,7 @@ jobs:
           src/manage.py test src \
             --parallel 4 \
             --verbosity 2
+            --exclude playwright
           coverage combine
         env:
           DB_POOL_ENABLED: ${{ matrix.use_pooling }}
@@ -125,6 +122,14 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: install playwright
+        if:  ${{ matrix.postgres == '17' && matrix.postgis == '3.5' && matrix.use_pooling == false  }}
+        run: playwright install --with-deps chromium
+
+      - name: Run playwright tests
+        if:  ${{ matrix.postgres == '17' && matrix.postgis == '3.5' && matrix.use_pooling == false  }}
+        run: src/manage.py test src --tag playwright
 
   performance-tests:
     name: Run the performance test suite

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -498,6 +498,8 @@ googleapis-common-protos==1.72.0
     #   -r requirements/base.txt
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
+greenlet==3.3.0
+    # via playwright
 grpcio==1.76.0
     # via
     #   -c requirements/base.txt
@@ -724,6 +726,10 @@ platformdirs==4.3.8
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   requests-cache
+playwright==1.57.0
+    # via
+    #   -r requirements/test-tools.in
+    #   pytest-playwright
 pluggy==1.5.0
     # via pytest
 prometheus-client==0.22.1
@@ -781,6 +787,8 @@ pydantic-settings==2.7.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-setup-configuration
+pyee==13.0.0
+    # via playwright
 pygments==2.19.2
     # via
     #   -c requirements/base.txt
@@ -817,9 +825,15 @@ pytest==8.3.3
     # via
     #   -r requirements/performance-tests.in
     #   -r requirements/test-tools.in
+    #   pytest-base-url
     #   pytest-benchmark
+    #   pytest-playwright
+pytest-base-url==2.1.0
+    # via pytest-playwright
 pytest-benchmark==5.1.0
     # via -r requirements/performance-tests.in
+pytest-playwright==0.7.2
+    # via -r requirements/test-tools.in
 python-creole==1.4.10
     # via
     #   -c requirements/base.txt
@@ -855,6 +869,8 @@ python-ipware==3.0.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-ipware
+python-slugify==8.0.4
+    # via pytest-playwright
 pytz==2022.6
     # via
     #   -c requirements/base.txt
@@ -899,6 +915,7 @@ requests==2.32.4
     #   mozilla-django-oidc
     #   open-api-framework
     #   opentelemetry-exporter-otlp-proto-http
+    #   pytest-base-url
     #   requests-cache
     #   requests-mock
     #   requests-oauthlib
@@ -1012,6 +1029,8 @@ structlog==25.4.0
     #   django-structlog
 tblib==1.7.0
     # via -r requirements/test-tools.in
+text-unidecode==1.3
+    # via python-slugify
 textile==4.0.3
     # via
     #   -c requirements/base.txt
@@ -1038,6 +1057,7 @@ typing-extensions==4.12.2
     #   psycopg-pool
     #   pydantic
     #   pydantic-core
+    #   pyee
     #   pyopenssl
     #   qrcode
     #   zgw-consumers

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -556,6 +556,11 @@ googleapis-common-protos==1.72.0
     #   opentelemetry-exporter-otlp-proto-http
 gprof2dot==2019.11.30
     # via django-silk
+greenlet==3.3.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   playwright
 grpcio==1.76.0
     # via
     #   -c requirements/ci.txt
@@ -816,6 +821,11 @@ platformdirs==4.3.8
     #   -r requirements/ci.txt
     #   requests-cache
     #   virtualenv
+playwright==1.57.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   pytest-playwright
 pluggy==1.5.0
     # via
     #   -c requirements/ci.txt
@@ -889,6 +899,11 @@ pydantic-settings==2.7.0
     #   -r requirements/ci.txt
     #   bump-my-version
     #   django-setup-configuration
+pyee==13.0.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   playwright
 pygments==2.19.2
     # via
     #   -c requirements/ci.txt
@@ -937,12 +952,23 @@ pytest==8.3.3
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   -r requirements/performance-tests.in
+    #   pytest-base-url
     #   pytest-benchmark
+    #   pytest-playwright
+pytest-base-url==2.1.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   pytest-playwright
 pytest-benchmark==5.1.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   -r requirements/performance-tests.in
+pytest-playwright==0.7.2
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 python-creole==1.4.10
     # via
     #   -c requirements/ci.txt
@@ -978,6 +1004,11 @@ python-ipware==3.0.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-ipware
+python-slugify==8.0.4
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   pytest-playwright
 pytz==2022.6
     # via
     #   -c requirements/ci.txt
@@ -1027,6 +1058,7 @@ requests==2.32.4
     #   mozilla-django-oidc
     #   open-api-framework
     #   opentelemetry-exporter-otlp-proto-http
+    #   pytest-base-url
     #   requests-cache
     #   requests-mock
     #   requests-oauthlib
@@ -1181,6 +1213,11 @@ tblib==1.7.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+text-unidecode==1.3
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   python-slugify
 textile==4.0.3
     # via
     #   -c requirements/ci.txt
@@ -1210,6 +1247,7 @@ typing-extensions==4.12.2
     #   psycopg-pool
     #   pydantic
     #   pydantic-core
+    #   pyee
     #   pyopenssl
     #   qrcode
     #   rich-click

--- a/requirements/test-tools.in
+++ b/requirements/test-tools.in
@@ -33,3 +33,8 @@ django-extensions
 
 # SPDX header checks
 click
+
+
+# playwright
+playwright
+pytest-playwright

--- a/requirements/test-tools.in
+++ b/requirements/test-tools.in
@@ -35,6 +35,6 @@ django-extensions
 click
 
 
-# playwright
+# user interface testing
 playwright
 pytest-playwright

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,11 @@
+# TODO move to pyproject?
+
 [coverage:run]
 branch = True
 source = src
 omit =
     */test_*.py
+    */tests/utils/playwright.py
 
 [coverage:report]
 exclude_also =

--- a/src/openzaak/sass/admin/_admin_theme.scss
+++ b/src/openzaak/sass/admin/_admin_theme.scss
@@ -330,3 +330,12 @@ div:has(> div.help ) {
   display: inline-block;
   margin-left: inherit !important;
 }
+
+.audit-button[disabled] {
+  cursor: not-allowed;
+
+  &:hover {
+    background: var(--button-bg);
+  }
+
+}

--- a/src/openzaak/templates/admin/object_history.html
+++ b/src/openzaak/templates/admin/object_history.html
@@ -66,7 +66,7 @@
                     </tbody>
                 </table>
 
-                <h5 id="audit-table-title" style="display: none">Gewijzigde velden</h5>
+                <h5 id="audit-table-title" style="display: none">{% trans 'Gewijzigde velden' %}</h5>
 
                 {% for audit, changes in object.audittrail %}
                     <div id='detail-{{ forloop.counter }}' style="display: none" class="audit-table">

--- a/src/openzaak/templates/admin/object_history.html
+++ b/src/openzaak/templates/admin/object_history.html
@@ -4,111 +4,101 @@
 {% load i18n admin_urls %}
 {% load static %}
 
-{% block content %}
-{% if object.audittrail %}
-<div id="content-main-audittrail">
-<div class="module">
-    <table id="change-history">
-        <thead>
-        <tr>
-            <th scope="col">{% trans 'Aanmaakdatum' %}</th>
-            <th scope="col">{% trans 'UUID' %}</th>
-            <th scope="col">{% trans 'Actie' %}</th>
-            <th scope="col">{% trans 'Resultaat' %}</th>
-            <th scope="col">{% trans 'Gebruiker' %}</th>
-            <th scope="col">{% trans 'Applicatie' %}</th>
-            <th scope="col">{% trans 'Object' %}</th>
-            <th scope="col">{% trans 'Toelichting' %}</th>
-            <th scope="col">{% trans 'Wijzigingen' %}</th>
-        </tr>
-        </thead>
-        <tbody>
-        {% for audit, changes in object.audittrail %}
-            <tr>
-                <th scope="row">{{ audit.aanmaakdatum }}</th>
-                <td>{{ audit.uuid }}</td>
-                <td>{{ audit.actie_weergave }}</td>
-                <td>{{ audit.resultaat }}</td>
-                <td>{{ audit.gebruikers_weergave }}</td>
-                <td>{{ audit.applicatie_weergave }}</td>
-                <td>{{ audit.resource_url }}</td>
-                <td>{{ audit.toelichting }}</td>
-                <td><button class="btn btn-primary" data-toggle="modal" data-target="#myModal-{{forloop.counter}}">{% trans 'Toon wijzigingen' %}</button></td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table>
-</div>
-</div>
-{% endif %}
 
-        {% if object.audittrail and action_list %}
-            <h1>{% trans "Changes made via the admin." %}</h1>
-        {% endif %}
+
+{% block content %}
+    {% if object.audittrail %}
+        <div id="content-main-audittrail">
+            <div class="module">
+                <table id="change-history">
+                    <thead>
+                    <tr>
+                        <th scope="col">{% trans 'Aanmaakdatum' %}</th>
+                        <th scope="col">{% trans 'UUID' %}</th>
+                        <th scope="col">{% trans 'Actie' %}</th>
+                        <th scope="col">{% trans 'Resultaat' %}</th>
+                        <th scope="col">{% trans 'Gebruiker' %}</th>
+                        <th scope="col">{% trans 'Applicatie' %}</th>
+                        <th scope="col">{% trans 'Object' %}</th>
+                        <th scope="col">{% trans 'Toelichting' %}</th>
+                        <th scope="col">{% trans 'Wijzigingen' %}</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for audit, changes in object.audittrail %}
+                        <tr>
+                            <th scope="row">{{ audit.aanmaakdatum }}</th>
+                            <td>{{ audit.uuid }}</td>
+                            <td>{{ audit.actie_weergave }}</td>
+                            <td>{{ audit.resultaat }}</td>
+                            <td>{{ audit.gebruikers_weergave }}</td>
+                            <td>{{ audit.applicatie_weergave }}</td>
+                            <td>{{ audit.resource_url }}</td>
+                            <td>{{ audit.toelichting }}</td>
+                            <td>
+                                <button class="button"
+                                        onclick="toggleTable('detail-{{ forloop.counter }}')">{% trans 'Toon wijzigingen' %}</button>
+                                <script>
+                                    function toggleTable(id) {
+                                        const tables = document.getElementsByClassName("audit-table");
+                                        for (let table of tables) {
+                                            table.style.display = "none";
+                                        };
+
+                                        const selected_table = document.getElementById(id);
+                                        selected_table.style.display = "block"
+
+                                        const title = document.getElementById("audit-table-title");
+                                        title.style.display = "block"
+                                    }
+                                </script>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+
+                <h5 id="audit-table-title" style="display: none">Gewijzigde velden</h5>
+
+                {% for audit, changes in object.audittrail %}
+                    <table id='detail-{{ forloop.counter }}' style="display: none" class="audit-table">
+                        <thead>
+                        <tr>
+                            <th scope="col">{% trans 'veld' %}</th>
+                            <th scope="col">{% trans 'oud' %}</th>
+                            <th scope="col">{% trans 'nieuw' %}</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for change in changes %}
+                            {% for field, diff in change.1.items %}
+                                <tr>
+                                    <th scope="row">{{ field }}</th>
+                                    {% if change.0 == 'add' %}
+                                        <td>-</td>
+                                        <td>{{ diff }}</td>
+                                    {% elif change.0 == 'change' %}
+                                        <td>{{ diff.0 }}</td>
+                                        <td>{{ diff.1 }}</td>
+                                    {% elif change.0 == 'remove' %}
+                                        <td>{{ diff }}</td>
+                                        <td>-</td>
+                                    {% endif %}
+                                </tr>
+                            {% endfor %}
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                {% endfor %}
+
+            </div>
+        </div>
+    {% endif %}
+
+    {% if object.audittrail and action_list %}
+        <h1>{% trans "Changes made via the admin." %}</h1>
+    {% endif %}
 
     {{ block.super }}
 
 {% endblock %}
-
-
-{% block modals %}
-{% for audit, changes in object.audittrail %}
-    <div class="modal hide fade" tabindex="-1" id="myModal-{{forloop.counter}}" role="dialog">
-        <div class="modal-dialog modal-lg" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Gewijzigde velden</h5>
-                    <button type="button" class="close" data-dismiss="modal">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-                <div class="modal-body">
-                    <div class="container bordered">
-                        <div class="row">
-                            <div class="col">
-                                <h4>{% trans 'Veld' %}</h4>
-                            </div>
-                            <div class="col">
-                                <h4>{% trans 'Oud' %}</h4>
-                            </div>
-                            <div class="col">
-                                <h4>{% trans 'Nieuw' %}</h4>
-                            </div>
-                        </div>
-                        {% for change in changes %}
-                            {% if change.0 == 'add' %}
-                                {% for field, diff in change.1.items %}
-                                    <div class="row">
-                                        <div class="col"><code>{{ field }}</code></div>
-                                        <div class="col"></div>
-                                        <div class="col"><p>{{ diff }}</p></div>
-                                    </div>
-                                    <hr/>
-                                {% endfor %}
-                            {% elif change.0 == 'change' %}
-                                {% for field, diff in change.1.items %}
-                                    <div class="row">
-                                        <div class="col"><code>{{ field }}</code></div>
-                                        <div class="col">{{ diff.0 }}</div>
-                                        <div class="col lg-2">{{ diff.1 }}</div>
-                                    </div>
-                                    <hr/>
-                                {% endfor %}
-                            {% elif change.0 == 'remove' %}
-                                {% for field, diff in change.1.items %}
-                                    <div class="row">
-                                        <div class="col"><code>{{ field }}</code></div>
-                                        <div class="col">{{ diff }}</div>
-                                        <div class="col lg-2"></div>
-                                    </div>
-                                    <hr/>
-                                {% endfor %}
-                            {% endif %}
-                        {% endfor %}
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-{% endfor %}
-{% endblock modals %}

--- a/src/openzaak/templates/admin/object_history.html
+++ b/src/openzaak/templates/admin/object_history.html
@@ -36,20 +36,28 @@
                             <td>{{ audit.resource_url }}</td>
                             <td>{{ audit.toelichting }}</td>
                             <td>
-                                <button class="button"
-                                        onclick="toggleTable('detail-{{ forloop.counter }}')">{% trans 'Toon wijzigingen' %}</button>
+                                <button class="button audit-button"
+                                        onclick="toggleTable('{{ forloop.counter }}', this)">{% trans 'Toon wijzigingen' %}</button>
                                 <script>
-                                    function toggleTable(id) {
+                                    function toggleTable(id, selected_button) {
+
                                         const tables = document.getElementsByClassName("audit-table");
                                         for (let table of tables) {
                                             table.style.display = "none";
-                                        };
+                                        }
 
-                                        const selected_table = document.getElementById(id);
-                                        selected_table.style.display = "block"
+                                        const buttons = document.getElementsByClassName("button");
+                                        for (let button of buttons) {
+                                            button.disabled = false;
+                                        }
+
+                                        selected_button.disabled = true;
+
+                                        const selected_table = document.getElementById(`detail-${id}`);
+                                        selected_table.style.display = "block";
 
                                         const title = document.getElementById("audit-table-title");
-                                        title.style.display = "block"
+                                        title.style.display = "block";
                                     }
                                 </script>
                             </td>
@@ -61,34 +69,37 @@
                 <h5 id="audit-table-title" style="display: none">Gewijzigde velden</h5>
 
                 {% for audit, changes in object.audittrail %}
-                    <table id='detail-{{ forloop.counter }}' style="display: none" class="audit-table">
-                        <thead>
-                        <tr>
-                            <th scope="col">{% trans 'veld' %}</th>
-                            <th scope="col">{% trans 'oud' %}</th>
-                            <th scope="col">{% trans 'nieuw' %}</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {% for change in changes %}
-                            {% for field, diff in change.1.items %}
-                                <tr>
-                                    <th scope="row">{{ field }}</th>
-                                    {% if change.0 == 'add' %}
-                                        <td>-</td>
-                                        <td>{{ diff }}</td>
-                                    {% elif change.0 == 'change' %}
-                                        <td>{{ diff.0 }}</td>
-                                        <td>{{ diff.1 }}</td>
-                                    {% elif change.0 == 'remove' %}
-                                        <td>{{ diff }}</td>
-                                        <td>-</td>
-                                    {% endif %}
-                                </tr>
+                    <div id='detail-{{ forloop.counter }}' style="display: none" class="audit-table">
+                        <h5>{{ audit.aanmaakdatum }} - {{ audit.uuid }}</h5>
+                        <table>
+                            <thead>
+                            <tr>
+                                <th scope="col">{% trans 'veld' %}</th>
+                                <th scope="col">{% trans 'oud' %}</th>
+                                <th scope="col">{% trans 'nieuw' %}</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {% for change in changes %}
+                                {% for field, diff in change.1.items %}
+                                    <tr>
+                                        <th scope="row">{{ field }}</th>
+                                        {% if change.0 == 'add' %}
+                                            <td>-</td>
+                                            <td>{{ diff }}</td>
+                                        {% elif change.0 == 'change' %}
+                                            <td>{{ diff.0 }}</td>
+                                            <td>{{ diff.1 }}</td>
+                                        {% elif change.0 == 'remove' %}
+                                            <td>{{ diff }}</td>
+                                            <td>-</td>
+                                        {% endif %}
+                                    </tr>
+                                {% endfor %}
                             {% endfor %}
-                        {% endfor %}
-                        </tbody>
-                    </table>
+                            </tbody>
+                        </table>
+                    </div>
                 {% endfor %}
 
             </div>

--- a/src/openzaak/tests/js/__init__.py
+++ b/src/openzaak/tests/js/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2025 Dimpact

--- a/src/openzaak/tests/js/test_objecthistory.py
+++ b/src/openzaak/tests/js/test_objecthistory.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2025 Dimpact
 from django.test import override_settings, tag
+from django.utils.translation import gettext as _
 
+from maykin_2fa.test import disable_admin_mfa
 from playwright.sync_api import expect
 
 from openzaak.accounts.tests.factories import SuperUserFactory
@@ -11,6 +13,7 @@ from openzaak.tests.utils.playwright import PlaywrightSyncLiveServerTestCase
 
 @tag("playwright")
 @override_settings(AXES_ENABLED=False)
+@disable_admin_mfa()
 class ObjectHistoryTests(PlaywrightSyncLiveServerTestCase):
     def setUp(self):
         super().setUp()
@@ -23,6 +26,7 @@ class ObjectHistoryTests(PlaywrightSyncLiveServerTestCase):
         context = self.browser.new_context(storage_state=self.login_state)
 
         page = context.new_page()
+
         page.goto(self.live_reverse("admin:zaken_zaak_history", args=(zaak.pk,)))
 
         page.wait_for_url(
@@ -30,7 +34,11 @@ class ObjectHistoryTests(PlaywrightSyncLiveServerTestCase):
         )
 
         expect(
-            page.get_by_text("Dit object heeft geen wijzigingsgeschiedenis.")
+            page.get_by_text(
+                _(
+                    "This object doesn’t have a change history. It probably wasn’t added via this admin site."
+                )
+            )
         ).to_be_visible()
 
     def test_object_history_page_with_trails(self):
@@ -42,7 +50,7 @@ class ObjectHistoryTests(PlaywrightSyncLiveServerTestCase):
         # create 5 audittrails
         for i in range(5):
             page.fill("#id_toelichting", f"test {i}")
-            page.get_by_role("button", name="Opslaan en opnieuw bewerken").click()
+            page.get_by_role("button", name=_("Save and continue editing")).click()
             page.wait_for_url(
                 self.live_reverse("admin:zaken_zaak_change", args=(zaak.pk,))
             )
@@ -50,13 +58,14 @@ class ObjectHistoryTests(PlaywrightSyncLiveServerTestCase):
         page.goto(self.live_reverse("admin:zaken_zaak_history", args=(zaak.pk,)))
 
         # 5 audittrail rows are shown
-        self.assertEqual(page.locator("text=Toon wijzigingen").count(), 5)
+        buttons = page.locator(f"text={_('Toon wijzigingen')}")
+        self.assertEqual(buttons.count(), 5)
 
         # on page load no changed fields are shown
-        expect(page.get_by_text("Gewijzigde velden")).to_be_hidden()
+        expect(page.get_by_text(_("Gewijzigde velden"))).to_be_hidden()
 
         # toon wijzigingen
-        page.locator("text=Toon wijzigingen").first.click()
+        buttons.first.click()
         expect(page.get_by_text("Gewijzigde velden")).to_be_visible()
 
         # expect table text
@@ -64,7 +73,17 @@ class ObjectHistoryTests(PlaywrightSyncLiveServerTestCase):
         expect(table_div).to_be_visible()
         text = [t.strip() for t in table_div.text_content().split() if t.strip()]
         self.assertEqual(
-            text, ["veld", "oud", "nieuw", "toelichting", "test", "3", "test", "4"]
+            text,
+            [
+                _("veld"),
+                _("oud"),
+                _("nieuw"),
+                "toelichting",
+                "test",
+                "3",
+                "test",
+                "4",
+            ],
         )
 
         # expect other tables to be hidden
@@ -78,7 +97,7 @@ class ObjectHistoryTests(PlaywrightSyncLiveServerTestCase):
         self.assertEqual(disabled_buttons.count(), 1)
 
         # select different one
-        page.locator("text=Toon wijzigingen").nth(1).click()
+        buttons.nth(1).click()
         expect(page.get_by_text("Gewijzigde velden")).to_be_visible()
 
         # expect table text

--- a/src/openzaak/tests/js/test_objecthistory.py
+++ b/src/openzaak/tests/js/test_objecthistory.py
@@ -1,0 +1,98 @@
+from django.test import override_settings, tag
+
+from playwright.sync_api import expect
+
+from openzaak.accounts.tests.factories import SuperUserFactory
+from openzaak.components.zaken.tests.factories import ZaakFactory
+from openzaak.tests.utils.playwright import PlaywrightSyncLiveServerTestCase
+
+
+@tag("playwright")
+@override_settings(AXES_ENABLED=False)
+class ObjectHistoryTests(PlaywrightSyncLiveServerTestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = SuperUserFactory.create()
+        self.login_state = self.get_user_login_state(self.user)
+
+    def test_object_history_page_without_trails(self):
+        zaak = ZaakFactory.create()
+
+        context = self.browser.new_context(storage_state=self.login_state)
+
+        page = context.new_page()
+        page.goto(self.live_reverse("admin:zaken_zaak_history", args=(zaak.pk,)))
+
+        page.wait_for_url(
+            self.live_reverse("admin:zaken_zaak_history", args=(zaak.pk,))
+        )
+
+        expect(
+            page.get_by_text("Dit object heeft geen wijzigingsgeschiedenis.")
+        ).to_be_visible()
+
+    def test_object_history_page_with_trails(self):
+        zaak = ZaakFactory.create()
+        context = self.browser.new_context(storage_state=self.login_state)
+        page = context.new_page()
+        page.goto(self.live_reverse("admin:zaken_zaak_change", args=(zaak.pk,)))
+
+        # create 5 audittrails
+        for i in range(5):
+            page.fill("#id_toelichting", f"test {i}")
+            page.get_by_role("button", name="Opslaan en opnieuw bewerken").click()
+            page.wait_for_url(
+                self.live_reverse("admin:zaken_zaak_change", args=(zaak.pk,))
+            )
+
+        page.goto(self.live_reverse("admin:zaken_zaak_history", args=(zaak.pk,)))
+
+        # 5 audittrail rows are shown
+        self.assertEqual(page.locator("text=Toon wijzigingen").count(), 5)
+
+        # on page load no changed fields are shown
+        expect(page.get_by_text("Gewijzigde velden")).to_be_hidden()
+
+        # toon wijzigingen
+        page.locator("text=Toon wijzigingen").first.click()
+        expect(page.get_by_text("Gewijzigde velden")).to_be_visible()
+
+        # expect table text
+        table_div = page.locator("#detail-1 table")
+        expect(table_div).to_be_visible()
+        text = [t.strip() for t in table_div.text_content().split() if t.strip()]
+        self.assertEqual(
+            text, ["veld", "oud", "nieuw", "toelichting", "test", "3", "test", "4"]
+        )
+
+        # expect other tables to be hidden
+        expect(page.get_by_text("#detail-2")).to_be_hidden()
+        expect(page.get_by_text("#detail-3")).to_be_hidden()
+        expect(page.get_by_text("#detail-4")).to_be_hidden()
+        expect(page.get_by_text("#detail-5")).to_be_hidden()
+
+        # expect 1 button to be disabled
+        disabled_buttons = page.locator("button.audit-button:disabled")
+        self.assertEqual(disabled_buttons.count(), 1)
+
+        # select different one
+        page.locator("text=Toon wijzigingen").nth(1).click()
+        expect(page.get_by_text("Gewijzigde velden")).to_be_visible()
+
+        # expect table text
+        table_div = page.locator("#detail-2 table")
+        expect(table_div).to_be_visible()
+        text = [t.strip() for t in table_div.text_content().split() if t.strip()]
+        self.assertEqual(
+            text, ["veld", "oud", "nieuw", "toelichting", "test", "2", "test", "3"]
+        )
+
+        # expect other tables to be hidden
+        expect(page.get_by_text("#detail-1")).to_be_hidden()
+        expect(page.get_by_text("#detail-3")).to_be_hidden()
+        expect(page.get_by_text("#detail-4")).to_be_hidden()
+        expect(page.get_by_text("#detail-5")).to_be_hidden()
+
+        # expect 1 button to be disabled
+        disabled_buttons = page.locator("button.audit-button:disabled")
+        self.assertEqual(disabled_buttons.count(), 1)

--- a/src/openzaak/tests/js/test_objecthistory.py
+++ b/src/openzaak/tests/js/test_objecthistory.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2025 Dimpact
 from django.test import override_settings, tag
 
 from playwright.sync_api import expect

--- a/src/openzaak/tests/utils/playwright.py
+++ b/src/openzaak/tests/utils/playwright.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2025 Dimpact
 import os
 import tempfile
 from collections.abc import Callable

--- a/src/openzaak/tests/utils/playwright.py
+++ b/src/openzaak/tests/utils/playwright.py
@@ -1,0 +1,153 @@
+import os
+import tempfile
+from collections.abc import Callable
+
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.test import override_settings
+from django.urls import reverse
+
+from furl import furl
+from playwright.sync_api import Browser, Playwright, sync_playwright
+
+from openzaak.accounts.models import User
+
+BROWSER_DRIVERS = {
+    # keys for the E2E_DRIVER environment variable (likely from test matrix)
+    "chromium": lambda p: p.chromium.launch(),
+    "firefox": lambda p: p.firefox.launch(),
+    "webkit": lambda p: p.webkit.launch(),
+    "msedge": lambda p: p.chromium.launch(channel="msedge"),
+    # MORE here, with interesting launch options
+}
+BROWSER_DEFAULT = "chromium"
+
+
+def temp_media_root():
+    # Convenience decorator/context manager to use a temporary directory as
+    # PRIVATE_MEDIA_ROOT.
+    tmpdir = tempfile.mkdtemp()
+    return override_settings(MEDIA_ROOT=tmpdir)
+
+
+def get_driver_name() -> str:
+    return os.environ.get("E2E_DRIVER", BROWSER_DEFAULT)
+
+
+@temp_media_root()
+class PlaywrightSyncLiveServerTestCase(StaticLiveServerTestCase):
+    """
+    base class for convenient synchronous Playwright in Django
+
+    to help with debugging set the environment variable PWDEBUG=1 or PWDEBUG=console
+
+    to set the browser define E2E_DRIVER environment variable, with a value from the BROWSER_DRIVERS dictionary above.
+
+    usage:
+
+    from playwright.sync_api import expect
+
+    class MyPageTest(PlaywrightSyncLiveServerTestCase):
+        def test_my_page():
+            # get a new context for test isolation
+            context = self.browser.new_context()
+
+            # open a page
+            page = context.new_page()
+
+            url = ...
+            page.goto(url)
+
+            # or more convenient:
+            page.goto(self.live_url(path))
+            page.goto(self.live_reverse("myapp:someobject_details", kwargs={"object_id": obj.id}, params={"query": "my keyword")))
+
+            # do your things
+            expect(page).to_have_title("Awesome title")
+            ...
+    """
+
+    playwright: Playwright
+    browser: Browser
+
+    _old_async_unsafe: str
+
+    @classmethod
+    def launch_browser(cls, playwright: Playwright) -> Browser:
+        launcher = cls.get_browser_launcher()
+        return launcher(playwright)
+
+    @classmethod
+    def get_browser_launcher(cls) -> Callable[[Playwright], Browser]:
+        name = get_driver_name()
+        if name in BROWSER_DRIVERS:
+            return BROWSER_DRIVERS[name]
+        else:
+            raise Exception(f"cannot find browser end-2-end driver '{name}'")
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # required for playwright cleanup
+        cls._old_async_unsafe = os.environ.get("DJANGO_ALLOW_ASYNC_UNSAFE")
+        os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
+
+        cls.playwright = sync_playwright().start()
+        cls.browser = cls.launch_browser(cls.playwright)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._old_async_unsafe is None:
+            os.environ.pop("DJANGO_ALLOW_ASYNC_UNSAFE")
+        else:
+            os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = cls._old_async_unsafe
+
+        super().tearDownClass()
+
+        cls.browser.close()
+        cls.playwright.stop()
+
+    @classmethod
+    def live_url(cls, path="/", star=False):
+        """
+        prepend self.live_server_url to path
+        optionally append '*' wildcard matcher (useful for page.wait_for_url() etc)
+        """
+        url = f"{cls.live_server_url}{path}"
+        if star:
+            url = f"{url}*"
+        return url
+
+    @classmethod
+    def live_reverse(cls, viewname, args=None, kwargs=None, params=None, star=False):
+        """
+        do a reverse() url, prepend self.live_server_url
+        optionally add query params to url
+        optionally append '*' wildcard matcher (useful for page.wait_for_url() etc)
+        """
+        path = reverse(viewname, args=args, kwargs=kwargs)
+        assert not (params and star), "cannot combine params and star arguments (yet)"
+        url = cls.live_url(path, star=star)
+        if params:
+            url = furl(url).set(params).url
+        return url
+
+    @classmethod
+    def get_user_login_state(cls, user: User):
+        assert user.pk, "user instance must be saved"
+
+        context = cls.browser.new_context()
+        page = context.new_page()
+
+        page.goto(cls.live_reverse("admin:login"))
+
+        page.fill("#id_auth-username", user.username)
+        page.fill("#id_auth-password", "secret")
+
+        page.get_by_role("button", name="Aanmelden").click()
+        page.wait_for_url(cls.live_reverse("admin:index"))
+
+        page.close()
+        login_state = context.storage_state()
+        context.close()
+        return login_state

--- a/src/openzaak/tests/utils/playwright.py
+++ b/src/openzaak/tests/utils/playwright.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.test import override_settings
 from django.urls import reverse
+from django.utils.translation import gettext as _
 
 from furl import furl
 from playwright.sync_api import Browser, Playwright, sync_playwright
@@ -146,7 +147,7 @@ class PlaywrightSyncLiveServerTestCase(StaticLiveServerTestCase):
         page.fill("#id_auth-username", user.username)
         page.fill("#id_auth-password", "secret")
 
-        page.get_by_role("button", name="Aanmelden").click()
+        page.get_by_role("button", name=_("Log in")).click()
         page.wait_for_url(cls.live_reverse("admin:index"))
 
         page.close()


### PR DESCRIPTION
Closes #2268 

**Changes**
- replaces broken audit change modal popup with table

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
