### PR TITLE
Fix missing network in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,6 +155,8 @@ services:
       - "9000:80"
     depends_on:
       - web.local
+    networks:
+      - open-zaak-dev
 
 volumes:
   db:


### PR DESCRIPTION
The missing docker network was making the web.local host unreacheable