### PR TITLE
:bookmark: Release version 1.27.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.27.1 (2026-05-04)
+-------------------
+
+**Bugfixes**
+
+* Add missing sass dependency that caused failing Docker frontend builds
+
 1.27.0 (2026-02-06)
 -------------------
 

--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@
 
 | | | |
 |-|-|-|
-| **Version:** | 1.27.0 |
+| **Version:** | 1.27.1 |
 | **Source:** | https://github.com/open-zaak/open-zaak |
 | **Keywords:** | zaken, zaakgericht werken, zaken-api, catalogi-api, besluiten-api, documenten-api |
 | **PythonVersion:** | 3.12 |

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Open Zaak
 
 .. _`Read this in English`: README.en.md
 
-:Version: 1.27.0
+:Version: 1.27.1
 :Source: https://github.com/open-zaak/open-zaak
 :Keywords: zaken, zaakgericht werken, zaken-api, catalogi-api, besluiten-api, documenten-api
 :PythonVersion: 3.12

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,6 +112,8 @@ linkcheck_ignore = [
     r"https://www.npmjs.com/.*",
     "https://github.com/maykinmedia/django-setup-configuration/blob/main/README.rst#environment-variable-substitution",
     r"https://opentelemetry\.io/docs/.*",  # times out frequently, even with 30s timeouts
+    r"https://samenorganiseren.slack.com",  # raises 403
+    r"https://join.slack.com",  # raises 403
 ]
 
 linkcheck_request_headers = {

--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -27,7 +27,7 @@ You need the following libraries and/or programs:
 
 .. _Python: https://www.python.org/
 .. _Virtualenv: https://virtualenv.pypa.io/en/stable/
-.. _Pip: https://packaging.python.org/tutorials/installing-packages/#ensure-pip-setuptools-and-wheel-are-up-to-date
+.. _Pip: https://packaging.python.org/tutorials/installing-packages/
 .. _PostgreSQL: https://www.postgresql.org
 .. _PostGIS-extension: https://postgis.net/
 .. _Node.js: http://nodejs.org/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openzaak",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openzaak",
-      "version": "1.27.0",
+      "version": "1.27.1",
       "license": "EUPL-1.2",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openzaak",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "Open Zaak",
   "main": "src/openzaak/static/bundles/openzaak-js.js",
   "directories": {

--- a/publiccode.yaml
+++ b/publiccode.yaml
@@ -7,8 +7,8 @@ publiccodeYmlVersion: '0.2'
 name: Open Zaak
 url: 'https://github.com/open-zaak/open-zaak.git'
 softwareType: standalone/backend
-softwareVersion: 1.27.0
-releaseDate: '2026-02-06'
+softwareVersion: 1.27.1
+releaseDate: '2026-05-04'
 logo: 'https://raw.githubusercontent.com/open-zaak/open-zaak/main/docs/logo.svg'
 platforms:
   - web

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 requires-python = "~= 3.12.12"
-version = "1.27.0"
+version = "1.27.1"
 name = "open-zaak"
 
 # Bumpversion configuration
@@ -8,7 +8,7 @@ name = "open-zaak"
 [tool.bumpversion]
 commit = false
 tag = false
-current_version = "1.27.0"
+current_version = "1.27.1"
 pre_commit_hooks = [
     "npm i",  # ensure that package-lock.json is updated
 ]

--- a/src/openzaak/__init__.py
+++ b/src/openzaak/__init__.py
@@ -3,6 +3,6 @@
 from .celery import app as celery_app
 
 __all__ = ("celery_app",)
-__version__ = "1.27.0"
+__version__ = "1.27.1"
 __author__ = "Maykin Media"
 __homepage__ = "https://github.com/open-zaak/open-zaak"


### PR DESCRIPTION
Closes https://github.com/open-zaak/open-zaak/issues/2376

small patch release to make sure Dimpact can build their images again on ARM for local development on macs

**Changes**

* Release version 1.27.1

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
