### PR TITLE
:construction_worker: Improve setup for bencher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
 
   performance-tests:
     name: Run the performance test suite
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     services:
       postgres:
@@ -191,12 +191,11 @@ jobs:
                       --project open-zaak-ed2ce35-z71n5gf8t4f40 \
                       --token '${{ secrets.BENCHER_API_TOKEN }}' \
                       --branch main \
-                      --testbed ubuntu-latest \
+                      --testbed ubuntu-24.04 \
                       --average median \
-                      --start-point-reset \
                       --github-actions '${{ secrets.GITHUB_TOKEN }}' \
                       --file output.json \
-                      "pytest performance_test/ --benchmark-json output.json"
+                      "pytest performance_test/ --benchmark-warmup=on --benchmark-warmup-iterations=5 --benchmark-json output.json"
 
       - name: Run tests for other branches
         if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
@@ -206,17 +205,15 @@ jobs:
                       --token '${{ secrets.BENCHER_API_TOKEN }}' \
                       --branch "$GITHUB_HEAD_REF" \
                       --start-point "$GITHUB_BASE_REF" \
-                      --start-point-reset \
                       --start-point-max-versions 1 \
                       --average median \
                       --threshold-measure latency \
                       --threshold-test percentage \
                       --threshold-upper-boundary 0.05 \
-                      --thresholds-reset \
-                      --testbed ubuntu-latest \
+                      --testbed ubuntu-24.04 \
                       --github-actions '${{ secrets.GITHUB_TOKEN }}' \
                       --file output.json \
-                      "pytest performance_test/ --benchmark-json output.json"
+                      "pytest performance_test/ --benchmark-warmup=on --benchmark-warmup-iterations=5 --benchmark-json output.json"
 
   docs:
     name: Documentation check


### PR DESCRIPTION
I noticed I could see a plot for the history of results on main, this PR should fix that. Tested it locally by doing manual runs for a tmp branch:

<img width="1519" height="760" alt="image" src="https://github.com/user-attachments/assets/487eae1b-b3e9-4ca8-9548-eea0fdafb8ef" />

**Changes**

* ensure runs-on is pinned on ubuntu-24.04 and use this as the new testbed
* avoid resetting startpoint for main to make sure history can be plotted for main in bencher
* enable warmup for pytest-benchmark to avoid noisy results

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
