### PR TITLE
:bug: Fix OSError: Too many open files

### DIFF
--- a/src/openzaak/components/documenten/api/serializers.py
+++ b/src/openzaak/components/documenten/api/serializers.py
@@ -128,7 +128,8 @@ class AnyBase64File(Base64FileField):
 
         # if there is no associated file link is not returned
         try:
-            file.file
+            with file.file:
+                pass
         except ValueError as e:
             logger.warning("unable_to_open_file", error=str(e))
             return None


### PR DESCRIPTION
FileStorage returns an open file descriptor!

For paginated EIOs with sufficiently large page size this runs into the max open inodes per process if not properly closed.

I haven't seen this error in Sentry. I hope this is not because the process can't open the socket to report the error. In dev it results in a long cascade of the same error because the 500.html template can't be opened.

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
