### PR TITLE
:bug: [#2230] Fix PATCH for ZaakNotitie

### DIFF
--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -2003,6 +2003,7 @@ class ZaakNotitieViewSet(
         "retrieve": SCOPE_ZAKEN_ALLES_LEZEN,
         "create": SCOPE_ZAKEN_BIJWERKEN,
         "update": SCOPE_ZAKEN_BIJWERKEN,
+        "partial_update": SCOPE_ZAKEN_BIJWERKEN,
         "destroy": SCOPE_ZAKEN_BIJWERKEN,
     }
 

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -6587,6 +6587,9 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PatchedZaakNotitieRequest'
+      security:
+      - JWT-Claims:
+        - zaken.bijwerken
       responses:
         '200':
           headers:

--- a/src/openzaak/components/zaken/tests/test_notitie.py
+++ b/src/openzaak/components/zaken/tests/test_notitie.py
@@ -137,6 +137,20 @@ class ZaakNotitieTestCase(JWTAuthMixin, APITestCase):
             _("Notitie can only be modified when status is `concept`."),
         )
 
+    def test_partial_update(self):
+        notitie = ZaakNotitieFactory.create(
+            onderwerp="Old Value",
+            status=NotitieStatus.CONCEPT,
+        )
+        detail_url = reverse("zaaknotitie-detail", kwargs={"uuid": notitie.uuid})
+
+        data = {"onderwerp": "New Value"}
+        response = self.client.patch(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        notitie = ZaakNotitie.objects.get()
+        self.assertEqual(notitie.onderwerp, "New Value")
+
     def test_delete(self):
         notitie = ZaakNotitieFactory.create(onderwerp="Old Value")
         self.assertEqual(ZaakNotitie.objects.count(), 1)


### PR DESCRIPTION
Closes #2230 

**Changes**

Add missing  ` "partial_update": SCOPE_ZAKEN_BIJWERKEN `

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [ ] Any experimental features added in this PR are backwards compatible
  - [ ] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how
