### PR TITLE
:sparkles: [#1877] Allow deletion of unused published catalogi resources via admin

### DIFF
--- a/src/openzaak/components/catalogi/admin/catalogus.py
+++ b/src/openzaak/components/catalogi/admin/catalogus.py
@@ -106,6 +106,13 @@ class CatalogusAdmin(
     )
     inlines = (ZaakTypeInline, BesluitTypeInline, InformatieObjectTypeInline)
     readonly_fields = ("uuid",)
+    # Templates to add warning message when trying to delete published types
+    delete_confirmation_template = (
+        "admin/catalogi/delete_confirmation_published_warning.html"
+    )
+    delete_selected_confirmation_template = (
+        "admin/catalogi/delete_selected_confirmation_published_warning.html"
+    )
 
     # For import/export mixins
     resource_name = "catalogus"

--- a/src/openzaak/components/catalogi/admin/informatieobjecttype.py
+++ b/src/openzaak/components/catalogi/admin/informatieobjecttype.py
@@ -4,6 +4,8 @@ from django.contrib import admin
 from django.db.models import Count
 from django.utils.translation import gettext_lazy as _
 
+from openzaak.components.documenten.models import EnkelvoudigInformatieObject
+from openzaak.components.zaken.models import ZaakInformatieObject
 from openzaak.utils.admin import (
     EditInlineAdminMixin,
     ListObjectActionsAdminMixin,
@@ -68,6 +70,23 @@ class ZaakTypeInformatieObjectTypeAdmin(
         if not obj:
             return True
         return obj.zaaktype.concept or obj.informatieobjecttype.concept
+
+    def has_delete_permission(self, request, obj=None):
+        # Instead of checking whether or not the zaaktype/informatieobjecttype is a
+        # concept, we check if any relations between Zaken and InformatieObjecten exist
+        # that depend on this relationship. If they do, the relationship cannot be
+        # deleted
+        if obj:
+            # Only allow deletion if no relations exist between zaken and documenten
+            # of the types linked by this ZaakTypeInformatieObjectType object
+            if ZaakInformatieObject.objects.filter(
+                zaak__zaaktype=obj.zaaktype,
+                _informatieobject__pk__in=EnkelvoudigInformatieObject.objects.filter(
+                    _informatieobjecttype=obj.informatieobjecttype
+                ).values_list("canonical", flat=True),
+            ).exists():
+                return False
+        return super().has_delete_permission(request, obj)
 
 
 class ZaakTypeInformatieObjectTypeInline(EditInlineAdminMixin, admin.TabularInline):

--- a/src/openzaak/components/catalogi/admin/mixins.py
+++ b/src/openzaak/components/catalogi/admin/mixins.py
@@ -386,15 +386,18 @@ class ImportMixin:
 
 
 class ReadOnlyPublishedBaseMixin:
+    # Templates to add warning message when trying to delete published types
+    delete_confirmation_template = (
+        "admin/catalogi/delete_confirmation_published_warning.html"
+    )
+    delete_selected_confirmation_template = (
+        "admin/catalogi/delete_selected_confirmation_published_warning.html"
+    )
+
     def get_concept(self, obj):
         return NotImplementedError(
             "subclasses of ReadOnlyPublishedBaseMixin must provide a get_concept() method"
         )
-
-    def has_delete_permission(self, request, obj=None):
-        if self.get_concept(obj):
-            return super().has_delete_permission(request, obj)
-        return False
 
     def get_inline_instances(self, request, obj=None):
         inlines = super().get_inline_instances(request, obj)

--- a/src/openzaak/components/catalogi/models/catalogus.py
+++ b/src/openzaak/components/catalogi/models/catalogus.py
@@ -120,3 +120,14 @@ class Catalogus(ETagMixin, APIMixin, models.Model):
 
     def __str__(self):
         return self.naam
+
+    @property
+    def concept(self):
+        """
+        A Catalogus is only considered concept if all subresources are concepts
+        """
+        return not (
+            self.zaaktype_set.filter(concept=False).exists()
+            or self.informatieobjecttype_set.filter(concept=False).exists()
+            or self.besluittype_set.filter(concept=False).exists()
+        )

--- a/src/openzaak/components/catalogi/models/eigenschap.py
+++ b/src/openzaak/components/catalogi/models/eigenschap.py
@@ -223,6 +223,14 @@ class Eigenschap(ETagMixin, APIMixin, OptionalGeldigheidMixin, models.Model):
         ),
     )
 
+    @property
+    def concept(self):
+        """
+        Subresources of Zaaktype are implicitly concept or non-concept based on the
+        value of this attribute of the Zaaktype
+        """
+        return self.zaaktype.concept
+
     class Meta:
         unique_together = ("zaaktype", "eigenschapnaam")
         verbose_name = _("Eigenschap")

--- a/src/openzaak/components/catalogi/models/eigenschap.py
+++ b/src/openzaak/components/catalogi/models/eigenschap.py
@@ -239,7 +239,11 @@ class Eigenschap(ETagMixin, APIMixin, OptionalGeldigheidMixin, models.Model):
     def clean(self):
         super().clean()
 
-        validate_zaaktype_concept(self.zaaktype)
+        # This validation is performed before validating required fields, if zaaktype
+        # was not supplied, we skip this validation and the form validate will fail
+        # on the missing zaaktype
+        if zaaktype := getattr(self, "zaaktype", None):
+            validate_zaaktype_concept(zaaktype)
 
     def __str__(self):
         return self.eigenschapnaam

--- a/src/openzaak/components/catalogi/models/relatieklassen.py
+++ b/src/openzaak/components/catalogi/models/relatieklassen.py
@@ -129,7 +129,7 @@ class ZaakTypenRelatie(models.Model):
     def concept(self):
         """
         Subresources of Zaaktype are implicitly concept or non-concept based on the
-        value of this attribute of the Zaaktype
+        value of this attribute of the Zaaktype and the Informatieobjecttype
         """
         return self.zaaktype.concept
 

--- a/src/openzaak/components/catalogi/models/relatieklassen.py
+++ b/src/openzaak/components/catalogi/models/relatieklassen.py
@@ -68,6 +68,14 @@ class ZaakTypeInformatieObjectType(ETagMixin, models.Model):
         ),
     )
 
+    @property
+    def concept(self):
+        """
+        Subresources of Zaaktype are implicitly concept or non-concept based on the
+        value of this attribute of the Zaaktype
+        """
+        return self.zaaktype.concept and self.informatieobjecttype.concept
+
     class Meta:
         # NOTE: The uniqueness is implied in the specification.
         unique_together = ("zaaktype", "volgnummer")
@@ -116,6 +124,14 @@ class ZaakTypenRelatie(models.Model):
             "Een toelichting op de aard van de relatie tussen beide ZAAKTYPEN."
         ),
     )
+
+    @property
+    def concept(self):
+        """
+        Subresources of Zaaktype are implicitly concept or non-concept based on the
+        value of this attribute of the Zaaktype
+        """
+        return self.zaaktype.concept
 
     class Meta:
         # NOTE: The uniqueness is not explicitly defined in specification:

--- a/src/openzaak/components/catalogi/models/resultaattype.py
+++ b/src/openzaak/components/catalogi/models/resultaattype.py
@@ -284,6 +284,14 @@ class ResultaatType(ETagMixin, OptionalGeldigheidMixin, models.Model):
         ),
     )
 
+    @property
+    def concept(self):
+        """
+        Subresources of Zaaktype are implicitly concept or non-concept based on the
+        value of this attribute of the Zaaktype
+        """
+        return self.zaaktype.concept
+
     class Meta:
         unique_together = ("zaaktype", "omschrijving")
         verbose_name = _("resultaattype")

--- a/src/openzaak/components/catalogi/models/roltype.py
+++ b/src/openzaak/components/catalogi/models/roltype.py
@@ -59,6 +59,14 @@ class RolType(ETagMixin, OptionalGeldigheidMixin, models.Model):
         ),
     )
 
+    @property
+    def concept(self):
+        """
+        Subresources of Zaaktype are implicitly concept or non-concept based on the
+        value of this attribute of the Zaaktype
+        """
+        return self.zaaktype.concept
+
     class Meta:
         unique_together = ("zaaktype", "omschrijving")
         verbose_name = _("Roltype")

--- a/src/openzaak/components/catalogi/models/statustype.py
+++ b/src/openzaak/components/catalogi/models/statustype.py
@@ -100,6 +100,14 @@ class StatusType(ETagMixin, OptionalGeldigheidMixin, models.Model):
         help_text=_("Een eventuele toelichting op dit STATUSTYPE."),
     )
 
+    @property
+    def concept(self):
+        """
+        Subresources of Zaaktype are implicitly concept or non-concept based on the
+        value of this attribute of the Zaaktype
+        """
+        return self.zaaktype.concept
+
     class Meta:
         unique_together = ("zaaktype", "statustypevolgnummer")
         verbose_name = _("Statustype")

--- a/src/openzaak/components/catalogi/models/zaakobjecttype.py
+++ b/src/openzaak/components/catalogi/models/zaakobjecttype.py
@@ -51,6 +51,14 @@ class ZaakObjectType(ETagMixin, OptionalGeldigheidMixin, models.Model):
         help_text=_("URL-referentie naar het STATUSTYPE"),
     )
 
+    @property
+    def concept(self):
+        """
+        Subresources of Zaaktype are implicitly concept or non-concept based on the
+        value of this attribute of the Zaaktype
+        """
+        return self.zaaktype.concept
+
     class Meta:
         verbose_name = _("Zaakobjecttype")
         verbose_name_plural = _("Zaakobjecttypen")

--- a/src/openzaak/components/catalogi/tests/admin/test_besluittype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_besluittype_admin.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2020 Dimpact
+from django.test import tag
 from django.urls import reverse, reverse_lazy
 from django.utils.http import urlencode
 from django.utils.translation import gettext as _, ngettext_lazy
@@ -8,6 +9,7 @@ from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
 
 from openzaak.accounts.tests.factories import SuperUserFactory
+from openzaak.components.besluiten.tests.factories import BesluitFactory
 
 from ...models import BesluitType, InformatieObjectType, ZaakType
 from ..factories import (
@@ -319,3 +321,168 @@ class BesluitTypePublishAdminTests(WebTest):
                 "overlappende geldigheid hebben."
             ],
         )
+
+
+@tag("gh-1877")
+@disable_admin_mfa()
+class BesluitTypeDeleteAdminTests(WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = SuperUserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+
+        self.app.set_user(self.user)
+
+    def test_delete_published_besluittype_not_allowed_if_besluiten_related(self):
+        non_concept_besluittype = BesluitTypeFactory.create(concept=False)
+
+        BesluitFactory.create(besluittype=non_concept_besluittype)
+
+        admin_url = reverse(
+            "admin:catalogi_besluittype_delete", args=(non_concept_besluittype.id,)
+        )
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(_("besluittype kan niet worden verwijderd"), response.text)
+        self.assertIn(
+            _("vereist het verwijderen van de volgende gerelateerde objecten"),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(BesluitType.objects.count(), 1)
+
+    def test_bulk_delete_published_besluittypen_not_allowed_if_besluiten_related(self):
+        concept_besluittype = BesluitTypeFactory.create(concept=True)
+        non_concept_besluittype = BesluitTypeFactory.create(concept=False)
+
+        BesluitFactory.create(besluittype=non_concept_besluittype)
+
+        admin_url = reverse("admin:catalogi_besluittype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_besluittype.id, non_concept_besluittype.id]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(_("besluittypen kan niet worden verwijderd"), response.text)
+        self.assertIn(
+            _(
+                "vereist het verwijderen van de volgende beschermde gerelateerde objecten"
+            ),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(BesluitType.objects.count(), 2)
+
+    def test_delete_published_besluittype_allowed_if_no_besluiten_related(self):
+        non_concept_besluittype = BesluitTypeFactory.create(concept=False)
+
+        admin_url = reverse(
+            "admin:catalogi_besluittype_delete", args=(non_concept_besluittype.id,)
+        )
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # besluittype is successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(BesluitType.objects.exists())
+
+    def test_bulk_delete_published_besluittypen_allowed_if_no_besluiten_related(self):
+        concept_besluittype = BesluitTypeFactory.create(concept=True)
+        non_concept_besluittype = BesluitTypeFactory.create(concept=False)
+
+        admin_url = reverse("admin:catalogi_besluittype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_besluittype.id, non_concept_besluittype.id]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both Besluittypen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(BesluitType.objects.exists())
+
+    def test_delete_concept_besluittype_allowed_if_no_besluiten_related(self):
+        concept_besluittype = BesluitTypeFactory.create(concept=True)
+
+        admin_url = reverse(
+            "admin:catalogi_besluittype_delete", args=(concept_besluittype.id,)
+        )
+
+        response = self.app.get(admin_url)
+
+        # no warning, because all besluittypen are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # besluittype is successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(BesluitType.objects.exists())
+
+    def test_bulk_delete_concept_besluittypen_allowed_if_no_besluiten_related(self):
+        concept_besluittype1 = BesluitTypeFactory.create(concept=True)
+        concept_besluittype2 = BesluitTypeFactory.create(concept=True)
+
+        admin_url = reverse("admin:catalogi_besluittype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_besluittype1.id, concept_besluittype2.id]
+
+        response = form.submit()
+
+        # no warning, because all besluittypen are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both besluittypen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(BesluitType.objects.exists())

--- a/src/openzaak/components/catalogi/tests/admin/test_catalogus.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_catalogus.py
@@ -1,18 +1,17 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2021 Dimpact
+from django.test import tag
 from django.urls import reverse
+from django.utils.translation import gettext as _
 
 from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
 
 from openzaak.accounts.tests.factories import SuperUserFactory
+from openzaak.components.zaken.tests.factories import ZaakFactory
 
-<<<<<<< Updated upstream
-from ..factories import CatalogusFactory
-=======
-from ...models import ZaakType
+from ...models import Catalogus
 from ..factories import CatalogusFactory, ZaakTypeFactory, ZaakTypenRelatieFactory
->>>>>>> Stashed changes
 
 
 @disable_admin_mfa()
@@ -63,8 +62,6 @@ class CatalogusAdminTests(WebTest):
             with self.subTest(url):
                 response = self.app.get(url)
                 self.assertEqual(response.status_code, 200)
-<<<<<<< Updated upstream
-=======
 
 
 @tag("gh-1877")
@@ -107,7 +104,7 @@ class CatalogusDeleteAdminTests(WebTest):
         )
         # Delete confirmation form should not be present
         self.assertNotIn(1, response.forms)
-        self.assertEqual(ZaakType.objects.count(), 1)
+        self.assertEqual(Catalogus.objects.count(), 1)
 
     def test_bulk_delete_catalogus_with_published_zaaktypen_not_allowed_if_zaken_related(
         self,
@@ -141,7 +138,7 @@ class CatalogusDeleteAdminTests(WebTest):
         )
         # Delete confirmation form should not be present
         self.assertNotIn(1, response.forms)
-        self.assertEqual(ZaakType.objects.count(), 2)
+        self.assertEqual(Catalogus.objects.count(), 1)
 
     def test_delete_catalogus_with_published_zaaktype_allowed_if_no_zaken_related(self):
         catalogus = CatalogusFactory.create()
@@ -149,6 +146,7 @@ class CatalogusDeleteAdminTests(WebTest):
 
         # Relations should not block deletion
         ZaakTypenRelatieFactory.create(zaaktype=zaaktype)
+        ZaakTypeFactory.create(concept=False, catalogus=catalogus)
 
         admin_url = reverse("admin:catalogi_catalogus_delete", args=(catalogus.id,))
 
@@ -165,7 +163,7 @@ class CatalogusDeleteAdminTests(WebTest):
 
         # Both Zaaktypen are successfully deleted
         self.assertEqual(response.status_code, 302)
-        self.assertFalse(ZaakType.objects.exists())
+        self.assertFalse(Catalogus.objects.exists())
 
     def test_bulk_delete_catalogus_with_published_zaaktypen_allowed_if_no_zaken_related(
         self,
@@ -192,9 +190,9 @@ class CatalogusDeleteAdminTests(WebTest):
 
         response = form.submit()
 
-        # Both Zaaktypen are successfully deleted
+        # catalogus is successfully deleted
         self.assertEqual(response.status_code, 302)
-        self.assertFalse(ZaakType.objects.exists())
+        self.assertFalse(Catalogus.objects.exists())
 
     def test_delete_catalogus_with_concept_zaaktype_allowed_if_no_zaken_related(self):
         catalogus = CatalogusFactory.create()
@@ -213,21 +211,22 @@ class CatalogusDeleteAdminTests(WebTest):
 
         response = form.submit()
 
-        # Both Zaaktypen are successfully deleted
+        # catalogus is successfully deleted
         self.assertEqual(response.status_code, 302)
-        self.assertFalse(ZaakType.objects.exists())
+        self.assertFalse(Catalogus.objects.exists())
 
     def test_bulk_delete_catalogus_with_concept_zaaktypen_allowed_if_no_zaken_related(
         self,
     ):
-        catalogus = CatalogusFactory.create()
-        ZaakTypeFactory.create(concept=True, catalogus=catalogus)
-        ZaakTypeFactory.create(concept=True, catalogus=catalogus)
+        catalogus1 = CatalogusFactory.create()
+        catalogus2 = CatalogusFactory.create()
+        ZaakTypeFactory.create(concept=True, catalogus=catalogus1)
+        ZaakTypeFactory.create(concept=True, catalogus=catalogus2)
 
         admin_url = reverse("admin:catalogi_catalogus_changelist")
         form = self.app.get(admin_url).forms["changelist-form"]
         form["action"] = "delete_selected"
-        form["_selected_action"] = [catalogus.id]
+        form["_selected_action"] = [catalogus1.id, catalogus2.id]
 
         response = form.submit()
 
@@ -242,7 +241,6 @@ class CatalogusDeleteAdminTests(WebTest):
 
         response = form.submit()
 
-        # Both Zaaktypen are successfully deleted
+        # catalogi are successfully deleted
         self.assertEqual(response.status_code, 302)
-        self.assertFalse(ZaakType.objects.exists())
->>>>>>> Stashed changes
+        self.assertFalse(Catalogus.objects.exists())

--- a/src/openzaak/components/catalogi/tests/admin/test_catalogus.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_catalogus.py
@@ -7,7 +7,12 @@ from maykin_2fa.test import disable_admin_mfa
 
 from openzaak.accounts.tests.factories import SuperUserFactory
 
+<<<<<<< Updated upstream
 from ..factories import CatalogusFactory
+=======
+from ...models import ZaakType
+from ..factories import CatalogusFactory, ZaakTypeFactory, ZaakTypenRelatieFactory
+>>>>>>> Stashed changes
 
 
 @disable_admin_mfa()
@@ -58,3 +63,186 @@ class CatalogusAdminTests(WebTest):
             with self.subTest(url):
                 response = self.app.get(url)
                 self.assertEqual(response.status_code, 200)
+<<<<<<< Updated upstream
+=======
+
+
+@tag("gh-1877")
+@disable_admin_mfa()
+class CatalogusDeleteAdminTests(WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = SuperUserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+
+        self.app.set_user(self.user)
+
+    def test_delete_catalogus_with_published_zaaktype_not_allowed_if_zaken_related(
+        self,
+    ):
+        catalogus = CatalogusFactory.create()
+        non_concept_zaaktype = ZaakTypeFactory.create(
+            concept=False, catalogus=catalogus
+        )
+
+        ZaakFactory.create(zaaktype=non_concept_zaaktype)
+
+        admin_url = reverse("admin:catalogi_catalogus_delete", args=(catalogus.id,))
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(_("catalogus kan niet worden verwijderd"), response.text)
+        self.assertIn(
+            _("vereist het verwijderen van de volgende gerelateerde objecten"),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(ZaakType.objects.count(), 1)
+
+    def test_bulk_delete_catalogus_with_published_zaaktypen_not_allowed_if_zaken_related(
+        self,
+    ):
+        catalogus = CatalogusFactory.create()
+        ZaakTypeFactory.create(concept=True, catalogus=catalogus)
+        non_concept_zaaktype = ZaakTypeFactory.create(
+            concept=False, catalogus=catalogus
+        )
+
+        ZaakFactory.create(zaaktype=non_concept_zaaktype)
+
+        admin_url = reverse("admin:catalogi_catalogus_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [catalogus.id]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(_("catalogus kan niet worden verwijderd"), response.text)
+        self.assertIn(
+            _(
+                "vereist het verwijderen van de volgende beschermde gerelateerde objecten"
+            ),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(ZaakType.objects.count(), 2)
+
+    def test_delete_catalogus_with_published_zaaktype_allowed_if_no_zaken_related(self):
+        catalogus = CatalogusFactory.create()
+        zaaktype = ZaakTypeFactory.create(concept=False, catalogus=catalogus)
+
+        # Relations should not block deletion
+        ZaakTypenRelatieFactory.create(zaaktype=zaaktype)
+
+        admin_url = reverse("admin:catalogi_catalogus_delete", args=(catalogus.id,))
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # Both Zaaktypen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakType.objects.exists())
+
+    def test_bulk_delete_catalogus_with_published_zaaktypen_allowed_if_no_zaken_related(
+        self,
+    ):
+        catalogus = CatalogusFactory.create()
+        ZaakTypeFactory.create(concept=True, catalogus=catalogus)
+        ZaakTypeFactory.create(concept=False, catalogus=catalogus)
+
+        admin_url = reverse("admin:catalogi_catalogus_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [catalogus.id]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both Zaaktypen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakType.objects.exists())
+
+    def test_delete_catalogus_with_concept_zaaktype_allowed_if_no_zaken_related(self):
+        catalogus = CatalogusFactory.create()
+        ZaakTypeFactory.create(concept=True, catalogus=catalogus)
+
+        admin_url = reverse("admin:catalogi_catalogus_delete", args=(catalogus.id,))
+
+        response = self.app.get(admin_url)
+
+        # no warning, because all zaaktypen are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # Both Zaaktypen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakType.objects.exists())
+
+    def test_bulk_delete_catalogus_with_concept_zaaktypen_allowed_if_no_zaken_related(
+        self,
+    ):
+        catalogus = CatalogusFactory.create()
+        ZaakTypeFactory.create(concept=True, catalogus=catalogus)
+        ZaakTypeFactory.create(concept=True, catalogus=catalogus)
+
+        admin_url = reverse("admin:catalogi_catalogus_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [catalogus.id]
+
+        response = form.submit()
+
+        # no warning, because all zaaktypen are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both Zaaktypen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakType.objects.exists())
+>>>>>>> Stashed changes

--- a/src/openzaak/components/catalogi/tests/admin/test_eigenschap_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_eigenschap_admin.py
@@ -8,9 +8,14 @@ from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
 
 from openzaak.accounts.tests.factories import SuperUserFactory
+from openzaak.components.zaken.tests.factories import ZaakEigenschapFactory
 
 from ...models import Eigenschap, EigenschapSpecificatie
-from ..factories import EigenschapSpecificatieFactory, ZaakTypeFactory
+from ..factories import (
+    EigenschapFactory,
+    EigenschapSpecificatieFactory,
+    ZaakTypeFactory,
+)
 
 
 @disable_admin_mfa()
@@ -99,3 +104,182 @@ class EigenschapAdminTests(WebTest):
             },
         )
         self.assertEqual(Eigenschap.objects.count(), 0)
+
+
+@tag("gh-1877")
+@disable_admin_mfa()
+class EigenschapDeleteAdminTests(WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = SuperUserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+
+        self.app.set_user(self.user)
+
+    def test_delete_published_eigenschap_not_allowed_if_zaakeigenschappen_related(self):
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        eigenschap = EigenschapFactory.create(zaaktype=non_concept_zaaktype)
+        ZaakEigenschapFactory.create(
+            zaak__zaaktype=non_concept_zaaktype, eigenschap=eigenschap
+        )
+
+        admin_url = reverse("admin:catalogi_eigenschap_delete", args=(eigenschap.id,))
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(_("Eigenschap kan niet worden verwijderd"), response.text)
+        self.assertIn(
+            _("vereist het verwijderen van de volgende gerelateerde objecten"),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(Eigenschap.objects.count(), 1)
+
+    def test_bulk_delete_published_eigenschappen_not_allowed_if_zaakeigenschappen_related(
+        self,
+    ):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        concept_eigenschap = EigenschapFactory.create(zaaktype=concept_zaaktype)
+        non_concept_eigenschap = EigenschapFactory.create(zaaktype=non_concept_zaaktype)
+
+        ZaakEigenschapFactory.create(eigenschap=non_concept_eigenschap)
+
+        admin_url = reverse("admin:catalogi_eigenschap_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_eigenschap.id, non_concept_eigenschap.id]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(_("Eigenschappen kan niet worden verwijderd"), response.text)
+        self.assertIn(
+            _(
+                "vereist het verwijderen van de volgende beschermde gerelateerde objecten"
+            ),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(Eigenschap.objects.count(), 2)
+
+    def test_delete_published_eigenschap_allowed_if_no_zaakeigenschappen_related(self):
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        non_concept_eigenschap = EigenschapFactory.create(zaaktype=non_concept_zaaktype)
+
+        admin_url = reverse(
+            "admin:catalogi_eigenschap_delete", args=(non_concept_eigenschap.id,)
+        )
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # eigenschap is successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Eigenschap.objects.exists())
+
+    def test_bulk_delete_published_eigenschappen_allowed_if_no_zaakeigenschappen_related(
+        self,
+    ):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        concept_eigenschap = EigenschapFactory.create(zaaktype=concept_zaaktype)
+        non_concept_eigenschap = EigenschapFactory.create(zaaktype=non_concept_zaaktype)
+
+        admin_url = reverse("admin:catalogi_eigenschap_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_eigenschap.id, non_concept_eigenschap.id]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both eigenschappen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Eigenschap.objects.exists())
+
+    def test_delete_concept_eigenschap_allowed_if_no_zaakeigenschappen_related(self):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        concept_eigenschap = EigenschapFactory.create(zaaktype=concept_zaaktype)
+
+        admin_url = reverse(
+            "admin:catalogi_eigenschap_delete", args=(concept_eigenschap.id,)
+        )
+
+        response = self.app.get(admin_url)
+
+        # no warning, because all eigenschappen are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # eigenschap is successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Eigenschap.objects.exists())
+
+    def test_bulk_delete_concept_eigenschappen_allowed_if_no_zaakeigenschappen_related(
+        self,
+    ):
+        concept_zaaktype1 = ZaakTypeFactory.create(concept=True)
+        concept_zaaktype2 = ZaakTypeFactory.create(concept=True)
+        concept_eigenschap1 = EigenschapFactory.create(zaaktype=concept_zaaktype1)
+        concept_eigenschap2 = EigenschapFactory.create(zaaktype=concept_zaaktype2)
+
+        admin_url = reverse("admin:catalogi_eigenschap_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_eigenschap1.id, concept_eigenschap2.id]
+
+        response = form.submit()
+
+        # no warning, because all eigenschappen are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both eigenschappen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Eigenschap.objects.exists())

--- a/src/openzaak/components/catalogi/tests/admin/test_eigenschap_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_eigenschap_admin.py
@@ -105,6 +105,30 @@ class EigenschapAdminTests(WebTest):
         )
         self.assertEqual(Eigenschap.objects.count(), 0)
 
+    def test_create_eigenschap_without_zaaktype_raises_error(self):
+        specificatie = EigenschapSpecificatieFactory.create(
+            waardenverzameling=["some,comma", "bla"]
+        )
+
+        response = self.app.get(reverse("admin:catalogi_eigenschap_add"))
+
+        form = response.forms["eigenschap_form"]
+
+        form["eigenschapnaam"] = "foo"
+        form["definitie"] = "bar"
+        form["specificatie_van_eigenschap"] = specificatie.id
+        form["toelichting"] = "baz"
+
+        # Leave zaaktype empty
+        form["zaaktype"] = ""
+        response = form.submit()
+
+        self.assertEqual(
+            response.context["adminform"].errors,
+            {"zaaktype": [_("Dit veld is verplicht.")]},
+        )
+        self.assertEqual(Eigenschap.objects.count(), 0)
+
 
 @tag("gh-1877")
 @disable_admin_mfa()

--- a/src/openzaak/components/catalogi/tests/admin/test_informatieobjecttype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_informatieobjecttype_admin.py
@@ -16,6 +16,7 @@ from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
 from openzaak.notifications.tests.mixins import NotificationsConfigMixin
+from openzaak.tests.utils.admin import AdminTestMixin
 
 from ...models import InformatieObjectType, ZaakType, ZaakTypeInformatieObjectType
 from ..factories import (
@@ -27,10 +28,10 @@ from ..factories import (
 
 
 @disable_admin_mfa()
-class ZiotFilterAdminTests(WebTest):
+class ZiotFilterAdminTests(AdminTestMixin, WebTest):
     @classmethod
     def setUpTestData(cls):
-        cls.user = SuperUserFactory.create()
+        super().setUpTestData()
 
         cls.catalogus = CatalogusFactory.create()
 
@@ -38,11 +39,6 @@ class ZiotFilterAdminTests(WebTest):
         ZaakType.objects.all().delete()
         cls.zaaktype = ZaakTypeFactory.create(catalogus=cls.catalogus)
         ZaakTypeFactory.create_batch(3, catalogus=CatalogusFactory.create())
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
 
     def test_create_ziot_zaaktype_popup_filter_no_catalogus(self):
         response = self.app.get(
@@ -162,19 +158,16 @@ class AddZiotAdminTests(WebTest):
 
 
 @disable_admin_mfa()
-class IoTypePublishAdminTests(WebTest):
+class IoTypePublishAdminTests(AdminTestMixin, WebTest):
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
+
         cls.user = SuperUserFactory.create()
 
         cls.catalogus = CatalogusFactory.create()
         cls.url = reverse_lazy("admin:catalogi_informatieobjecttype_changelist")
         cls.query_params = {"catalogus_id__exact": cls.catalogus.pk}
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
 
     def test_publish_selected_success(self):
         iotype1, iotype2 = InformatieObjectTypeFactory.create_batch(
@@ -292,21 +285,14 @@ class IoTypePublishAdminTests(WebTest):
 
 
 @disable_admin_mfa()
-class CreateIotypeTests(NotificationsConfigMixin, WebTest):
+class CreateIotypeTests(NotificationsConfigMixin, AdminTestMixin, WebTest):
     url = reverse_lazy("admin:catalogi_informatieobjecttype_add")
-
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-
-        cls.user = SuperUserFactory.create()
 
     @override_settings(NOTIFICATIONS_DISABLED=False)
     @freeze_time("2022-01-01")
     @patch("notifications_api_common.viewsets.send_notification.delay")
     def test_create_notification_actie(self, mock_notif):
         catalogus = CatalogusFactory.create()
-        self.app.set_user(self.user)
 
         response = self.app.get(self.url)
 
@@ -346,18 +332,7 @@ class CreateIotypeTests(NotificationsConfigMixin, WebTest):
 
 @tag("gh-1877")
 @disable_admin_mfa()
-class InformatieObjectTypeDeleteAdminTests(WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
+class InformatieObjectTypeDeleteAdminTests(AdminTestMixin, WebTest):
     def test_delete_published_informatieobjecttype_not_allowed_if_documenten_related(
         self,
     ):

--- a/src/openzaak/components/catalogi/tests/admin/test_informatieobjecttype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_informatieobjecttype_admin.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2020 Dimpact
 from unittest.mock import patch
 
-from django.test import override_settings
+from django.test import override_settings, tag
 from django.urls import reverse, reverse_lazy
 from django.utils.http import urlencode
 from django.utils.translation import gettext as _, ngettext_lazy
@@ -12,6 +12,9 @@ from freezegun import freeze_time
 from maykin_2fa.test import disable_admin_mfa
 
 from openzaak.accounts.tests.factories import SuperUserFactory
+from openzaak.components.documenten.tests.factories import (
+    EnkelvoudigInformatieObjectFactory,
+)
 from openzaak.notifications.tests.mixins import NotificationsConfigMixin
 
 from ...models import InformatieObjectType, ZaakType, ZaakTypeInformatieObjectType
@@ -339,3 +342,206 @@ class CreateIotypeTests(NotificationsConfigMixin, WebTest):
                 },
             }
         )
+
+
+@tag("gh-1877")
+@disable_admin_mfa()
+class InformatieObjectTypeDeleteAdminTests(WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = SuperUserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+
+        self.app.set_user(self.user)
+
+    def test_delete_published_informatieobjecttype_not_allowed_if_documenten_related(
+        self,
+    ):
+        non_concept_informatieobjecttype = InformatieObjectTypeFactory.create(
+            concept=False
+        )
+
+        EnkelvoudigInformatieObjectFactory.create(
+            informatieobjecttype=non_concept_informatieobjecttype
+        )
+
+        admin_url = reverse(
+            "admin:catalogi_informatieobjecttype_delete",
+            args=(non_concept_informatieobjecttype.id,),
+        )
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(
+            _("Informatieobjecttype kan niet worden verwijderd"), response.text
+        )
+        self.assertIn(
+            _("vereist het verwijderen van de volgende gerelateerde objecten"),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(InformatieObjectType.objects.count(), 1)
+
+    def test_bulk_delete_published_informatieobjecttypen_not_allowed_if_documenten_related(
+        self,
+    ):
+        concept_informatieobjecttype = InformatieObjectTypeFactory.create(concept=True)
+        non_concept_informatieobjecttype = InformatieObjectTypeFactory.create(
+            concept=False
+        )
+
+        EnkelvoudigInformatieObjectFactory.create(
+            informatieobjecttype=non_concept_informatieobjecttype
+        )
+
+        admin_url = reverse("admin:catalogi_informatieobjecttype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [
+            concept_informatieobjecttype.id,
+            non_concept_informatieobjecttype.id,
+        ]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(
+            _("Informatieobjecttypen kan niet worden verwijderd"), response.text
+        )
+        self.assertIn(
+            _(
+                "vereist het verwijderen van de volgende beschermde gerelateerde objecten"
+            ),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(InformatieObjectType.objects.count(), 2)
+
+    def test_delete_published_informatieobjecttype_allowed_if_no_documenten_related(
+        self,
+    ):
+        non_concept_informatieobjecttype = InformatieObjectTypeFactory.create(
+            concept=False
+        )
+
+        admin_url = reverse(
+            "admin:catalogi_informatieobjecttype_delete",
+            args=(non_concept_informatieobjecttype.id,),
+        )
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # informatieobjecttype is successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(InformatieObjectType.objects.exists())
+
+    def test_bulk_delete_published_informatieobjecttypen_allowed_if_no_documenten_related(
+        self,
+    ):
+        concept_informatieobjecttype = InformatieObjectTypeFactory.create(concept=True)
+        non_concept_informatieobjecttype = InformatieObjectTypeFactory.create(
+            concept=False
+        )
+
+        admin_url = reverse("admin:catalogi_informatieobjecttype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [
+            concept_informatieobjecttype.id,
+            non_concept_informatieobjecttype.id,
+        ]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both Besluittypen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(InformatieObjectType.objects.exists())
+
+    def test_delete_concept_informatieobjecttype_allowed_if_no_documenten_related(self):
+        concept_informatieobjecttype = InformatieObjectTypeFactory.create(concept=True)
+
+        admin_url = reverse(
+            "admin:catalogi_informatieobjecttype_delete",
+            args=(concept_informatieobjecttype.id,),
+        )
+
+        response = self.app.get(admin_url)
+
+        # no warning, because all informatieobjecttypen are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # informatieobjecttype is successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(InformatieObjectType.objects.exists())
+
+    def test_bulk_delete_concept_informatieobjecttypen_allowed_if_no_documenten_related(
+        self,
+    ):
+        concept_informatieobjecttype1 = InformatieObjectTypeFactory.create(concept=True)
+        concept_informatieobjecttype2 = InformatieObjectTypeFactory.create(concept=True)
+
+        admin_url = reverse("admin:catalogi_informatieobjecttype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [
+            concept_informatieobjecttype1.id,
+            concept_informatieobjecttype2.id,
+        ]
+
+        response = form.submit()
+
+        # no warning, because all informatieobjecttypen are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both informatieobjecttypen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(InformatieObjectType.objects.exists())

--- a/src/openzaak/components/catalogi/tests/admin/test_notifications.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_notifications.py
@@ -9,11 +9,11 @@ from django_webtest import WebTest
 from freezegun import freeze_time
 from maykin_2fa.test import disable_admin_mfa
 
-from openzaak.accounts.tests.factories import SuperUserFactory
 from openzaak.notifications.tests.mixins import NotificationsConfigMixin
 from openzaak.selectielijst.models import ReferentieLijstConfig
 from openzaak.selectielijst.tests.mixins import ReferentieLijstServiceMixin
 from openzaak.tests.utils import ClearCachesMixin
+from openzaak.tests.utils.admin import AdminTestMixin
 
 from ...models import BesluitType, InformatieObjectType, ZaakType
 from ..factories import (
@@ -30,7 +30,11 @@ from ..factories import (
 @freeze_time("2022-01-01")
 @patch("notifications_api_common.viewsets.send_notification.delay")
 class NotificationAdminTests(
-    NotificationsConfigMixin, ReferentieLijstServiceMixin, ClearCachesMixin, WebTest
+    NotificationsConfigMixin,
+    ReferentieLijstServiceMixin,
+    ClearCachesMixin,
+    AdminTestMixin,
+    WebTest,
 ):
     @classmethod
     def setUpTestData(cls):
@@ -42,17 +46,10 @@ class NotificationAdminTests(
         config.allowed_years = [2017, 2020]
         config.save()
 
-        cls.user = SuperUserFactory.create()
-
         cls.catalogus = CatalogusFactory.create()
         cls.catalogus_url = reverse(
             "catalogus-detail", kwargs={"uuid": cls.catalogus.uuid, "version": 1}
         )
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
 
     def test_informatieobjecttype_notify_on_create(self, mock_notif):
         url = reverse("admin:catalogi_informatieobjecttype_add")

--- a/src/openzaak/components/catalogi/tests/admin/test_published_readonly.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_published_readonly.py
@@ -10,7 +10,6 @@ from dateutil.relativedelta import relativedelta
 from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
 
-from openzaak.accounts.tests.factories import SuperUserFactory
 from openzaak.selectielijst.tests import (
     mock_resource_get,
     mock_resource_list,
@@ -18,6 +17,7 @@ from openzaak.selectielijst.tests import (
 )
 from openzaak.selectielijst.tests.mixins import ReferentieLijstServiceMixin
 from openzaak.tests.utils import ClearCachesMixin
+from openzaak.tests.utils.admin import AdminTestMixin
 
 from ..factories import (
     BesluitTypeFactory,
@@ -31,18 +31,9 @@ from ..factories import (
 
 @disable_admin_mfa()
 @requests_mock.Mocker()
-class ReadonlyAdminTests(ReferentieLijstServiceMixin, ClearCachesMixin, WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
+class ReadonlyAdminTests(
+    ReferentieLijstServiceMixin, ClearCachesMixin, AdminTestMixin, WebTest
+):
     def test_readonly_zaaktype(self, m):
         """
         check that in case of published zaaktype only "datum_einde_geldigheid" field is editable

--- a/src/openzaak/components/catalogi/tests/admin/test_resultaattype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_resultaattype_admin.py
@@ -19,6 +19,7 @@ from vng_api_common.constants import (
 )
 
 from openzaak.accounts.tests.factories import SuperUserFactory, UserFactory
+from openzaak.components.zaken.tests.factories import ResultaatFactory
 from openzaak.selectielijst.admin_fields import (
     get_resultaattype_omschrijving_readonly_field,
 )
@@ -676,3 +677,199 @@ class ResultaattypeAdminVCRTests(
             "De resultaattypeomschrijving is niet afkomstig uit de Selectielijst API-service"
         )
         assert expected_error in response.text
+
+
+@tag("gh-1877")
+@disable_admin_mfa()
+class ResultaatTypeDeleteAdminTests(WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = SuperUserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+
+        self.app.set_user(self.user)
+
+    def test_delete_published_resultaattype_not_allowed_if_resultaten_related(self):
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        resultaattype = ResultaatTypeFactory.create(zaaktype=non_concept_zaaktype)
+        ResultaatFactory.create(
+            zaak__zaaktype=non_concept_zaaktype, resultaattype=resultaattype
+        )
+
+        admin_url = reverse(
+            "admin:catalogi_resultaattype_delete", args=(resultaattype.id,)
+        )
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(_("resultaattype kan niet worden verwijderd"), response.text)
+        self.assertIn(
+            _("vereist het verwijderen van de volgende gerelateerde objecten"),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(ResultaatType.objects.count(), 1)
+
+    def test_bulk_delete_published_resultaattypen_not_allowed_if_resultaten_related(
+        self,
+    ):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        concept_resultaattype = ResultaatTypeFactory.create(zaaktype=concept_zaaktype)
+        non_concept_resultaattype = ResultaatTypeFactory.create(
+            zaaktype=non_concept_zaaktype
+        )
+
+        ResultaatFactory.create(resultaattype=non_concept_resultaattype)
+
+        admin_url = reverse("admin:catalogi_resultaattype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [
+            concept_resultaattype.id,
+            non_concept_resultaattype.id,
+        ]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(_("resultaattypen kan niet worden verwijderd"), response.text)
+        self.assertIn(
+            _(
+                "vereist het verwijderen van de volgende beschermde gerelateerde objecten"
+            ),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(ResultaatType.objects.count(), 2)
+
+    def test_delete_published_resultaattype_allowed_if_no_resultaten_related(self):
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        non_concept_resultaattype = ResultaatTypeFactory.create(
+            zaaktype=non_concept_zaaktype
+        )
+
+        admin_url = reverse(
+            "admin:catalogi_resultaattype_delete", args=(non_concept_resultaattype.id,)
+        )
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # resultaattype is successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ResultaatType.objects.exists())
+
+    def test_bulk_delete_published_resultaattypen_allowed_if_no_resultaten_related(
+        self,
+    ):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        concept_resultaattype = ResultaatTypeFactory.create(zaaktype=concept_zaaktype)
+        non_concept_resultaattype = ResultaatTypeFactory.create(
+            zaaktype=non_concept_zaaktype
+        )
+
+        admin_url = reverse("admin:catalogi_resultaattype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [
+            concept_resultaattype.id,
+            non_concept_resultaattype.id,
+        ]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both resultaattypen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ResultaatType.objects.exists())
+
+    def test_delete_concept_resultaattype_allowed_if_no_resultaten_related(self):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        concept_resultaattype = ResultaatTypeFactory.create(zaaktype=concept_zaaktype)
+
+        admin_url = reverse(
+            "admin:catalogi_resultaattype_delete", args=(concept_resultaattype.id,)
+        )
+
+        response = self.app.get(admin_url)
+
+        # no warning, because all resultaattypen are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # resultaattype is successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ResultaatType.objects.exists())
+
+    def test_bulk_delete_concept_resultaattypen_allowed_if_no_resultaten_related(
+        self,
+    ):
+        concept_zaaktype1 = ZaakTypeFactory.create(concept=True)
+        concept_zaaktype2 = ZaakTypeFactory.create(concept=True)
+        concept_resultaattype1 = ResultaatTypeFactory.create(zaaktype=concept_zaaktype1)
+        concept_resultaattype2 = ResultaatTypeFactory.create(zaaktype=concept_zaaktype2)
+
+        admin_url = reverse("admin:catalogi_resultaattype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [
+            concept_resultaattype1.id,
+            concept_resultaattype2.id,
+        ]
+
+        response = form.submit()
+
+        # no warning, because all resultaattypen are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both resultaattypen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ResultaatType.objects.exists())

--- a/src/openzaak/components/catalogi/tests/admin/test_resultaattype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_resultaattype_admin.py
@@ -75,6 +75,9 @@ class ResultaattypeAdminTests(
 
         response = self.app.get(url)
 
+        # Resultaattype can only be published via Zaaktype, not directly
+        self.assertIsNone(response.html.find("input", {"name": "_publish"}))
+
         self.assertEqual(response.status_code, 200)
 
         # Verify that the save button is visible

--- a/src/openzaak/components/catalogi/tests/admin/test_resultaattype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_resultaattype_admin.py
@@ -18,7 +18,7 @@ from vng_api_common.constants import (
     VertrouwelijkheidsAanduiding,
 )
 
-from openzaak.accounts.tests.factories import SuperUserFactory, UserFactory
+from openzaak.accounts.tests.factories import UserFactory
 from openzaak.components.zaken.tests.factories import ResultaatFactory
 from openzaak.selectielijst.admin_fields import (
     get_resultaattype_omschrijving_readonly_field,
@@ -31,6 +31,7 @@ from openzaak.selectielijst.tests import (
 )
 from openzaak.selectielijst.tests.mixins import ReferentieLijstServiceMixin
 from openzaak.tests.utils import ClearCachesMixin
+from openzaak.tests.utils.admin import AdminTestMixin
 
 from ...models import ResultaatType
 from ..factories import ResultaatTypeFactory, ZaakTypeFactory
@@ -39,18 +40,8 @@ from ..factories import ResultaatTypeFactory, ZaakTypeFactory
 @disable_admin_mfa()
 @requests_mock.Mocker()
 class ResultaattypeAdminTests(
-    VCRMixin, ReferentieLijstServiceMixin, ClearCachesMixin, WebTest
+    VCRMixin, ReferentieLijstServiceMixin, ClearCachesMixin, AdminTestMixin, WebTest
 ):
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
     def test_zaaktypen_list(self, m):
         ResultaatTypeFactory.create()
         url = reverse("admin:catalogi_resultaattype_changelist")
@@ -684,18 +675,7 @@ class ResultaattypeAdminVCRTests(
 
 @tag("gh-1877")
 @disable_admin_mfa()
-class ResultaatTypeDeleteAdminTests(WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
+class ResultaatTypeDeleteAdminTests(AdminTestMixin, WebTest):
     def test_delete_published_resultaattype_not_allowed_if_resultaten_related(self):
         non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
         resultaattype = ResultaatTypeFactory.create(zaaktype=non_concept_zaaktype)

--- a/src/openzaak/components/catalogi/tests/admin/test_roltype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_roltype_admin.py
@@ -9,6 +9,7 @@ from maykin_2fa.test import disable_admin_mfa
 from vng_api_common.constants import RolOmschrijving
 
 from openzaak.accounts.tests.factories import SuperUserFactory
+from openzaak.components.zaken.tests.factories import RolFactory
 
 from ...models import RolType
 from ..factories import RolTypeFactory, ZaakTypeFactory
@@ -79,3 +80,178 @@ class RolTypeAdminTests(WebTest):
         roltype.refresh_from_db()
 
         self.assertNotEqual(roltype.zaaktype, zaaktype)
+
+
+@tag("gh-1877")
+@disable_admin_mfa()
+class RolTypeDeleteAdminTests(WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = SuperUserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+
+        self.app.set_user(self.user)
+
+    def test_delete_published_roltype_not_allowed_if_rollen_related(self):
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        roltype = RolTypeFactory.create(zaaktype=non_concept_zaaktype)
+        RolFactory.create(zaak__zaaktype=non_concept_zaaktype, roltype=roltype)
+
+        admin_url = reverse("admin:catalogi_roltype_delete", args=(roltype.id,))
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(_("Roltype kan niet worden verwijderd"), response.text)
+        self.assertIn(
+            _("vereist het verwijderen van de volgende gerelateerde objecten"),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(RolType.objects.count(), 1)
+
+    def test_bulk_delete_published_roltypen_not_allowed_if_rollen_related(
+        self,
+    ):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        concept_roltype = RolTypeFactory.create(zaaktype=concept_zaaktype)
+        non_concept_roltype = RolTypeFactory.create(zaaktype=non_concept_zaaktype)
+
+        RolFactory.create(roltype=non_concept_roltype)
+
+        admin_url = reverse("admin:catalogi_roltype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_roltype.id, non_concept_roltype.id]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(_("Roltypen kan niet worden verwijderd"), response.text)
+        self.assertIn(
+            _(
+                "vereist het verwijderen van de volgende beschermde gerelateerde objecten"
+            ),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(RolType.objects.count(), 2)
+
+    def test_delete_published_roltype_allowed_if_no_rollen_related(self):
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        non_concept_roltype = RolTypeFactory.create(zaaktype=non_concept_zaaktype)
+
+        admin_url = reverse(
+            "admin:catalogi_roltype_delete", args=(non_concept_roltype.id,)
+        )
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # roltype is successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(RolType.objects.exists())
+
+    def test_bulk_delete_published_roltypen_allowed_if_no_rollen_related(
+        self,
+    ):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        concept_roltype = RolTypeFactory.create(zaaktype=concept_zaaktype)
+        non_concept_roltype = RolTypeFactory.create(zaaktype=non_concept_zaaktype)
+
+        admin_url = reverse("admin:catalogi_roltype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_roltype.id, non_concept_roltype.id]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both roltypen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(RolType.objects.exists())
+
+    def test_delete_concept_roltype_allowed_if_no_rollen_related(self):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        concept_roltype = RolTypeFactory.create(zaaktype=concept_zaaktype)
+
+        admin_url = reverse("admin:catalogi_roltype_delete", args=(concept_roltype.id,))
+
+        response = self.app.get(admin_url)
+
+        # no warning, because all roltypen are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # roltype is successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(RolType.objects.exists())
+
+    def test_bulk_delete_concept_roltypen_allowed_if_no_rollen_related(
+        self,
+    ):
+        concept_zaaktype1 = ZaakTypeFactory.create(concept=True)
+        concept_zaaktype2 = ZaakTypeFactory.create(concept=True)
+        concept_roltype1 = RolTypeFactory.create(zaaktype=concept_zaaktype1)
+        concept_roltype2 = RolTypeFactory.create(zaaktype=concept_zaaktype2)
+
+        admin_url = reverse("admin:catalogi_roltype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_roltype1.id, concept_roltype2.id]
+
+        response = form.submit()
+
+        # no warning, because all roltypen are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both roltypen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(RolType.objects.exists())

--- a/src/openzaak/components/catalogi/tests/admin/test_roltype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_roltype_admin.py
@@ -10,6 +10,7 @@ from vng_api_common.constants import RolOmschrijving
 
 from openzaak.accounts.tests.factories import SuperUserFactory
 from openzaak.components.zaken.tests.factories import RolFactory
+from openzaak.tests.utils.admin import AdminTestMixin
 
 from ...models import RolType
 from ..factories import RolTypeFactory, ZaakTypeFactory
@@ -17,18 +18,7 @@ from ..factories import RolTypeFactory, ZaakTypeFactory
 
 @tag("gh-1042")
 @disable_admin_mfa()
-class RolTypeAdminTests(WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
+class RolTypeAdminTests(AdminTestMixin, WebTest):
     def test_create_roltype_for_published_zaaktype_not_allowed(self):
         zaaktype = ZaakTypeFactory.create(concept=False)
 

--- a/src/openzaak/components/catalogi/tests/admin/test_statustype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_statustype_admin.py
@@ -7,8 +7,8 @@ from django.utils.translation import gettext as _
 from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
 
-from openzaak.accounts.tests.factories import SuperUserFactory
 from openzaak.components.zaken.tests.factories import StatusFactory
+from openzaak.tests.utils.admin import AdminTestMixin
 
 from ...models import StatusType
 from ..factories import StatusTypeFactory, ZaakTypeFactory
@@ -16,18 +16,7 @@ from ..factories import StatusTypeFactory, ZaakTypeFactory
 
 @tag("gh-1042")
 @disable_admin_mfa()
-class StatusTypeAdminTests(WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
+class StatusTypeAdminTests(AdminTestMixin, WebTest):
     def test_create_statustype_for_published_zaaktype_not_allowed(self):
         zaaktype = ZaakTypeFactory.create(concept=False)
 
@@ -55,18 +44,7 @@ class StatusTypeAdminTests(WebTest):
 
 @tag("gh-1877")
 @disable_admin_mfa()
-class StatusTypeDeleteAdminTests(WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
+class StatusTypeDeleteAdminTests(AdminTestMixin, WebTest):
     def test_delete_published_statustype_not_allowed_if_statussen_related(self):
         non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
         statustype = StatusTypeFactory.create(zaaktype=non_concept_zaaktype)

--- a/src/openzaak/components/catalogi/tests/admin/test_statustype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_statustype_admin.py
@@ -8,9 +8,10 @@ from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
 
 from openzaak.accounts.tests.factories import SuperUserFactory
+from openzaak.components.zaken.tests.factories import StatusFactory
 
 from ...models import StatusType
-from ..factories import ZaakTypeFactory
+from ..factories import StatusTypeFactory, ZaakTypeFactory
 
 
 @tag("gh-1042")
@@ -50,3 +51,180 @@ class StatusTypeAdminTests(WebTest):
             },
         )
         self.assertEqual(StatusType.objects.count(), 0)
+
+
+@tag("gh-1877")
+@disable_admin_mfa()
+class StatusTypeDeleteAdminTests(WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = SuperUserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+
+        self.app.set_user(self.user)
+
+    def test_delete_published_statustype_not_allowed_if_statussen_related(self):
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        statustype = StatusTypeFactory.create(zaaktype=non_concept_zaaktype)
+        StatusFactory.create(zaak__zaaktype=non_concept_zaaktype, statustype=statustype)
+
+        admin_url = reverse("admin:catalogi_statustype_delete", args=(statustype.id,))
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(_("Statustype kan niet worden verwijderd"), response.text)
+        self.assertIn(
+            _("vereist het verwijderen van de volgende gerelateerde objecten"),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(StatusType.objects.count(), 1)
+
+    def test_bulk_delete_published_statustypen_not_allowed_if_statussen_related(
+        self,
+    ):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        concept_statustype = StatusTypeFactory.create(zaaktype=concept_zaaktype)
+        non_concept_statustype = StatusTypeFactory.create(zaaktype=non_concept_zaaktype)
+
+        StatusFactory.create(statustype=non_concept_statustype)
+
+        admin_url = reverse("admin:catalogi_statustype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_statustype.id, non_concept_statustype.id]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(_("Statustypen kan niet worden verwijderd"), response.text)
+        self.assertIn(
+            _(
+                "vereist het verwijderen van de volgende beschermde gerelateerde objecten"
+            ),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(StatusType.objects.count(), 2)
+
+    def test_delete_published_statustype_allowed_if_no_statussen_related(self):
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        non_concept_statustype = StatusTypeFactory.create(zaaktype=non_concept_zaaktype)
+
+        admin_url = reverse(
+            "admin:catalogi_statustype_delete", args=(non_concept_statustype.id,)
+        )
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # statustype is successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(StatusType.objects.exists())
+
+    def test_bulk_delete_published_statustypen_allowed_if_no_statussen_related(
+        self,
+    ):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        concept_statustype = StatusTypeFactory.create(zaaktype=concept_zaaktype)
+        non_concept_statustype = StatusTypeFactory.create(zaaktype=non_concept_zaaktype)
+
+        admin_url = reverse("admin:catalogi_statustype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_statustype.id, non_concept_statustype.id]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both statustypen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(StatusType.objects.exists())
+
+    def test_delete_concept_statustype_allowed_if_no_statussen_related(self):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        concept_statustype = StatusTypeFactory.create(zaaktype=concept_zaaktype)
+
+        admin_url = reverse(
+            "admin:catalogi_statustype_delete", args=(concept_statustype.id,)
+        )
+
+        response = self.app.get(admin_url)
+
+        # no warning, because all statussen are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # statustype is successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(StatusType.objects.exists())
+
+    def test_bulk_delete_concept_statustypen_allowed_if_no_statussen_related(
+        self,
+    ):
+        concept_zaaktype1 = ZaakTypeFactory.create(concept=True)
+        concept_zaaktype2 = ZaakTypeFactory.create(concept=True)
+        concept_statustype1 = StatusTypeFactory.create(zaaktype=concept_zaaktype1)
+        concept_statustype2 = StatusTypeFactory.create(zaaktype=concept_zaaktype2)
+
+        admin_url = reverse("admin:catalogi_statustype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_statustype1.id, concept_statustype2.id]
+
+        response = form.submit()
+
+        # no warning, because all statussen are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both statustypen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(StatusType.objects.exists())

--- a/src/openzaak/components/catalogi/tests/admin/test_zaakobjecttype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_zaakobjecttype_admin.py
@@ -8,8 +8,8 @@ from django.utils.translation import gettext as _
 from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
 
-from openzaak.accounts.tests.factories import SuperUserFactory
 from openzaak.components.zaken.tests.factories import ZaakObjectFactory
+from openzaak.tests.utils.admin import AdminTestMixin
 
 from ...models import ZaakObjectType
 from ..factories import ZaakObjectTypeFactory, ZaakTypeFactory
@@ -17,18 +17,7 @@ from ..factories import ZaakObjectTypeFactory, ZaakTypeFactory
 
 @tag("gh-1877")
 @disable_admin_mfa()
-class ZaakObjectTypeDeleteAdminTests(WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
+class ZaakObjectTypeDeleteAdminTests(AdminTestMixin, WebTest):
     def test_delete_published_zaakobjecttype_not_allowed_if_resultaten_related(self):
         non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
         zaakobjecttype = ZaakObjectTypeFactory.create(zaaktype=non_concept_zaaktype)

--- a/src/openzaak/components/catalogi/tests/admin/test_zaakobjecttype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_zaakobjecttype_admin.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2019 - 2020 Dimpact
+
+from django.test import tag
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from django_webtest import WebTest
+from maykin_2fa.test import disable_admin_mfa
+
+from openzaak.accounts.tests.factories import SuperUserFactory
+from openzaak.components.zaken.tests.factories import ZaakObjectFactory
+
+from ...models import ZaakObjectType
+from ..factories import ZaakObjectTypeFactory, ZaakTypeFactory
+
+
+@tag("gh-1877")
+@disable_admin_mfa()
+class ZaakObjectTypeDeleteAdminTests(WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = SuperUserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+
+        self.app.set_user(self.user)
+
+    def test_delete_published_zaakobjecttype_not_allowed_if_resultaten_related(self):
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        zaakobjecttype = ZaakObjectTypeFactory.create(zaaktype=non_concept_zaaktype)
+        ZaakObjectFactory.create(
+            zaak__zaaktype=non_concept_zaaktype, zaakobjecttype=zaakobjecttype
+        )
+
+        admin_url = reverse(
+            "admin:catalogi_zaakobjecttype_delete", args=(zaakobjecttype.id,)
+        )
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(_("Zaakobjecttype kan niet worden verwijderd"), response.text)
+        self.assertIn(
+            _("vereist het verwijderen van de volgende gerelateerde objecten"),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(ZaakObjectType.objects.count(), 1)
+
+    def test_bulk_delete_published_zaakobjecttypen_not_allowed_if_resultaten_related(
+        self,
+    ):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        concept_zaakobjecttype = ZaakObjectTypeFactory.create(zaaktype=concept_zaaktype)
+        non_concept_zaakobjecttype = ZaakObjectTypeFactory.create(
+            zaaktype=non_concept_zaaktype
+        )
+
+        ZaakObjectFactory.create(zaakobjecttype=non_concept_zaakobjecttype)
+
+        admin_url = reverse("admin:catalogi_zaakobjecttype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [
+            concept_zaakobjecttype.id,
+            non_concept_zaakobjecttype.id,
+        ]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(_("Zaakobjecttypen kan niet worden verwijderd"), response.text)
+        self.assertIn(
+            _(
+                "vereist het verwijderen van de volgende beschermde gerelateerde objecten"
+            ),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(ZaakObjectType.objects.count(), 2)
+
+    def test_delete_published_zaakobjecttype_allowed_if_no_resultaten_related(self):
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        non_concept_zaakobjecttype = ZaakObjectTypeFactory.create(
+            zaaktype=non_concept_zaaktype
+        )
+
+        admin_url = reverse(
+            "admin:catalogi_zaakobjecttype_delete",
+            args=(non_concept_zaakobjecttype.id,),
+        )
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # zaakobjecttype is successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakObjectType.objects.exists())
+
+    def test_bulk_delete_published_zaakobjecttypen_allowed_if_no_resultaten_related(
+        self,
+    ):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        concept_zaakobjecttype = ZaakObjectTypeFactory.create(zaaktype=concept_zaaktype)
+        non_concept_zaakobjecttype = ZaakObjectTypeFactory.create(
+            zaaktype=non_concept_zaaktype
+        )
+
+        admin_url = reverse("admin:catalogi_zaakobjecttype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [
+            concept_zaakobjecttype.id,
+            non_concept_zaakobjecttype.id,
+        ]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both zaakobjecttypen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakObjectType.objects.exists())
+
+    def test_delete_concept_zaakobjecttype_allowed_if_no_resultaten_related(self):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        concept_zaakobjecttype = ZaakObjectTypeFactory.create(zaaktype=concept_zaaktype)
+
+        admin_url = reverse(
+            "admin:catalogi_zaakobjecttype_delete", args=(concept_zaakobjecttype.id,)
+        )
+
+        response = self.app.get(admin_url)
+
+        # no warning, because all zaakobjecttypen are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # zaakobjecttype is successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakObjectType.objects.exists())
+
+    def test_bulk_delete_concept_zaakobjecttypen_allowed_if_no_resultaten_related(
+        self,
+    ):
+        concept_zaaktype1 = ZaakTypeFactory.create(concept=True)
+        concept_zaaktype2 = ZaakTypeFactory.create(concept=True)
+        concept_zaakobjecttype1 = ZaakObjectTypeFactory.create(
+            zaaktype=concept_zaaktype1
+        )
+        concept_zaakobjecttype2 = ZaakObjectTypeFactory.create(
+            zaaktype=concept_zaaktype2
+        )
+
+        admin_url = reverse("admin:catalogi_zaakobjecttype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [
+            concept_zaakobjecttype1.id,
+            concept_zaakobjecttype2.id,
+        ]
+
+        response = form.submit()
+
+        # no warning, because all zaakobjecttypen are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both zaakobjecttypen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakObjectType.objects.exists())

--- a/src/openzaak/components/catalogi/tests/admin/test_zaaktype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_zaaktype_admin.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from django.test import override_settings, tag
 from django.urls import reverse, reverse_lazy
-from django.utils.translation import gettext, gettext_lazy as _, ngettext_lazy
+from django.utils.translation import gettext as _, ngettext_lazy
 
 import requests_mock
 from dateutil.relativedelta import relativedelta
@@ -456,7 +456,7 @@ class ZaaktypeAdminTests(
             self.assertContains(changelist_page, "zaaktype 4")
 
         with self.subTest("filter currently valid"):
-            response = changelist_page.click(description=gettext("Now"))
+            response = changelist_page.click(description=_("Now"))
 
             self.assertNotContains(response, "zaaktype 1")
             self.assertContains(response, "zaaktype 2")
@@ -464,7 +464,7 @@ class ZaaktypeAdminTests(
             self.assertNotContains(response, "zaaktype 4")
 
         with self.subTest("filter valid in the past"):
-            response = changelist_page.click(description=gettext("Past"))
+            response = changelist_page.click(description=_("Past"))
 
             self.assertContains(response, "zaaktype 1")
             self.assertNotContains(response, "zaaktype 2")
@@ -472,7 +472,7 @@ class ZaaktypeAdminTests(
             self.assertNotContains(response, "zaaktype 4")
 
         with self.subTest("filter valid in the future"):
-            response = changelist_page.click(description=gettext("Future"))
+            response = changelist_page.click(description=_("Future"))
 
             self.assertNotContains(response, "zaaktype 1")
             self.assertNotContains(response, "zaaktype 2")
@@ -1289,3 +1289,168 @@ class ZaakTypePublishAdminTests(SelectieLijstMixin, WebTest):
         self.assertEqual(zt.besluittypen.count(), 2)
         self.assertIn(bt1, zt.besluittypen.all())
         self.assertIn(bt2, zt.besluittypen.all())
+
+
+@tag("gh-1877")
+@disable_admin_mfa()
+class ZaakTypeDeleteAdminTests(WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = SuperUserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+
+        self.app.set_user(self.user)
+
+    def test_delete_published_zaaktype_not_allowed_if_zaken_related(self):
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+
+        ZaakFactory.create(zaaktype=non_concept_zaaktype)
+
+        admin_url = reverse(
+            "admin:catalogi_zaaktype_delete", args=(non_concept_zaaktype.id,)
+        )
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(_("Zaaktype kan niet worden verwijderd"), response.text)
+        self.assertIn(
+            _("vereist het verwijderen van de volgende gerelateerde objecten"),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(ZaakType.objects.count(), 1)
+
+    def test_bulk_delete_published_zaaktypen_not_allowed_if_zaken_related(self):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+
+        ZaakFactory.create(zaaktype=non_concept_zaaktype)
+
+        admin_url = reverse("admin:catalogi_zaaktype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_zaaktype.id, non_concept_zaaktype.id]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(_("Zaaktypen kan niet worden verwijderd"), response.text)
+        self.assertIn(
+            _(
+                "vereist het verwijderen van de volgende beschermde gerelateerde objecten"
+            ),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(ZaakType.objects.count(), 2)
+
+    def test_delete_published_zaaktype_allowed_if_no_zaken_related(self):
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+
+        admin_url = reverse(
+            "admin:catalogi_zaaktype_delete", args=(non_concept_zaaktype.id,)
+        )
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # Zaaktype is successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakType.objects.exists())
+
+    def test_bulk_delete_published_zaaktypen_allowed_if_no_zaken_related(self):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+
+        admin_url = reverse("admin:catalogi_zaaktype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_zaaktype.id, non_concept_zaaktype.id]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both Zaaktypen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakType.objects.exists())
+
+    def test_delete_concept_zaaktype_allowed_if_no_zaken_related(self):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+
+        admin_url = reverse(
+            "admin:catalogi_zaaktype_delete", args=(concept_zaaktype.id,)
+        )
+
+        response = self.app.get(admin_url)
+
+        # no warning, because all zaaktypen are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # Zaaktype is successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakType.objects.exists())
+
+    def test_bulk_delete_concept_zaaktypen_allowed_if_no_zaken_related(self):
+        concept_zaaktype1 = ZaakTypeFactory.create(concept=True)
+        concept_zaaktype2 = ZaakTypeFactory.create(concept=True)
+
+        admin_url = reverse("admin:catalogi_zaaktype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_zaaktype1.id, concept_zaaktype2.id]
+
+        response = form.submit()
+
+        # no warning, because all zaaktypen are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both Zaaktypen are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakType.objects.exists())

--- a/src/openzaak/components/catalogi/tests/admin/test_zaaktype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_zaaktype_admin.py
@@ -14,7 +14,6 @@ from freezegun import freeze_time
 from maykin_2fa.test import disable_admin_mfa
 from vng_api_common.constants import VertrouwelijkheidsAanduiding
 
-from openzaak.accounts.tests.factories import SuperUserFactory
 from openzaak.components.zaken.tests.factories import ZaakFactory
 from openzaak.notifications.tests.mixins import NotificationsConfigMixin
 from openzaak.selectielijst.models import ReferentieLijstConfig
@@ -25,6 +24,7 @@ from openzaak.selectielijst.tests import (
 )
 from openzaak.selectielijst.tests.mixins import SelectieLijstMixin
 from openzaak.tests.utils import ClearCachesMixin, mock_nrc_oas_get
+from openzaak.tests.utils.admin import AdminTestMixin
 
 from ...models import ZaakType
 from ..factories import (
@@ -43,24 +43,21 @@ from ..factories import (
 @disable_admin_mfa()
 @requests_mock.Mocker()
 class ZaaktypeAdminTests(
-    NotificationsConfigMixin, SelectieLijstMixin, ClearCachesMixin, WebTest
+    NotificationsConfigMixin,
+    SelectieLijstMixin,
+    ClearCachesMixin,
+    AdminTestMixin,
+    WebTest,
 ):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-
-        cls.user = SuperUserFactory.create()
 
         # there are TransactionTestCases that truncate the DB, so we need to ensure
         # there are available years
         selectielijst_config = ReferentieLijstConfig.get_solo()
         selectielijst_config.allowed_years = [2017, 2020]
         selectielijst_config.save()
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
 
     def test_zaaktypen_list(self, m):
         ZaakTypeFactory.create()
@@ -783,17 +780,9 @@ class ZaaktypeAdminTests(
 
 
 @disable_admin_mfa()
-class ZaakTypePublishAdminTests(SelectieLijstMixin, WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-
-        cls.user = SuperUserFactory.create()
-
+class ZaakTypePublishAdminTests(SelectieLijstMixin, AdminTestMixin, WebTest):
     def setUp(self):
         super().setUp()
-
-        self.app.set_user(self.user)
 
         self.catalogus = CatalogusFactory.create()
         self.url = reverse_lazy("admin:catalogi_zaaktype_changelist")
@@ -1293,18 +1282,7 @@ class ZaakTypePublishAdminTests(SelectieLijstMixin, WebTest):
 
 @tag("gh-1877")
 @disable_admin_mfa()
-class ZaakTypeDeleteAdminTests(WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
+class ZaakTypeDeleteAdminTests(AdminTestMixin, WebTest):
     def test_delete_published_zaaktype_not_allowed_if_zaken_related(self):
         non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
 

--- a/src/openzaak/components/catalogi/tests/admin/test_zaaktypeinformatieobjecttype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_zaaktypeinformatieobjecttype_admin.py
@@ -1,0 +1,358 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2020 Dimpact
+from django.test import tag
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from django_webtest import WebTest
+from maykin_2fa.test import disable_admin_mfa
+
+from openzaak.accounts.tests.factories import SuperUserFactory
+from openzaak.components.documenten.tests.factories import (
+    EnkelvoudigInformatieObjectFactory,
+)
+from openzaak.components.zaken.tests.factories import ZaakInformatieObjectFactory
+
+from ...models import ZaakTypeInformatieObjectType
+from ..factories import (
+    InformatieObjectTypeFactory,
+    ZaakTypeFactory,
+    ZaakTypeInformatieObjectTypeFactory,
+)
+
+
+@tag("gh-1877")
+@disable_admin_mfa()
+class ZaakTypeInformatieObjectTypeDeleteAdminTests(WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = SuperUserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+
+        self.app.set_user(self.user)
+
+    def test_delete_published_ziot_not_allowed_if_documenten_related(self):
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        non_concept_informatieobjecttype = InformatieObjectTypeFactory.create(
+            concept=False, zaaktypen=None
+        )
+        ziot = ZaakTypeInformatieObjectTypeFactory.create(
+            zaaktype=non_concept_zaaktype,
+            informatieobjecttype=non_concept_informatieobjecttype,
+        )
+        document = EnkelvoudigInformatieObjectFactory.create(
+            informatieobjecttype=non_concept_informatieobjecttype
+        )
+        ZaakInformatieObjectFactory.create(
+            zaak__zaaktype=non_concept_zaaktype, informatieobject=document.canonical
+        )
+
+        admin_url = reverse(
+            "admin:catalogi_zaaktypeinformatieobjecttype_delete", args=(ziot.id,)
+        )
+
+        response = self.app.get(admin_url, status=403)
+
+        # Deletion should not be allowed, because there are existing relations between
+        # documenten and zaken that depend on the relation between their types
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(ZaakTypeInformatieObjectType.objects.count(), 1)
+
+    def test_delete_half_published_ziot_not_allowed_if_documenten_related(self):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        non_concept_informatieobjecttype = InformatieObjectTypeFactory.create(
+            concept=False, zaaktypen=None
+        )
+        ziot = ZaakTypeInformatieObjectTypeFactory.create(
+            zaaktype=concept_zaaktype,
+            informatieobjecttype=non_concept_informatieobjecttype,
+        )
+        document = EnkelvoudigInformatieObjectFactory.create(
+            informatieobjecttype=non_concept_informatieobjecttype
+        )
+        ZaakInformatieObjectFactory.create(
+            zaak__zaaktype=concept_zaaktype, informatieobject=document.canonical
+        )
+
+        admin_url = reverse(
+            "admin:catalogi_zaaktypeinformatieobjecttype_delete", args=(ziot.id,)
+        )
+
+        response = self.app.get(admin_url, status=403)
+
+        # Deletion should not be allowed, because there are existing relations between
+        # documenten and zaken that depend on the relation between their types
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(ZaakTypeInformatieObjectType.objects.count(), 1)
+
+    def test_bulk_delete_published_ziots_not_allowed_if_documenten_related(
+        self,
+    ):
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        non_concept_informatieobjecttype = InformatieObjectTypeFactory.create(
+            concept=False, zaaktypen=None
+        )
+        ziot = ZaakTypeInformatieObjectTypeFactory.create(
+            zaaktype=non_concept_zaaktype,
+            informatieobjecttype=non_concept_informatieobjecttype,
+        )
+        document = EnkelvoudigInformatieObjectFactory.create(
+            informatieobjecttype=non_concept_informatieobjecttype
+        )
+        ZaakInformatieObjectFactory.create(
+            zaak__zaaktype=non_concept_zaaktype, informatieobject=document.canonical
+        )
+
+        admin_url = reverse("admin:catalogi_zaaktypeinformatieobjecttype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [ziot.id]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(
+            _("Zaak-Informatieobject-Type kan niet worden verwijderd"), response.text
+        )
+        self.assertIn(
+            _(
+                "uw account heeft geen rechten om de volgende typen objecten te verwijderen"
+            ),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(ZaakTypeInformatieObjectType.objects.count(), 1)
+
+    def test_delete_published_ziot_allowed_if_no_documenten_related(self):
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        non_concept_informatieobjecttype = InformatieObjectTypeFactory.create(
+            concept=False, zaaktypen=None
+        )
+        ziot = ZaakTypeInformatieObjectTypeFactory.create(
+            zaaktype=non_concept_zaaktype,
+            informatieobjecttype=non_concept_informatieobjecttype,
+        )
+
+        admin_url = reverse(
+            "admin:catalogi_zaaktypeinformatieobjecttype_delete",
+            args=(ziot.id,),
+        )
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # The relation is successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakTypeInformatieObjectType.objects.exists())
+
+    def test_bulk_delete_published_ziots_allowed_if_no_documenten_related(
+        self,
+    ):
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        non_concept_informatieobjecttype = InformatieObjectTypeFactory.create(
+            concept=False, zaaktypen=None
+        )
+        ziot = ZaakTypeInformatieObjectTypeFactory.create(
+            zaaktype=non_concept_zaaktype,
+            informatieobjecttype=non_concept_informatieobjecttype,
+        )
+        concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        concept_informatieobjecttype = InformatieObjectTypeFactory.create(
+            concept=False, zaaktypen=None
+        )
+        concept_ziot = ZaakTypeInformatieObjectTypeFactory.create(
+            zaaktype=concept_zaaktype,
+            informatieobjecttype=concept_informatieobjecttype,
+        )
+
+        admin_url = reverse("admin:catalogi_zaaktypeinformatieobjecttype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [ziot.id, concept_ziot.id]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both relations are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakTypeInformatieObjectType.objects.exists())
+
+    def test_delete_concept_ziot_not_allowed_if_documenten_related(self):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        concept_informatieobjecttype = InformatieObjectTypeFactory.create(
+            concept=True, zaaktypen=None
+        )
+        concept_ziot = ZaakTypeInformatieObjectTypeFactory.create(
+            zaaktype=concept_zaaktype,
+            informatieobjecttype=concept_informatieobjecttype,
+        )
+
+        document = EnkelvoudigInformatieObjectFactory.create(
+            informatieobjecttype=concept_informatieobjecttype
+        )
+        ZaakInformatieObjectFactory.create(
+            zaak__zaaktype=concept_zaaktype, informatieobject=document.canonical
+        )
+
+        admin_url = reverse(
+            "admin:catalogi_zaaktypeinformatieobjecttype_delete",
+            args=(concept_ziot.id,),
+        )
+
+        response = self.app.get(admin_url, status=403)
+
+        # Deletion should not be allowed, because there are existing relations between
+        # documenten and zaken that depend on the relation between their types
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(ZaakTypeInformatieObjectType.objects.count(), 1)
+
+    def test_bulk_delete_concept_ziots_not_allowed_if_documenten_related(
+        self,
+    ):
+        concept_zaaktype1 = ZaakTypeFactory.create(concept=True)
+        concept_informatieobjecttype1 = InformatieObjectTypeFactory.create(
+            concept=True, zaaktypen=None
+        )
+        concept_ziot1 = ZaakTypeInformatieObjectTypeFactory.create(
+            zaaktype=concept_zaaktype1,
+            informatieobjecttype=concept_informatieobjecttype1,
+        )
+        concept_zaaktype2 = ZaakTypeFactory.create(concept=True)
+        concept_informatieobjecttype2 = InformatieObjectTypeFactory.create(
+            concept=True, zaaktypen=None
+        )
+        concept_ziot2 = ZaakTypeInformatieObjectTypeFactory.create(
+            zaaktype=concept_zaaktype2,
+            informatieobjecttype=concept_informatieobjecttype2,
+        )
+
+        document = EnkelvoudigInformatieObjectFactory.create(
+            informatieobjecttype=concept_informatieobjecttype1
+        )
+        ZaakInformatieObjectFactory.create(
+            zaak__zaaktype=concept_zaaktype1, informatieobject=document.canonical
+        )
+
+        admin_url = reverse("admin:catalogi_zaaktypeinformatieobjecttype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_ziot1.id, concept_ziot2.id]
+
+        response = form.submit()
+
+        # no warning, because all relaties are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+        # Delete is not allowed
+        self.assertIn(
+            _("Zaak-Informatieobject-Typen kan niet worden verwijderd"), response.text
+        )
+        self.assertIn(
+            _(
+                "uw account heeft geen rechten om de volgende typen objecten te verwijderen"
+            ),
+            response.text,
+        )
+        # Delete confirmation form should not be present
+        self.assertNotIn(1, response.forms)
+        self.assertEqual(ZaakTypeInformatieObjectType.objects.count(), 2)
+
+    def test_delete_concept_ziot_allowed_if_no_documenten_related(self):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        concept_informatieobjecttype = InformatieObjectTypeFactory.create(
+            concept=True, zaaktypen=None
+        )
+        concept_ziot = ZaakTypeInformatieObjectTypeFactory.create(
+            zaaktype=concept_zaaktype,
+            informatieobjecttype=concept_informatieobjecttype,
+        )
+
+        admin_url = reverse(
+            "admin:catalogi_zaaktypeinformatieobjecttype_delete",
+            args=(concept_ziot.id,),
+        )
+
+        response = self.app.get(admin_url)
+
+        # no warning, because all relaties are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # Both relaties are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakTypeInformatieObjectType.objects.exists())
+
+    def test_bulk_delete_concept_ziots_allowed_if_no_documenten_related(
+        self,
+    ):
+        concept_zaaktype1 = ZaakTypeFactory.create(concept=True)
+        concept_informatieobjecttype1 = InformatieObjectTypeFactory.create(
+            concept=True, zaaktypen=None
+        )
+        concept_ziot1 = ZaakTypeInformatieObjectTypeFactory.create(
+            zaaktype=concept_zaaktype1,
+            informatieobjecttype=concept_informatieobjecttype1,
+        )
+        concept_zaaktype2 = ZaakTypeFactory.create(concept=True)
+        concept_informatieobjecttype2 = InformatieObjectTypeFactory.create(
+            concept=True, zaaktypen=None
+        )
+        concept_ziot2 = ZaakTypeInformatieObjectTypeFactory.create(
+            zaaktype=concept_zaaktype2,
+            informatieobjecttype=concept_informatieobjecttype2,
+        )
+
+        admin_url = reverse("admin:catalogi_zaaktypeinformatieobjecttype_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_ziot1.id, concept_ziot2.id]
+
+        response = form.submit()
+
+        # no warning, because all relaties are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both relations are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakTypeInformatieObjectType.objects.exists())

--- a/src/openzaak/components/catalogi/tests/admin/test_zaaktypeinformatieobjecttype_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_zaaktypeinformatieobjecttype_admin.py
@@ -7,11 +7,11 @@ from django.utils.translation import gettext as _
 from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
 
-from openzaak.accounts.tests.factories import SuperUserFactory
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
 from openzaak.components.zaken.tests.factories import ZaakInformatieObjectFactory
+from openzaak.tests.utils.admin import AdminTestMixin
 
 from ...models import ZaakTypeInformatieObjectType
 from ..factories import (
@@ -23,18 +23,7 @@ from ..factories import (
 
 @tag("gh-1877")
 @disable_admin_mfa()
-class ZaakTypeInformatieObjectTypeDeleteAdminTests(WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
+class ZaakTypeInformatieObjectTypeDeleteAdminTests(AdminTestMixin, WebTest):
     def test_delete_published_ziot_not_allowed_if_documenten_related(self):
         non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
         non_concept_informatieobjecttype = InformatieObjectTypeFactory.create(

--- a/src/openzaak/components/catalogi/tests/admin/test_zaaktypenrelatie_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_zaaktypenrelatie_admin.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2021 Dimpact
-from django.test import override_settings
+from django.test import override_settings, tag
 from django.urls import reverse
 
 from django_webtest import WebTest
@@ -9,6 +9,7 @@ from vng_api_common.tests import reverse as _reverse
 
 from openzaak.accounts.tests.factories import SuperUserFactory
 from openzaak.components.catalogi.models import ZaakTypenRelatie
+from openzaak.components.zaken.tests.factories import ZaakFactory
 from openzaak.tests.utils import ClearCachesMixin
 
 from ...constants import AardRelatieChoices
@@ -254,3 +255,265 @@ class ZaakTypenRelatieAdminTests(ClearCachesMixin, WebTest):
 
         lookup = response.html.find("a", {"id": "lookup_id_gerelateerd_zaaktype_0"})
         self.assertIsNotNone(lookup)
+
+
+@tag("gh-1877")
+@disable_admin_mfa()
+class ZaakTypenRelatieDeleteAdminTests(WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = SuperUserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+
+        self.app.set_user(self.user)
+
+    def test_delete_published_zaaktypenrelatie_allowed_if_zaken_related(self):
+        """
+        Because zaaktypenrelaties are not relevant for runtime validation for zaken,
+        deleting them should be possible
+        """
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        relatie = ZaakTypenRelatieFactory.create(
+            zaaktype=non_concept_zaaktype,
+        )
+        ZaakFactory.create(zaaktype=non_concept_zaaktype)
+
+        admin_url = reverse(
+            "admin:catalogi_zaaktypenrelatie_delete", args=(relatie.id,)
+        )
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # The relation are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakTypenRelatie.objects.exists())
+
+    def test_bulk_delete_published_zaaktypenrelaties_allowed_if_zaken_related(
+        self,
+    ):
+        """
+        Because zaaktypenrelaties are not relevant for runtime validation for zaken,
+        deleting them should be possible
+        """
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        relatie = ZaakTypenRelatieFactory.create(
+            zaaktype=non_concept_zaaktype,
+        )
+        ZaakFactory.create(zaaktype=non_concept_zaaktype)
+
+        admin_url = reverse("admin:catalogi_zaaktypenrelatie_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [relatie.id]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        # delete is allowed
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both relations are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakTypenRelatie.objects.exists())
+
+    def test_delete_published_zaaktypenrelatie_allowed_if_no_zaken_related(self):
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        relatie = ZaakTypenRelatieFactory.create(zaaktype=non_concept_zaaktype)
+
+        admin_url = reverse(
+            "admin:catalogi_zaaktypenrelatie_delete",
+            args=(relatie.id,),
+        )
+
+        response = self.app.get(admin_url)
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # The relation are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakTypenRelatie.objects.exists())
+
+    def test_bulk_delete_published_zaaktypenrelaties_allowed_if_no_zaken_related(
+        self,
+    ):
+        non_concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        relatie = ZaakTypenRelatieFactory.create(
+            zaaktype=non_concept_zaaktype,
+        )
+        concept_zaaktype = ZaakTypeFactory.create(concept=False)
+        concept_relatie = ZaakTypenRelatieFactory.create(
+            zaaktype=concept_zaaktype,
+        )
+
+        admin_url = reverse("admin:catalogi_zaaktypenrelatie_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [relatie.id, concept_relatie.id]
+
+        response = form.submit()
+
+        # warning about deleting published types should be present on confirmation page
+        self.assertIsNotNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both relations are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakTypenRelatie.objects.exists())
+
+    def test_delete_concept_zaaktypenrelatie_allowed_if_zaken_related(self):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        concept_relatie = ZaakTypenRelatieFactory.create(zaaktype=concept_zaaktype)
+
+        ZaakFactory.create(zaaktype=concept_zaaktype)
+
+        admin_url = reverse(
+            "admin:catalogi_zaaktypenrelatie_delete",
+            args=(concept_relatie.id,),
+        )
+
+        response = self.app.get(admin_url)
+
+        # no warning, because all relaties are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # Relatie is successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakTypenRelatie.objects.exists())
+
+    def test_bulk_delete_concept_zaaktypenrelaties_not_allowed_if_zaken_related(
+        self,
+    ):
+        concept_zaaktype1 = ZaakTypeFactory.create(concept=True)
+        concept_relatie1 = ZaakTypenRelatieFactory.create(
+            zaaktype=concept_zaaktype1,
+        )
+        ZaakFactory.create(zaaktype=concept_zaaktype1)
+
+        concept_zaaktype2 = ZaakTypeFactory.create(concept=True)
+        concept_relatie2 = ZaakTypenRelatieFactory.create(
+            zaaktype=concept_zaaktype2,
+        )
+
+        ZaakFactory.create(zaaktype=concept_zaaktype2)
+
+        admin_url = reverse("admin:catalogi_zaaktypenrelatie_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_relatie1.id, concept_relatie2.id]
+
+        response = form.submit()
+
+        # no warning, because all relaties are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both relations are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakTypenRelatie.objects.exists())
+
+    def test_delete_concept_zaaktypenrelatie_allowed_if_no_zaken_related(self):
+        concept_zaaktype = ZaakTypeFactory.create(concept=True)
+        concept_relatie = ZaakTypenRelatieFactory.create(
+            zaaktype=concept_zaaktype,
+        )
+
+        admin_url = reverse(
+            "admin:catalogi_zaaktypenrelatie_delete", args=(concept_relatie.id,)
+        )
+
+        response = self.app.get(admin_url)
+
+        # no warning, because all relaties are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+
+        response = form.submit()
+
+        # Both relaties are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakTypenRelatie.objects.exists())
+
+    def test_bulk_delete_concept_zaaktypenrelaties_allowed_if_no_zaken_related(
+        self,
+    ):
+        concept_zaaktype1 = ZaakTypeFactory.create(concept=True)
+        concept_relatie1 = ZaakTypenRelatieFactory.create(
+            zaaktype=concept_zaaktype1,
+        )
+        concept_zaaktype2 = ZaakTypeFactory.create(concept=True)
+        concept_relatie2 = ZaakTypenRelatieFactory.create(
+            zaaktype=concept_zaaktype2,
+        )
+
+        admin_url = reverse("admin:catalogi_zaaktypenrelatie_changelist")
+        form = self.app.get(admin_url).forms["changelist-form"]
+        form["action"] = "delete_selected"
+        form["_selected_action"] = [concept_relatie1.id, concept_relatie2.id]
+
+        response = form.submit()
+
+        # no warning, because all relaties are concepts
+        self.assertIsNone(
+            response.html.find("li", {"id": "deleting-published-types-warning"})
+        )
+
+        form = response.forms[1]
+        form["action"] = "delete_selected"
+        form["post"] = "yes"
+
+        response = form.submit()
+
+        # Both relations are successfully deleted
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(ZaakTypenRelatie.objects.exists())

--- a/src/openzaak/components/catalogi/tests/admin/test_zaaktypenrelatie_admin.py
+++ b/src/openzaak/components/catalogi/tests/admin/test_zaaktypenrelatie_admin.py
@@ -7,10 +7,10 @@ from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
 from vng_api_common.tests import reverse as _reverse
 
-from openzaak.accounts.tests.factories import SuperUserFactory
 from openzaak.components.catalogi.models import ZaakTypenRelatie
 from openzaak.components.zaken.tests.factories import ZaakFactory
 from openzaak.tests.utils import ClearCachesMixin
+from openzaak.tests.utils.admin import AdminTestMixin
 
 from ...constants import AardRelatieChoices
 from ..factories import ZaakTypeFactory, ZaakTypenRelatieFactory
@@ -18,18 +18,7 @@ from ..factories import ZaakTypeFactory, ZaakTypenRelatieFactory
 
 @disable_admin_mfa()
 @override_settings(IS_HTTPS=False, ALLOWED_HOSTS=["testserver", "testserver.com"])
-class ZaakTypenRelatieAdminTests(ClearCachesMixin, WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
+class ZaakTypenRelatieAdminTests(ClearCachesMixin, AdminTestMixin, WebTest):
     def test_zaaktypenrelatie_create_with_gerelateerd_zaaktype_internal(self):
         zaaktype1, zaaktype2 = ZaakTypeFactory.create_batch(2)
 
@@ -259,18 +248,7 @@ class ZaakTypenRelatieAdminTests(ClearCachesMixin, WebTest):
 
 @tag("gh-1877")
 @disable_admin_mfa()
-class ZaakTypenRelatieDeleteAdminTests(WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
+class ZaakTypenRelatieDeleteAdminTests(AdminTestMixin, WebTest):
     def test_delete_published_zaaktypenrelatie_allowed_if_zaken_related(self):
         """
         Because zaaktypenrelaties are not relevant for runtime validation for zaken,

--- a/src/openzaak/components/documenten/tests/admin/test_canonical.py
+++ b/src/openzaak/components/documenten/tests/admin/test_canonical.py
@@ -5,7 +5,6 @@ from django.urls import reverse
 from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
 
-from openzaak.accounts.tests.factories import SuperUserFactory
 from openzaak.components.documenten.models import (
     EnkelvoudigInformatieObject,
 )
@@ -13,19 +12,11 @@ from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectCanonicalFactory,
     EnkelvoudigInformatieObjectFactory,
 )
+from openzaak.tests.utils.admin import AdminTestMixin
 
 
 @disable_admin_mfa()
-class EnkelvoudigInformatieObjectCanonicalAdminTests(WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
+class EnkelvoudigInformatieObjectCanonicalAdminTests(AdminTestMixin, WebTest):
     def test_delete_last_inline_version(self):
         canonical = EnkelvoudigInformatieObjectCanonicalFactory.create()
 

--- a/src/openzaak/components/documenten/tests/admin/test_eio.py
+++ b/src/openzaak/components/documenten/tests/admin/test_eio.py
@@ -9,7 +9,6 @@ from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
 from webtest import Upload
 
-from openzaak.accounts.tests.factories import SuperUserFactory
 from openzaak.components.catalogi.tests.factories import InformatieObjectTypeFactory
 from openzaak.components.documenten.admin import EnkelvoudigInformatieObjectAdmin
 from openzaak.components.documenten.exceptions import DocumentBackendNotImplementedError
@@ -19,21 +18,13 @@ from openzaak.components.documenten.models import (
 )
 from openzaak.components.documenten.widgets import PrivateFileWidget
 from openzaak.components.zaken.tests.factories import ZaakInformatieObjectFactory
+from openzaak.tests.utils.admin import AdminTestMixin
 
 from ..factories import EnkelvoudigInformatieObjectCanonicalFactory
 
 
 @disable_admin_mfa()
-class EnkelvoudigInformatieObjectAdminTests(WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
+class EnkelvoudigInformatieObjectAdminTests(AdminTestMixin, WebTest):
     def test_form_widget(self):
         admin_obj = EnkelvoudigInformatieObjectAdmin(
             EnkelvoudigInformatieObject, admin.site
@@ -222,16 +213,7 @@ class EnkelvoudigInformatieObjectAdminTests(WebTest):
 
 
 @disable_admin_mfa()
-class EnkelvoudigInformatieObjectCanonicalAdminTests(WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
+class EnkelvoudigInformatieObjectCanonicalAdminTests(AdminTestMixin, WebTest):
     def test_eio_add_no_version(self):
         self.assertEqual(EnkelvoudigInformatieObjectCanonical.objects.count(), 0)
 

--- a/src/openzaak/components/documenten/tests/admin/test_eio_download.py
+++ b/src/openzaak/components/documenten/tests/admin/test_eio_download.py
@@ -7,7 +7,7 @@ from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
 from privates.test import temp_private_root
 
-from openzaak.accounts.tests.factories import SuperUserFactory
+from openzaak.tests.utils.admin import AdminTestMixin
 
 from ..factories import EnkelvoudigInformatieObjectFactory
 
@@ -15,15 +15,7 @@ from ..factories import EnkelvoudigInformatieObjectFactory
 @temp_private_root()
 @disable_admin_mfa()
 @override_settings(SENDFILE_BACKEND="django_sendfile.backends.simple")
-class EnkelvoudigInformatieObjectDownloadAdminTests(WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-        self.app.set_user(self.user)
-
+class EnkelvoudigInformatieObjectDownloadAdminTests(AdminTestMixin, WebTest):
     def test_eio_download_inhoud(self):
         eio = EnkelvoudigInformatieObjectFactory.create(
             bestandsnaam="iets.txt", inhoud__data=b"STUFF"

--- a/src/openzaak/components/documenten/tests/admin/test_eiocanonical_inline_audittrail.py
+++ b/src/openzaak/components/documenten/tests/admin/test_eiocanonical_inline_audittrail.py
@@ -9,9 +9,9 @@ from maykin_2fa.test import disable_admin_mfa
 from privates.test import temp_private_root
 from vng_api_common.audittrails.models import AuditTrail
 
-from openzaak.accounts.tests.factories import SuperUserFactory
 from openzaak.components.catalogi.tests.factories import InformatieObjectTypeFactory
 from openzaak.components.documenten.models import EnkelvoudigInformatieObject
+from openzaak.tests.utils.admin import AdminTestMixin
 
 from ..factories import (
     EnkelvoudigInformatieObjectCanonicalFactory,
@@ -22,10 +22,10 @@ from ..utils import get_operation_url
 
 @temp_private_root()
 @disable_admin_mfa()
-class EioAdminInlineTests(WebTest):
+class EioAdminInlineTests(AdminTestMixin, WebTest):
     @classmethod
     def setUpTestData(cls):
-        cls.user = SuperUserFactory.create()
+        super().setUpTestData()
         cls.canonical = EnkelvoudigInformatieObjectCanonicalFactory.create(
             latest_version=None
         )
@@ -33,11 +33,6 @@ class EioAdminInlineTests(WebTest):
             "admin:documenten_enkelvoudiginformatieobjectcanonical_change",
             args=(cls.canonical.pk,),
         )
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
 
     def assertEioAudittrail(self, audittrail):
         self.assertEqual(audittrail.bron, "DRC")

--- a/src/openzaak/components/documenten/tests/azure/admin/test_eio.py
+++ b/src/openzaak/components/documenten/tests/azure/admin/test_eio.py
@@ -12,7 +12,6 @@ from maykin_common.vcr import VCRMixin
 from requests.exceptions import RequestException
 from webtest import Upload
 
-from openzaak.accounts.tests.factories import SuperUserFactory
 from openzaak.components.catalogi.tests.factories import InformatieObjectTypeFactory
 from openzaak.components.documenten.admin import EnkelvoudigInformatieObjectAdmin
 from openzaak.components.documenten.constants import DocumentenBackendTypes
@@ -20,6 +19,7 @@ from openzaak.components.documenten.models import (
     EnkelvoudigInformatieObject,
 )
 from openzaak.components.documenten.widgets import AdminFileWidget
+from openzaak.tests.utils.admin import AdminTestMixin
 
 from ....storage import documenten_storage
 from ...factories import (
@@ -32,16 +32,9 @@ from ..mixins import AzureBlobStorageMixin
 @freeze_time("2025-12-01T12:00:00")
 @tag("gh-2217", "azure-storage")
 @disable_admin_mfa()
-class EnkelvoudigInformatieObjectAdminTests(VCRMixin, AzureBlobStorageMixin, WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
+class EnkelvoudigInformatieObjectAdminTests(
+    VCRMixin, AzureBlobStorageMixin, AdminTestMixin, WebTest
+):
     def test_form_widget(self):
         admin_obj = EnkelvoudigInformatieObjectAdmin(
             EnkelvoudigInformatieObject, admin.site

--- a/src/openzaak/components/documenten/tests/azure/admin/test_eio_download.py
+++ b/src/openzaak/components/documenten/tests/azure/admin/test_eio_download.py
@@ -9,7 +9,7 @@ from freezegun import freeze_time
 from maykin_2fa.test import disable_admin_mfa
 from maykin_common.vcr import VCRMixin
 
-from openzaak.accounts.tests.factories import SuperUserFactory
+from openzaak.tests.utils.admin import AdminTestMixin
 
 from ...factories import EnkelvoudigInformatieObjectFactory
 from ..mixins import AzureBlobStorageMixin
@@ -19,16 +19,8 @@ from ..mixins import AzureBlobStorageMixin
 @freeze_time("2030-01-01T12:00:00")
 @tag("gh-2217", "azure-storage")
 class EnkelvoudigInformatieObjectDownloadAdminTests(
-    VCRMixin, AzureBlobStorageMixin, WebTest
+    VCRMixin, AzureBlobStorageMixin, AdminTestMixin, WebTest
 ):
-    @classmethod
-    def setUpTestData(cls):
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-        self.app.set_user(self.user)
-
     def test_eio_download_inhoud(self):
         eio = EnkelvoudigInformatieObjectFactory.create(
             bestandsnaam="iets.txt",

--- a/src/openzaak/components/documenten/tests/s3/admin/test_eio.py
+++ b/src/openzaak/components/documenten/tests/s3/admin/test_eio.py
@@ -13,7 +13,6 @@ from maykin_common.vcr import VCRMixin
 from requests.exceptions import RequestException
 from webtest import Upload
 
-from openzaak.accounts.tests.factories import SuperUserFactory
 from openzaak.components.catalogi.tests.factories import InformatieObjectTypeFactory
 from openzaak.components.documenten.admin import EnkelvoudigInformatieObjectAdmin
 from openzaak.components.documenten.constants import DocumentenBackendTypes
@@ -21,6 +20,7 @@ from openzaak.components.documenten.models import (
     EnkelvoudigInformatieObject,
 )
 from openzaak.components.documenten.widgets import AdminFileWidget
+from openzaak.tests.utils.admin import AdminTestMixin
 
 from ....storage import documenten_storage
 from ...factories import (
@@ -33,16 +33,9 @@ from ..mixins import S3torageMixin, upload_to
 @disable_admin_mfa()
 @tag("gh-2282", "s3-storage")
 @patch("privates.fields.PrivateMediaFileField.generate_filename", upload_to)
-class EnkelvoudigInformatieObjectAdminTests(VCRMixin, S3torageMixin, WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        cls.user = SuperUserFactory.create()
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
+class EnkelvoudigInformatieObjectAdminTests(
+    VCRMixin, S3torageMixin, AdminTestMixin, WebTest
+):
     def test_form_widget(self):
         admin_obj = EnkelvoudigInformatieObjectAdmin(
             EnkelvoudigInformatieObject, admin.site

--- a/src/openzaak/components/documenten/tests/s3/admin/test_eio_download.py
+++ b/src/openzaak/components/documenten/tests/s3/admin/test_eio_download.py
@@ -10,7 +10,7 @@ from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
 from maykin_common.vcr import VCRMixin
 
-from openzaak.accounts.tests.factories import SuperUserFactory
+from openzaak.tests.utils.admin import AdminTestMixin
 
 from ...factories import EnkelvoudigInformatieObjectFactory
 from ..mixins import S3torageMixin, upload_to
@@ -19,14 +19,12 @@ from ..mixins import S3torageMixin, upload_to
 @disable_admin_mfa()
 @tag("gh-2282", "s3-storage")
 @patch("privates.fields.PrivateMediaFileField.generate_filename", upload_to)
-class EnkelvoudigInformatieObjectDownloadAdminTests(VCRMixin, S3torageMixin, WebTest):
-    @classmethod
-    def setUpTestData(cls):
-        cls.user = SuperUserFactory.create()
-
+class EnkelvoudigInformatieObjectDownloadAdminTests(
+    VCRMixin, S3torageMixin, AdminTestMixin, WebTest
+):
     def setUp(self):
         super().setUp()
-        self.app.set_user(self.user)
+
         vcr = self._get_vcr()
         vcr.filter_query_parameters += ("AWSAccessKeyId", "Expires", "Signature")
 

--- a/src/openzaak/components/zaken/tests/admin/test_rol_admin.py
+++ b/src/openzaak/components/zaken/tests/admin/test_rol_admin.py
@@ -20,10 +20,6 @@ from ..factories import RolFactory, ZaakFactory
 class RolAdminTests(AdminTestMixin, WebTest):
     heeft_alle_autorisaties = True
 
-    def setUp(self):
-        super().setUp()
-        self.app.set_user(self.user)
-
     def test_valid_create_rol(self):
         zaak = ZaakFactory.create()
         roltype = RolTypeFactory.create(zaaktype=zaak.zaaktype)

--- a/src/openzaak/components/zaken/tests/admin/test_rol_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/test_rol_audittrail.py
@@ -18,10 +18,6 @@ from ..utils import get_operation_url
 class RolAdminTests(AdminTestMixin, WebTest):
     heeft_alle_autorisaties = True
 
-    def setUp(self):
-        super().setUp()
-        self.app.set_user(self.user)
-
     def test_create_rol(self):
         zaak = ZaakFactory.create()
         zaak_url = get_operation_url("zaak_read", uuid=zaak.uuid)

--- a/src/openzaak/components/zaken/tests/admin/test_zaak_admin.py
+++ b/src/openzaak/components/zaken/tests/admin/test_zaak_admin.py
@@ -28,6 +28,7 @@ from openzaak.components.zaken.models.betrokkenen import (
     NatuurlijkPersoon,
     NietNatuurlijkPersoon,
 )
+from openzaak.tests.utils.admin import AdminTestMixin
 
 from ...models import ZaakBesluit
 from ..factories import (
@@ -41,19 +42,16 @@ from ..factories import (
 
 @disable_admin_mfa()
 @override_settings(ALLOWED_HOSTS=["testserver"])
-class ZaakAdminTests(WebTest):
+class ZaakAdminTests(AdminTestMixin, WebTest):
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
+
         cls.user = SuperUserFactory.create()
         cls.service = ServiceFactory.create(
             api_type=APITypes.drc,
             api_root="https://external.nl/api/v1/",
         )
-
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
 
     def test_zaaktype_detail_external_io_not_available(self):
         zaak = ZaakFactory.create()

--- a/src/openzaak/components/zaken/tests/admin/test_zaak_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/test_zaak_audittrail.py
@@ -16,11 +16,6 @@ from ..utils import get_operation_url
 
 @disable_admin_mfa()
 class ZaakAdminTests(AdminTestMixin, WebTest):
-    def setUp(self):
-        super().setUp()
-
-        self.app.set_user(self.user)
-
     def _create_zaak(self):
         zaaktype = ZaakTypeFactory.create(concept=False)
 
@@ -139,7 +134,6 @@ class ZaakAdminTests(AdminTestMixin, WebTest):
         self.assertEqual(AuditTrail.objects.count(), 0)
 
     def test_save_zaak_without_change(self):
-        self.app.set_user(self.user)
         zaak = ZaakFactory.create()
         change_url = reverse("admin:zaken_zaak_change", args=(zaak.pk,))
 

--- a/src/openzaak/components/zaken/tests/admin/test_zaaknotitie_admin.py
+++ b/src/openzaak/components/zaken/tests/admin/test_zaaknotitie_admin.py
@@ -16,10 +16,6 @@ from ..factories import ZaakFactory, ZaakNotitieFactory
 class ZaakNotitieAdminTests(AdminTestMixin, WebTest):
     heeft_alle_autorisaties = True
 
-    def setUp(self):
-        super().setUp()
-        self.app.set_user(self.user)
-
     def test_valid_create_zaaknotitie(self):
         zaak = ZaakFactory.create()
 

--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -109,6 +109,7 @@ INSTALLED_APPS = (
         "openzaak.config",
         "openzaak.selectielijst",
         "openzaak.notifications",
+        "openzaak.templatetags",
     ]
     + PLUGIN_INSTALLED_APPS
 )

--- a/src/openzaak/templates/admin/catalogi/change_form.html
+++ b/src/openzaak/templates/admin/catalogi/change_form.html
@@ -14,7 +14,8 @@
     <div class="submit-row submit-row-extended">
 
         {% block extra_submit_buttons %}
-            {# Only Catalogus.ZaakType, Catalogus.InformatieObjectType and Catalogus.BesluitType have this concept-attribute #}
+            {# Only Catalogus.ZaakType, Catalogus.InformatieObjectType and Catalogus.BesluitType can be published #}
+            {% if opts.model_name in "zaaktype,informatieobjecttype,besluittype" %}
             {% with concept=original.concept %}
                 {% if concept == True or concept == False %}
                     <span>of <strong>Opslaan</strong> en ...</span>
@@ -22,6 +23,7 @@
                     <input type="submit" value="{% trans 'Publiceren' %}" name="_publish" {% if concept == False %}disabled="disabled"{% endif %}>
                 {% endif %}
             {% endwith %}
+            {% endif %}
         {% endblock %}
 
     </div>

--- a/src/openzaak/templates/admin/catalogi/delete_confirmation_published_warning.html
+++ b/src/openzaak/templates/admin/catalogi/delete_confirmation_published_warning.html
@@ -1,0 +1,25 @@
+{% extends "admin/delete_confirmation.html" %}
+{% comment %} SPDX-License-Identifier: EUPL-1.2 {% endcomment %}
+{% comment %} Copyright (C) 2026 Dimpact {% endcomment %}
+{% load i18n %}
+
+{% block content %}
+    {# Explicitly check if concept is False, if the class does not implement #}
+    {# .concept, this warning message is not relevant for that class #}
+    {% if object.concept is False %}
+    <ul class="messagelist">
+        <li id="deleting-published-types-warning" class="warning">
+            {% blocktrans %}
+                Het verwijderen van gepubliceerde typen is alleen mogelijk als er geen
+                andere objecten zijn die gebruikmaken van deze typen.
+
+                Let op: er kan alleen gecontroleerd worden of er lokale objecten zijn die
+                deze typen gebruiken, er kan niet gecontroleerd worden of externe systemen
+                gebruikmaken van deze typen!
+            {% endblocktrans %}
+        </li>
+    </ul>
+    {% endif %}
+
+    {{ block.super }}
+{% endblock %}

--- a/src/openzaak/templates/admin/catalogi/delete_selected_confirmation_published_warning.html
+++ b/src/openzaak/templates/admin/catalogi/delete_selected_confirmation_published_warning.html
@@ -1,0 +1,23 @@
+{% extends "admin/delete_selected_confirmation.html" %}
+{% comment %} SPDX-License-Identifier: EUPL-1.2 {% endcomment %}
+{% comment %} Copyright (C) 2026 Dimpact {% endcomment %}
+{% load i18n list_filters %}
+
+{% block content %}
+    {% if not queryset|all_true:"concept" %}
+    <ul class="messagelist">
+        <li id="deleting-published-types-warning" class="warning">
+            {% blocktrans %}
+                Het verwijderen van gepubliceerde typen is alleen mogelijk als er geen
+                andere objecten zijn die gebruikmaken van deze typen.
+
+                Let op: er kan alleen gecontroleerd worden of er lokale objecten zijn die
+                deze typen gebruiken, er kan niet gecontroleerd worden of externe systemen
+                gebruikmaken van deze typen!
+            {% endblocktrans %}
+        </li>
+    </ul>
+    {% endif %}
+
+    {{ block.super }}
+{% endblock %}

--- a/src/openzaak/templatetags/__init__.py
+++ b/src/openzaak/templatetags/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2026 Dimpact

--- a/src/openzaak/templatetags/list_filters.py
+++ b/src/openzaak/templatetags/list_filters.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2026 Dimpact
+from typing import Iterable
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def all_true(iterable: Iterable, attribute: str) -> bool:
+    """Template tag to perform `all()` for a specific attribute on a list
+
+    Args:
+        iterable (Iterable): the iterable to perform `all()` on
+        attribute (str): the name of the attribute
+
+    Returns:
+        bool: True if all values of attribute in list are truthy, else False
+    """
+    return (
+        all(iterable)
+        if attribute is None
+        else all(getattr(item, attribute) for item in iterable)
+    )

--- a/src/openzaak/tests/utils/admin.py
+++ b/src/openzaak/tests/utils/admin.py
@@ -1,9 +1,15 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2022 Dimpact
+from django_webtest import WebTest
+
 from openzaak.accounts.models import User
 
 
 class AdminTestMixin:
+    """
+    Mixin to authenticate as a superuser for both Django TestCases and WebTest classes
+    """
+
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -19,6 +25,9 @@ class AdminTestMixin:
     def setUp(self) -> None:
         super().setUp()
         self.client.force_login(user=self.user)
+
+        if isinstance(self, WebTest):
+            self.app.set_user(self.user)
 
     def tearDown(self) -> None:
         super().tearDown()


### PR DESCRIPTION
Closes #1877

**Changes**

* Allow deletion of unused published catalogi resources via admin

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
