### PR TITLE
:heavy_plus_sign: Add missing sass dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "mini-css-extract-plugin": "latest",
         "postcss-loader": "latest",
         "postcss-selector-lint": "latest",
+        "sass": "^1.99.0",
         "sass-loader": "latest",
         "webpack": "latest",
         "webpack-cli": "latest",
@@ -5366,14 +5367,14 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.93.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.93.2.tgz",
-      "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+      "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
-        "immutable": "^5.0.2",
+        "immutable": "^5.1.5",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "mini-css-extract-plugin": "latest",
     "postcss-loader": "latest",
     "postcss-selector-lint": "latest",
+    "sass": "^1.99.0",
     "sass-loader": "latest",
     "webpack": "latest",
     "webpack-cli": "latest",


### PR DESCRIPTION
sass was never explicitly included as a dependency, but recently builds started failing, possibly another package included it as a dependency before https://github.com/open-zaak/open-zaak/actions/runs/24668752878/job/72133347409#step:4:1129

**Changes**

* Add missing sass dependency

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
