### PR TITLE
:green_heart: [#2390] Temporarily disable duplicated-entry-in-enum spectral rule

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2337,10 +2337,8 @@ Features:
 * Admin interface to manage Catalogi
 * Admin interface to manage Applicaties and Autorisaties
 * Admin interface to view data created via the APIs
-* `NLX`_ ready (can be used with NLX)
+* NLX ready (can be used with NLX)
 * Documentation on https://open-zaak.readthedocs.io/
 * Deployable on Kubernetes, single server and as VMware appliance
 * Automated test suite
 * Automated deployment
-
-.. _NLX: https://nlx.io/

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -32,12 +32,11 @@ Before you begin
   entry. In some cases, you might want this but it's not recommended. The same machine
   can be used for both Open Zaak and `Open Notificaties`_.
 
-* If you want to use `NLX`_, make sure you have a publicaly available domain name, for
+* If you want to use NLX, make sure you have a publicaly available domain name, for
   example ``nlx.<organization.com>``, where your NLX-inway is accessible to the outside
   world.
 
 .. _`Open Notificaties`: https://github.com/open-zaak/open-notificaties
-.. _`NLX`: https://nlx.io/
 
 Guides
 ------

--- a/docs/manual/other_apis.rst
+++ b/docs/manual/other_apis.rst
@@ -59,7 +59,7 @@ Klik tot slot op **Opslaan**.
 NLX
 ====
 
-`NLX`_ faciliteert data-uitwisseling voor overheden en organisaties. Open Zaak
+NLX faciliteert data-uitwisseling voor overheden en organisaties. Open Zaak
 heeft functionaliteiten die het gebruik van NLX aanmoedigen.
 
 Organisaties kunnen ervoor kiezen om de gegevens via NLX te ontsluiten in een opzet
@@ -82,5 +82,3 @@ To value:
     ``http://my-outway:8443/kadaster/bag``.
 
 .. note:: Consulteer de NLX directory om te zien welke services beschikbaar zijn.
-
-.. _NLX: https://nlx.io

--- a/ruleset.yaml
+++ b/ruleset.yaml
@@ -3,4 +3,7 @@ extends: https://static.developer.overheid.nl/adr/2.1/ruleset.yaml
 rules:
   nlgov:query-keys-camel-case: warn
   nlgov:paths-kebab-case: warn
-
+  # Workaround for https://github.com/open-zaak/open-zaak/issues/2390
+  # until a new version of spectral-rulesets is released
+  # See also: https://github.com/stoplightio/spectral/issues/2959#issuecomment-4526418689
+  duplicated-entry-in-enum: off


### PR DESCRIPTION
Closes #2390 

**Changes**

* Temporarily disable duplicated-entry-in-enum spectral rule
* Remove outdated NLX url from docs

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
