### PR TITLE
:sparkles: [#2283] Show ZaakNotities in the Admin

### DIFF
--- a/src/openzaak/components/zaken/admin/zaken.py
+++ b/src/openzaak/components/zaken/admin/zaken.py
@@ -38,6 +38,7 @@ from ..models import (
     ZaakContactMoment,
     ZaakEigenschap,
     ZaakInformatieObject,
+    ZaakNotitie,
     ZaakObject,
     ZaakVerzoek,
 )
@@ -600,6 +601,29 @@ class ZaakKenmerkAdmin(admin.ModelAdmin):
     raw_id_fields = ["zaak"]
 
 
+@admin.register(ZaakNotitie)
+class ZaakNotitieAdmin(admin.ModelAdmin):
+    list_display = [
+        "onderwerp",
+        "notitie_type",
+        "status",
+        "aanmaakdatum",
+    ]
+    readonly_fields = ("uuid", "aanmaakdatum", "wijzigingsdatum")
+    list_select_related = ["gerelateerd_aan"]
+    search_fields = (
+        "gerelateerd_aan__identificatie",
+        "gerelateerd_aan__uuid",
+        "onderwerp",
+        "tekst",
+    )
+    list_filter = (
+        "notitie_type",
+        "status",
+    )
+    raw_id_fields = ["gerelateerd_aan"]
+
+
 # inline classes for Zaak
 class StatusInline(EditInlineAdminMixin, admin.TabularInline):
     model = Status
@@ -679,6 +703,12 @@ class ZaakKenmerkInline(EditInlineAdminMixin, admin.TabularInline):
     fk_name = "zaak"
 
 
+class ZaakNotitieInline(EditInlineAdminMixin, admin.TabularInline):
+    model = ZaakNotitie
+    fields = ZaakNotitieAdmin.list_display
+    fk_name = "gerelateerd_aan"
+
+
 class ZaakForm(forms.ModelForm):
     class Meta:
         model = Zaak
@@ -748,6 +778,7 @@ class ZaakAdmin(
         RelevanteZaakRelatieInline,
         ZaakBesluitInline,
         KlantContactInline,
+        ZaakNotitieInline,
     ]
     raw_id_fields = ("_zaaktype", "hoofdzaak", "_zaaktype_base_url")
     viewset = "openzaak.components.zaken.api.viewsets.ZaakViewSet"
@@ -790,6 +821,7 @@ class ZaakAdmin(
             link_to_related_objects(ZaakKenmerk, obj),
             link_to_related_objects(ZaakBesluit, obj),
             link_to_related_objects(RelevanteZaakRelatie, obj, rel_field_name="zaak"),
+            link_to_related_objects(ZaakNotitie, obj, rel_field_name="gerelateerd_aan"),
         )
 
     def get_queryset(self, request):

--- a/src/openzaak/components/zaken/tests/admin/test_zaak_admin.py
+++ b/src/openzaak/components/zaken/tests/admin/test_zaak_admin.py
@@ -123,7 +123,7 @@ class ZaakAdminTests(WebTest):
             .find(class_="field-_get_object_actions")
             .find_all("a")
         )
-        self.assertEqual(len(rel_object_links), 10)
+        self.assertEqual(len(rel_object_links), 11)
         for link in rel_object_links:
             url = link["href"]
             with self.subTest(url):

--- a/src/openzaak/components/zaken/tests/admin/test_zaaknotitie_admin.py
+++ b/src/openzaak/components/zaken/tests/admin/test_zaaknotitie_admin.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2019 - 2020 Dimpact
+from django.urls import reverse
+
+from django_webtest import WebTest
+from maykin_2fa.test import disable_admin_mfa
+from vng_api_common.notes.constants import NotitieStatus, NotitieType
+
+from openzaak.components.zaken.models import ZaakNotitie
+from openzaak.tests.utils import AdminTestMixin
+
+from ..factories import ZaakFactory, ZaakNotitieFactory
+
+
+@disable_admin_mfa()
+class ZaakNotitieAdminTests(AdminTestMixin, WebTest):
+    heeft_alle_autorisaties = True
+
+    def setUp(self):
+        super().setUp()
+        self.app.set_user(self.user)
+
+    def test_valid_create_zaaknotitie(self):
+        zaak = ZaakFactory.create()
+
+        get_response = self.app.get(reverse("admin:zaken_zaaknotitie_add"))
+        form = get_response.forms["zaaknotitie_form"]
+        form["gerelateerd_aan"] = zaak.id
+        form["onderwerp"] = "onderwerp"
+        form["tekst"] = "tekst"
+        form["aangemaakt_door"] = "aangemaakt_door"
+        form["notitie_type"] = NotitieType.INTERN
+        form["status"] = NotitieStatus.CONCEPT
+
+        form.submit()
+
+        self.assertEqual(ZaakNotitie.objects.count(), 1)
+        zaaknotitie = ZaakNotitie.objects.get()
+
+        self.assertEqual(zaaknotitie.gerelateerd_aan.id, zaak.id)
+        self.assertEqual(zaaknotitie.onderwerp, "onderwerp")
+        self.assertEqual(zaaknotitie.tekst, "tekst")
+        self.assertEqual(zaaknotitie.aangemaakt_door, "aangemaakt_door")
+        self.assertEqual(zaaknotitie.notitie_type, NotitieType.INTERN)
+        self.assertEqual(zaaknotitie.status, NotitieStatus.CONCEPT)
+
+    def test_invalid_create_zaaknotitie(self):
+        zaak = ZaakFactory.create()
+
+        get_response = self.app.get(reverse("admin:zaken_zaaknotitie_add"))
+        form = get_response.forms["zaaknotitie_form"]
+        form["gerelateerd_aan"] = zaak.id
+        form["tekst"] = "tekst"
+        form["aangemaakt_door"] = "aangemaakt_door"
+        form["notitie_type"] = NotitieType.INTERN
+        form["status"] = NotitieStatus.CONCEPT
+
+        response = form.submit()
+        self.assertContains(
+            response,
+            "Dit veld is verplicht.",  # onderwerp field
+        )
+        self.assertEqual(ZaakNotitie.objects.count(), 0)
+
+    def test_valid_update_zaaknotitie(self):
+        zaak = ZaakFactory.create()
+        zaaknotitie = ZaakNotitieFactory.create(
+            gerelateerd_aan=zaak,
+            onderwerp="test_onderwerp",
+            tekst="test",
+            status=NotitieStatus.CONCEPT.value,
+            notitie_type=NotitieType.INTERN.value,
+        )
+        get_response = self.app.get(
+            reverse("admin:zaken_zaaknotitie_change", args=(zaaknotitie.pk,))
+        )
+
+        form = get_response.forms["zaaknotitie_form"]
+        form["notitie_type"] = NotitieType.EXTERN
+        form["status"] = NotitieStatus.DEFINITIEF
+
+        form.submit()
+
+        self.assertEqual(ZaakNotitie.objects.count(), 1)
+        zaaknotitie = ZaakNotitie.objects.get()
+
+        self.assertEqual(zaaknotitie.gerelateerd_aan.id, zaak.id)
+        self.assertEqual(zaaknotitie.onderwerp, "test_onderwerp")
+        self.assertEqual(zaaknotitie.tekst, "test")
+        self.assertEqual(zaaknotitie.notitie_type, NotitieType.EXTERN)
+        self.assertEqual(zaaknotitie.status, NotitieStatus.DEFINITIEF)


### PR DESCRIPTION
Closes #2283 

**Changes**

- Implement ZaakNotities in the Admin 

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [ ] Any experimental features added in this PR are backwards compatible
  - [ ] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how
