### PR TITLE
Feature/2372 uwv zaakidentificatie

### DIFF
--- a/docs/installation/case_identification.rst
+++ b/docs/installation/case_identification.rst
@@ -1,0 +1,16 @@
+===================
+Case Identification
+===================
+
+Open Zaak has multiple ``zaak identificatie`` generator options which are used when creating a zaak or when reserving a zaaknummer.
+A generator can be selected using ``ZAAK_IDENTIFICATIE_GENERATOR`` see :ref:`installation_env_config`.
+
+
+Standard options
+================
+* ``use-start-datum-year`` (default), uses the zaak start_datum for the identification. (e.g. ``ZAAK-2026-0000000001``)
+* ``use-creation-year`` (default), uses the current year when the zaak is created (or when zaaknummmmer is reserved). (e.g. ``ZAAK-2026-0000000001``)
+
+Specialized options
+===================
+* ``use-uwv-identification`` is a custom zaak identification for the UWV which uses an 11-proef. (e.g. ``A00000006``)

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -54,6 +54,7 @@ Guides
    post_install
    updating
    external_components
+   case_identification
 
 Reference
 ---------

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -544,6 +544,8 @@ humanize==4.0.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   flower
+hypothesis==6.155.2
+    # via -r requirements/test-tools.in
 idna==3.18
     # via
     #   -c requirements/base.txt
@@ -1067,6 +1069,8 @@ smartypants==2.0.2
     #   django-markup
 snowballstemmer==2.2.0
     # via sphinx
+sortedcontainers==2.4.0
+    # via hypothesis
 soupsieve==1.9.5
     # via beautifulsoup4
 sphinx==9.1.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -611,6 +611,10 @@ humanize==4.0.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   flower
+hypothesis==6.155.2
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 identify==2.6.10
     # via pre-commit
 idna==3.18
@@ -1222,6 +1226,11 @@ snowballstemmer==2.2.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   sphinx
+sortedcontainers==2.4.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   hypothesis
 soupsieve==1.9.5
     # via
     #   -c requirements/ci.txt

--- a/requirements/test-tools.in
+++ b/requirements/test-tools.in
@@ -10,6 +10,7 @@ pyquery
 requests-mock
 tblib
 vcrpy
+hypothesis
 
 # CI tools
 pytest

--- a/src/openzaak/components/zaken/api/identification.py
+++ b/src/openzaak/components/zaken/api/identification.py
@@ -1,0 +1,172 @@
+from abc import ABC, abstractmethod
+from datetime import date
+
+from django.db.models import Max
+from django.db.models.functions import Length
+
+from openzaak.components.zaken.models import ZaakIdentificatie
+from openzaak.utils.db import pg_advisory_lock
+
+LOCK_ID_IDENTIFICATION_GENERATION = "generate-zaak-identification"
+
+
+class BaseIdentificatie(ABC):
+    def __init__(self, organisation: str):
+        self.organisation = organisation
+
+        self.model = ZaakIdentificatie
+
+    @abstractmethod
+    def current(self) -> str:
+        pass
+
+    @abstractmethod
+    def _next(self, current_identificatie: str) -> str:
+        pass
+
+    def generate(self):
+        with pg_advisory_lock(LOCK_ID_IDENTIFICATION_GENERATION):
+            return self.model.objects.create(
+                identificatie=self._next(self.current()),
+                bronorganisatie=self.organisation,
+            )
+
+    def generate_bulk(self, amount: int):
+        with pg_advisory_lock(LOCK_ID_IDENTIFICATION_GENERATION):
+            next_identificatie = self.current()
+
+            instances = []
+            for i in range(amount):
+                next_identificatie = self._next(next_identificatie)
+
+                instance = self.model(
+                    identificatie=next_identificatie,
+                    bronorganisatie=self.organisation,
+                )
+                instances.append(instance)
+
+            return self.model.objects.bulk_create(instances)
+
+
+class YearIdentification(BaseIdentificatie):
+    def __init__(
+        self,
+        organisation: str,
+        date: date,
+    ):
+        super().__init__(organisation)
+
+        self.prefix = f"ZAAK-{date.year}"
+
+    def current(self) -> str:
+        pattern = self.prefix + r"-\d{10}"
+
+        # ⚡ start_with is added to use index in DB query
+        issued_ids_for_year = self.model.objects.filter(
+            identificatie__startswith=self.prefix, identificatie__regex=pattern
+        )
+        max_id = issued_ids_for_year.aggregate(Max("identificatie"))[
+            "identificatie__max"
+        ]
+
+        return max_id or f"{self.prefix}-{''.zfill(10)}"
+
+    def _next(self, current_identificatie: str) -> str:
+        number = int(current_identificatie.split("-")[-1]) + 1
+        return f"{self.prefix}-{str(number).zfill(10)}"
+
+
+class CreationYearIdentification(YearIdentification):
+    def __init__(self, validated_data: dict):
+        super().__init__(validated_data["bronorganisatie"], date.today())
+
+
+class StartDatumYearIdentification(YearIdentification):
+    def __init__(self, validated_data: dict):
+        super().__init__(
+            validated_data["bronorganisatie"], validated_data["startdatum"]
+        )
+
+
+class UWVIdentification(BaseIdentificatie):
+    """
+    Custom zaak identification for UWV
+
+    A00000000 -> Z99999999 -> AA99999999 -> AB99999999 -> ZZ99999999
+
+    `elfproef` is used for validation, each char is multiplied by its position (1-9 or 10), and
+    letters have the value 0-25. The remainer of the total is divided by 11 and should be 10.
+
+    Examples:
+        A00000005 = 0*1 + 5*9 -> 45 mod 11 -> 1 INVALID
+        A00000006 = 0*1 + 6*9 -> 54 mod 11 -> 10 VALID
+        Z99999990 = 25*1 + 9*35 -> 340 mod 11 -> 10 VALID
+        AA0000001 = 0*1 + 0*2 + 1*10 -> 10 mod 10 -> 10 VALID
+
+    """
+
+    def __init__(self, validated_data: dict):
+        super().__init__(validated_data["bronorganisatie"])
+
+    def current(self):
+        pattern = r"[A-Z]{1,2}[0-9]{8}"
+        max_id = (
+            self.model.objects.filter(identificatie__regex=pattern)
+            .order_by(-Length("identificatie"), "-identificatie")
+            .values_list("identificatie", flat=True)
+            .first()
+        )
+
+        return max_id or "A00000005"
+
+    def _split(self, identificatie: str):
+        chars = identificatie.strip("0123456789")
+        digits = identificatie[len(chars) :]
+        return chars, digits
+
+    def _validate(self, identificatie: str):
+        chars, digits = self._split(identificatie)
+
+        check = 0
+        i = 1
+        for c in chars:
+            check += (ord(c) - 65) * i
+            i += 1
+
+        for d in digits:
+            check += int(d) * i
+            i += 1
+
+        return check % 11 == 10
+
+    def _increase(self, identificatie: str):
+        def increase_char(char: str):
+            return chr(ord(char) + 1)
+
+        chars, digits = self._split(identificatie)
+
+        if digits != "99999999":
+            digits = str(int(digits) + 1).zfill(8)
+
+        else:
+            digits = "00000000"
+            if len(chars) == 1:
+                if chars == "Z":
+                    chars = "AA"
+                else:
+                    chars = increase_char(chars)
+            else:
+                if chars[1] == "Z":
+                    if chars[0] == "Z":
+                        raise ValueError("Max identification reached")
+                    chars = increase_char(chars[0]) + chars[1]
+                else:
+                    chars = chars[0] + increase_char(chars[1])
+
+        return f"{chars}{digits}"
+
+    def _next(self, current_identificatie: str) -> str:
+        next_identificatie = self._increase(current_identificatie)
+        while not self._validate(next_identificatie):
+            next_identificatie = self._increase(next_identificatie)
+        return next_identificatie

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -26,6 +26,7 @@ import structlog
 from django_loose_fk.virtual_models import ProxyMixin
 from drf_spectacular.utils import extend_schema_serializer
 from drf_writable_nested import NestedCreateMixin, NestedUpdateMixin, UniqueFieldsMixin
+from models.identification_classes import get_base_identification_class
 from rest_framework import serializers
 from rest_framework.exceptions import ErrorDetail
 from rest_framework_gis.fields import GeometryField
@@ -229,7 +230,7 @@ class GenerateZaakIdentificatieSerializer(serializers.ModelSerializer):
         fields = ("bronorganisatie", "startdatum")
 
     def create(self, validated_data):
-        func = import_string(
+        identification_class = import_string(
             settings.ZAAK_IDENTIFICATIE_GENERATOR_OPTIONS.get(
                 settings.ZAAK_IDENTIFICATIE_GENERATOR,
                 settings.ZAAK_IDENTIFICATIE_GENERATOR_OPTIONS.get(
@@ -237,7 +238,7 @@ class GenerateZaakIdentificatieSerializer(serializers.ModelSerializer):
                 ),
             )
         )
-        return func(validated_data)
+        return identification_class(**validated_data).generate()
 
     def update(self, instance, data):  # pragma:nocover
         raise NotImplementedError("Updating is not supported in this serializer")
@@ -275,17 +276,15 @@ class ReserveZaakIdentificatieSerializer(serializers.ModelSerializer):
         bronorganisatie = validated_data["bronorganisatie"]
         today = date.today()
 
-        if aantal == 1:
-            return self.Meta.model.objects.generate(
-                bronorganisatie,
-                today,
-            )
+        identification_class = get_base_identification_class()
 
-        return self.Meta.model.objects.generate_bulk(
-            bronorganisatie,
-            today,
+        created_identifications = identification_class(
+            bronorganisatie, date=today
+        ).generate_bulk(
             aantal,
         )
+
+        return created_identifications[0] if aantal == 1 else created_identifications
 
     def update(self, instance, data):  # pragma:nocover
         raise NotImplementedError("Updating is not supported in this serializer")

--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -26,7 +26,6 @@ import structlog
 from django_loose_fk.virtual_models import ProxyMixin
 from drf_spectacular.utils import extend_schema_serializer
 from drf_writable_nested import NestedCreateMixin, NestedUpdateMixin, UniqueFieldsMixin
-from models.identification_classes import get_base_identification_class
 from rest_framework import serializers
 from rest_framework.exceptions import ErrorDetail
 from rest_framework_gis.fields import GeometryField
@@ -105,6 +104,7 @@ from ...models import (
     ZaakRelatie,
     ZaakVerzoek,
 )
+from ...models.identification_classes import get_base_identification_class
 from ..validators import (
     DateNotInFutureValidator,
     DeelzaakReopenValidator,

--- a/src/openzaak/components/zaken/api/utils.py
+++ b/src/openzaak/components/zaken/api/utils.py
@@ -1,11 +1,9 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
-from datetime import date
 
 from vng_api_common.client import to_internal_data
 
 from openzaak.client import get_client
-from openzaak.components.zaken.models import ZaakIdentificatie
 
 
 def create_remote_zaakbesluit(besluit_url: str, zaak_url: str) -> dict:
@@ -18,19 +16,3 @@ def create_remote_zaakbesluit(besluit_url: str, zaak_url: str) -> dict:
 def delete_remote_zaakbesluit(zaakbesluit_url: str) -> None:
     client = get_client(zaakbesluit_url, raise_exceptions=True)
     to_internal_data(client.delete(zaakbesluit_url))
-
-
-def generate_zaak_identificatie_with_creation_year(
-    validated_data: dict,
-) -> ZaakIdentificatie:
-    return ZaakIdentificatie.objects.generate(
-        validated_data["bronorganisatie"], date.today()
-    )
-
-
-def generate_zaak_identificatie_with_start_datum_year(
-    validated_data: dict,
-) -> ZaakIdentificatie:
-    return ZaakIdentificatie.objects.generate(
-        validated_data["bronorganisatie"], validated_data["startdatum"]
-    )

--- a/src/openzaak/components/zaken/models/identification.py
+++ b/src/openzaak/components/zaken/models/identification.py
@@ -1,85 +1,10 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2022 Open Zaak maintainers
-from datetime import date
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from vng_api_common.fields import RSINField
-from vng_api_common.utils import generate_unique_identification
-
-from openzaak.utils.db import pg_advisory_lock
-
-LOCK_ID_IDENTIFICATION_GENERATION = "generate-zaak-identification"
-
-
-class ZaakIdentificatieManager(models.Manager):
-    def generate(self, organisation: str, date: date):
-        """
-        Generate an identification based on existing data.
-
-        This uses a PostgreSQL-specific advisory lock, meaning that only one
-        thread/process is able to generate a new identification at a time (other
-        threads will simply wait until they acquire the lock after the running call
-        releases it when the transaction exits).
-
-        Note that this does NOT prevent other records from being read or even written
-        to the involved table, so IntegrityError can still be raised if unique
-        constraints will be violated. However, this does allow for concurrent read
-        and writes with explicit identifications to different rows that don't affect
-        the ID generation and should be a better option for performance than pessimistic
-        locking where the entire table is locked even for reading (as otherwise the view
-        of the data inside by generate_unique_identification could be stale due to new
-        inserts).
-        """
-        with pg_advisory_lock(LOCK_ID_IDENTIFICATION_GENERATION):
-            instance = self.model()
-            instance.dummy_date = date
-            identification = generate_unique_identification(instance, "dummy_date")
-            return self.create(
-                identificatie=identification, bronorganisatie=organisation
-            )
-
-    def generate_bulk(self, organisation: str, date: date, amount: int):
-        """
-        Bulk generate multiple unique identificaties.
-
-        This method uses the same PostgreSQL advisory lock to avoid race conditions
-        and ensures identificaties are unique even when called concurrently.
-
-        :param organisation: The organisation (bronorganisatie) to use.
-        :param date: The date to include in the identificatie.
-        :param amount: How many identificaties to generate.
-        :return: List of created ZaakIdentificatie instances.
-        """
-        with pg_advisory_lock(LOCK_ID_IDENTIFICATION_GENERATION):
-            prefix = f"ZAAK-{date.year}-"
-
-            last_instance = (
-                self.filter(
-                    identificatie__startswith=prefix,
-                    bronorganisatie=organisation,
-                )
-                .order_by("-identificatie")
-                .first()
-            )
-
-            if last_instance:
-                last_number = int(last_instance.identificatie.split("-")[-1])
-            else:
-                last_number = 0
-
-            instances = []
-            for i in range(1, amount + 1):
-                new_number = last_number + i
-                identificatie = f"{prefix}{new_number:010d}"
-                instance = self.model(
-                    identificatie=identificatie,
-                    bronorganisatie=organisation,
-                )
-                instances.append(instance)
-
-            return self.bulk_create(instances)
 
 
 class ZaakIdentificatie(models.Model):
@@ -107,11 +32,6 @@ class ZaakIdentificatie(models.Model):
             "https://nl.wikipedia.org/wiki/Burgerservicenummer#11-proef"
         ),
     )
-
-    objects = ZaakIdentificatieManager()
-    IDENTIFICATIE_PREFIX = "ZAAK"
-
-    dummy_date = None
 
     class Meta:
         verbose_name = _("zaak identification")

--- a/src/openzaak/components/zaken/models/identification_classes.py
+++ b/src/openzaak/components/zaken/models/identification_classes.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2026 Open Zaak maintainers
+
 from abc import ABC, abstractmethod
 from datetime import date
 

--- a/src/openzaak/components/zaken/models/identification_classes.py
+++ b/src/openzaak/components/zaken/models/identification_classes.py
@@ -18,11 +18,11 @@ from .identification import ZaakIdentificatie
 LOCK_ID_IDENTIFICATION_GENERATION = "generate-zaak-identification"
 
 
-class BaseIdentificatie(ABC):
-    def __init__(self, organisation: str, **kwargs):
-        self.organisation = organisation
+class BaseZaakIdentificatie(ABC):
+    model = ZaakIdentificatie
 
-        self.model = ZaakIdentificatie
+    def __init__(self, bronorganisatie: str, **kwargs):
+        self.bronorganisatie = bronorganisatie
 
     @abstractmethod
     def current(self) -> str:
@@ -53,7 +53,7 @@ class BaseIdentificatie(ABC):
         with pg_advisory_lock(LOCK_ID_IDENTIFICATION_GENERATION):
             return self.model.objects.create(
                 identificatie=next(self._sequence(self.current())),
-                bronorganisatie=self.organisation,
+                bronorganisatie=self.bronorganisatie,
             )
 
     def generate_bulk(self, amount: int):
@@ -70,14 +70,14 @@ class BaseIdentificatie(ABC):
         """
         with pg_advisory_lock(LOCK_ID_IDENTIFICATION_GENERATION):
             return self.model.objects.bulk_create(
-                self.model(identificatie=id, bronorganisatie=self.organisation)
+                self.model(identificatie=id, bronorganisatie=self.bronorganisatie)
                 for id in islice(self._sequence(self.current()), amount)
             )
 
 
-class YearIdentification(BaseIdentificatie):
-    def __init__(self, organisation: str, date: date, **kwargs):
-        super().__init__(organisation, **kwargs)
+class YearIdentification(BaseZaakIdentificatie):
+    def __init__(self, bronorganisatie: str, date: date, **kwargs):
+        super().__init__(bronorganisatie, **kwargs)
 
         self.prefix = f"ZAAK-{date.year}"
 
@@ -111,7 +111,7 @@ class StartDatumYearIdentification(YearIdentification):
         super().__init__(bronorganisatie, startdatum, **kwargs)
 
 
-class UWVIdentification(BaseIdentificatie):
+class UWVIdentification(BaseZaakIdentificatie):
     """
     Custom zaak identification for UWV
 
@@ -211,7 +211,7 @@ class UWVIdentification(BaseIdentificatie):
 
 def get_base_identification_class():
     match settings.ZAAK_IDENTIFICATIE_GENERATOR:
-        case "use-uvw-identification":
+        case "use-uwv-identification":
             identification_class = UWVIdentification
         case _:
             identification_class = YearIdentification

--- a/src/openzaak/components/zaken/models/identification_classes.py
+++ b/src/openzaak/components/zaken/models/identification_classes.py
@@ -1,17 +1,19 @@
 from abc import ABC, abstractmethod
 from datetime import date
 
+from django.conf import settings
 from django.db.models import Max
 from django.db.models.functions import Length
 
-from openzaak.components.zaken.models import ZaakIdentificatie
 from openzaak.utils.db import pg_advisory_lock
+
+from .identification import ZaakIdentificatie
 
 LOCK_ID_IDENTIFICATION_GENERATION = "generate-zaak-identification"
 
 
 class BaseIdentificatie(ABC):
-    def __init__(self, organisation: str):
+    def __init__(self, organisation: str, **kwargs):
         self.organisation = organisation
 
         self.model = ZaakIdentificatie
@@ -25,6 +27,23 @@ class BaseIdentificatie(ABC):
         pass
 
     def generate(self):
+        """
+        Generate an identification based on existing data.
+
+        This uses a PostgreSQL-specific advisory lock, meaning that only one
+        thread/process is able to generate a new identification at a time (other
+        threads will simply wait until they acquire the lock after the running call
+        releases it when the transaction exits).
+
+        Note that this does NOT prevent other records from being read or even written
+        to the involved table, so IntegrityError can still be raised if unique
+        constraints will be violated. However, this does allow for concurrent read
+        and writes with explicit identifications to different rows that don't affect
+        the ID generation and should be a better option for performance than pessimistic
+        locking where the entire table is locked even for reading (as otherwise the view
+        of the data inside by generate_unique_identification could be stale due to new
+        inserts).
+        """
         with pg_advisory_lock(LOCK_ID_IDENTIFICATION_GENERATION):
             return self.model.objects.create(
                 identificatie=self._next(self.current()),
@@ -32,6 +51,17 @@ class BaseIdentificatie(ABC):
             )
 
     def generate_bulk(self, amount: int):
+        """
+        Bulk generate multiple unique identificaties.
+
+        This method uses the same PostgreSQL advisory lock to avoid race conditions
+        and ensures identificaties are unique even when called concurrently.
+
+        :param organisation: The organisation (bronorganisatie) to use.
+        :param date: The date to include in the identificatie.
+        :param amount: How many identificaties to generate.
+        :return: List of created ZaakIdentificatie instances.
+        """
         with pg_advisory_lock(LOCK_ID_IDENTIFICATION_GENERATION):
             next_identificatie = self.current()
 
@@ -49,12 +79,8 @@ class BaseIdentificatie(ABC):
 
 
 class YearIdentification(BaseIdentificatie):
-    def __init__(
-        self,
-        organisation: str,
-        date: date,
-    ):
-        super().__init__(organisation)
+    def __init__(self, organisation: str, date: date, **kwargs):
+        super().__init__(organisation, **kwargs)
 
         self.prefix = f"ZAAK-{date.year}"
 
@@ -77,15 +103,13 @@ class YearIdentification(BaseIdentificatie):
 
 
 class CreationYearIdentification(YearIdentification):
-    def __init__(self, validated_data: dict):
-        super().__init__(validated_data["bronorganisatie"], date.today())
+    def __init__(self, bronorganisatie: str, **kwargs):
+        super().__init__(bronorganisatie, date.today(), **kwargs)
 
 
 class StartDatumYearIdentification(YearIdentification):
-    def __init__(self, validated_data: dict):
-        super().__init__(
-            validated_data["bronorganisatie"], validated_data["startdatum"]
-        )
+    def __init__(self, bronorganisatie: str, startdatum: date, **kwargs):
+        super().__init__(bronorganisatie, startdatum, **kwargs)
 
 
 class UWVIdentification(BaseIdentificatie):
@@ -104,9 +128,6 @@ class UWVIdentification(BaseIdentificatie):
         AA0000001 = 0*1 + 0*2 + 1*10 -> 10 mod 10 -> 10 VALID
 
     """
-
-    def __init__(self, validated_data: dict):
-        super().__init__(validated_data["bronorganisatie"])
 
     def current(self):
         pattern = r"[A-Z]{1,2}[0-9]{8}"
@@ -170,3 +191,13 @@ class UWVIdentification(BaseIdentificatie):
         while not self._validate(next_identificatie):
             next_identificatie = self._increase(next_identificatie)
         return next_identificatie
+
+
+def get_base_identification_class():
+    match settings.ZAAK_IDENTIFICATIE_GENERATOR:
+        case "use-uvw-identification":
+            identification_class = UWVIdentification
+        case _:
+            identification_class = YearIdentification
+
+    return identification_class

--- a/src/openzaak/components/zaken/models/identification_classes.py
+++ b/src/openzaak/components/zaken/models/identification_classes.py
@@ -177,7 +177,7 @@ class UWVIdentification(BaseZaakIdentificatie):
 
         # This pow breaks when w is not co-prime to 11. 11 is prime so ValueError
         # is raised if w is a multiple of 11. But max len of an id is 2 + 8, and
-        # we checked for len(next_prefix), so w < 11 always holds.
+        # we checked for len(next_prefix) in _sequence, so w < 11 always holds.
         checksum = ((10 - weighted_sum) * pow(w, -1, 11)) % 11
         return checksum
 

--- a/src/openzaak/components/zaken/models/identification_classes.py
+++ b/src/openzaak/components/zaken/models/identification_classes.py
@@ -3,6 +3,9 @@
 
 from abc import ABC, abstractmethod
 from datetime import date
+from itertools import chain, count, islice, starmap
+from operator import mul
+from typing import Generator
 
 from django.conf import settings
 from django.db.models import Max
@@ -26,7 +29,7 @@ class BaseIdentificatie(ABC):
         pass
 
     @abstractmethod
-    def _next(self, current_identificatie: str) -> str:
+    def _sequence(self, current_identificatie: str) -> Generator[str, None, None]:
         pass
 
     def generate(self):
@@ -49,7 +52,7 @@ class BaseIdentificatie(ABC):
         """
         with pg_advisory_lock(LOCK_ID_IDENTIFICATION_GENERATION):
             return self.model.objects.create(
-                identificatie=self._next(self.current()),
+                identificatie=next(self._sequence(self.current())),
                 bronorganisatie=self.organisation,
             )
 
@@ -66,19 +69,10 @@ class BaseIdentificatie(ABC):
         :return: List of created ZaakIdentificatie instances.
         """
         with pg_advisory_lock(LOCK_ID_IDENTIFICATION_GENERATION):
-            next_identificatie = self.current()
-
-            instances = []
-            for i in range(amount):
-                next_identificatie = self._next(next_identificatie)
-
-                instance = self.model(
-                    identificatie=next_identificatie,
-                    bronorganisatie=self.organisation,
-                )
-                instances.append(instance)
-
-            return self.model.objects.bulk_create(instances)
+            return self.model.objects.bulk_create(
+                self.model(identificatie=id, bronorganisatie=self.organisation)
+                for id in islice(self._sequence(self.current()), amount)
+            )
 
 
 class YearIdentification(BaseIdentificatie):
@@ -100,9 +94,11 @@ class YearIdentification(BaseIdentificatie):
 
         return max_id or f"{self.prefix}-{''.zfill(10)}"
 
-    def _next(self, current_identificatie: str) -> str:
-        number = int(current_identificatie.split("-")[-1]) + 1
-        return f"{self.prefix}-{str(number).zfill(10)}"
+    def _sequence(self, current_identificatie: str) -> Generator[str, None, None]:
+        number = int(current_identificatie.split("-")[-1])
+        while True:
+            number += 1
+            yield f"{self.prefix}-{str(number).zfill(10)}"
 
 
 class CreationYearIdentification(YearIdentification):
@@ -119,7 +115,7 @@ class UWVIdentification(BaseIdentificatie):
     """
     Custom zaak identification for UWV
 
-    A00000000 -> Z99999999 -> AA99999999 -> AB99999999 -> ZZ99999999
+    A00000000 -> Z99999999 -> AA99999999 -> AB99999999 -> AZ99999999 -> BA99999999 -> ZZ99999999
 
     `elfproef` is used for validation, each char is multiplied by its position (1-9 or 10), and
     letters have the value 0-25. The remainer of the total is divided by 11 and should be 10.
@@ -141,59 +137,76 @@ class UWVIdentification(BaseIdentificatie):
             .first()
         )
 
-        return max_id or "A00000005"
+        return max_id or "A00000000"
 
-    def _split(self, identificatie: str):
-        chars = identificatie.strip("0123456789")
-        digits = identificatie[len(chars) :]
-        return chars, digits
+    def _as_int(self, char: str) -> int:
+        return int(char) if char.isnumeric() else (ord(char) - 65)
 
-    def _validate(self, identificatie: str):
-        chars, digits = self._split(identificatie)
+    def _next_prefix(self, prefix: str) -> str:
+        # convert to int (base 26 bijective)
+        n = 0
+        for char in prefix:
+            # 64: A->1
+            n = n * 26 + (ord(char) - 64)
 
-        check = 0
-        i = 1
-        for c in chars:
-            check += (ord(c) - 65) * i
-            i += 1
+        # next
+        n += 1
 
-        for d in digits:
-            check += int(d) * i
-            i += 1
+        # convert back to str
+        res = []
+        while n > 0:
+            n -= 1  # bijective! (A=1, not A=0)
+            res.append(chr((n % 26) + 65))  # 65 is 'A'
+            n //= 26
 
-        return check % 11 == 10
+        return "".join(reversed(res))
 
-    def _increase(self, identificatie: str):
-        def increase_char(char: str):
-            return chr(ord(char) + 1)
+    def _calc_checksum(self, prefix: str, seq: str):
+        """
+        valid identifier is by definition:
+            weighted_sum + checksum × w ≡ 10 (mod 11)
+        algebra:
+            checksum × w = 10 − weighted_sum (mod 11)
+            checksum = (10 − weighted_sum) * w⁻¹ (mod 11)
+        """
 
-        chars, digits = self._split(identificatie)
+        values = map(self._as_int, chain(prefix, seq))
+        weights = count(1)
+        weighted_sum = sum(starmap(mul, zip(values, weights)))
+        w = next(weights)  # weight of the checksum digit identifier[-1]
 
-        if digits != "99999999":
-            digits = str(int(digits) + 1).zfill(8)
+        # This pow breaks when w is not co-prime to 11. 11 is prime so ValueError
+        # is raised if w is a multiple of 11. But max len of an id is 2 + 8, and
+        # we checked for len(next_prefix), so w < 11 always holds.
+        checksum = ((10 - weighted_sum) * pow(w, -1, 11)) % 11
+        return checksum
 
-        else:
-            digits = "00000000"
-            if len(chars) == 1:
-                if chars == "Z":
-                    chars = "AA"
-                else:
-                    chars = increase_char(chars)
+    def _sequence(self, current_identificatie: str) -> Generator[str, None, None]:
+        if current_identificatie == "A00000000":
+            # special case for initial identification
+            current_identificatie = "A00000006"
+            yield current_identificatie
+
+        prefix = current_identificatie.strip("0123456789")
+        # sequence number without elf proef checksum
+        seq = current_identificatie[len(prefix) : len(prefix) + 7]
+
+        while True:
+            if seq == "9999999":
+                seq = f"{0:07n}"
+                prefix = self._next_prefix(prefix)
             else:
-                if chars[1] == "Z":
-                    if chars[0] == "Z":
-                        raise ValueError("Max identification reached")
-                    chars = increase_char(chars[0]) + chars[1]
-                else:
-                    chars = chars[0] + increase_char(chars[1])
+                seq = f"{int(seq) + 1:07d}"
 
-        return f"{chars}{digits}"
+            if len(prefix) > 2:
+                raise ValueError("Max identification reached")
 
-    def _next(self, current_identificatie: str) -> str:
-        next_identificatie = self._increase(current_identificatie)
-        while not self._validate(next_identificatie):
-            next_identificatie = self._increase(next_identificatie)
-        return next_identificatie
+            checksum = self._calc_checksum(prefix, seq)
+
+            if checksum != 10:
+                # we need a single digit checksum
+                # if 10 calculate next
+                yield f"{prefix}{seq}{checksum}"
 
 
 def get_base_identification_class():

--- a/src/openzaak/components/zaken/models/zaken.py
+++ b/src/openzaak/components/zaken/models/zaken.py
@@ -60,6 +60,7 @@ from ..query import (
     ZaakRelatedQuerySet,
 )
 from .identification import ZaakIdentificatie
+from .identification_classes import get_base_identification_class
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -519,10 +520,10 @@ class Zaak(ETagMixin, AuditTrailMixin, APIMixin, ZaakIdentificatie):
 
         if not self.identificatie:
             assert not self.identificatie_ptr_id
-            self.identificatie_ptr = ZaakIdentificatie.objects.generate(
-                organisation=self.bronorganisatie,
-                date=self.registratiedatum,
-            )
+            identification_class = get_base_identification_class()
+            self.identificatie_ptr = identification_class(
+                self.bronorganisatie, date=self.registratiedatum
+            ).generate()
             self.identificatie = self.identificatie_ptr.identificatie
         elif not self.identificatie_ptr_id:
             reserved_identificatie = ZaakIdentificatie.objects.filter(

--- a/src/openzaak/components/zaken/tests/test_create.py
+++ b/src/openzaak/components/zaken/tests/test_create.py
@@ -33,6 +33,7 @@ from openzaak.tests.utils import ClearCachesMixin, JWTAuthMixin
 from ..api.scopes import SCOPE_ZAKEN_ALLES_LEZEN, SCOPE_ZAKEN_CREATE
 from ..api.viewsets import ZaakViewSet
 from ..models import KlantContact, Rol, Status, Zaak, ZaakIdentificatie, ZaakObject
+from ..models.identification_classes import YearIdentification
 from .factories import ZaakFactory
 from .utils import ZAAK_WRITE_KWARGS, get_operation_url, isodatetime
 
@@ -378,9 +379,9 @@ class CreateZaakTransactionTests(JWTAuthMixin, APITransactionTestCase):
             try:
                 # starts first, but commits last
                 with transaction.atomic():
-                    ZaakIdentificatie.objects.generate(
+                    YearIdentification(
                         VERANTWOORDELIJKE_ORGANISATIE, date(2022, 12, 12)
-                    )
+                    ).generate()
                     time.sleep(0.1)
             finally:
                 close_old_connections()
@@ -388,9 +389,9 @@ class CreateZaakTransactionTests(JWTAuthMixin, APITransactionTestCase):
         def create_zaak2():
             try:
                 with transaction.atomic():
-                    ZaakIdentificatie.objects.generate(
+                    YearIdentification(
                         VERANTWOORDELIJKE_ORGANISATIE, date(2022, 12, 12)
-                    )
+                    ).generate()
             finally:
                 close_old_connections()
 

--- a/src/openzaak/components/zaken/tests/test_identification.py
+++ b/src/openzaak/components/zaken/tests/test_identification.py
@@ -1,0 +1,188 @@
+from datetime import date
+
+from django.test import TestCase
+
+from freezegun.api import freeze_time
+
+from openzaak.components.zaken.api.identification import (
+    CreationYearIdentification,
+    StartDatumYearIdentification,
+    UWVIdentification,
+)
+from openzaak.components.zaken.models import ZaakIdentificatie
+
+
+class UWVIdentificationTests(TestCase):
+    def setUp(self):
+        self.uwv = UWVIdentification({"bronorganisatie": "111222333"})
+
+    def test_current(self):
+        with self.subTest("No identificatie"):
+            self.assertEqual(self.uwv.current(), "A00000005")
+
+        with self.subTest("existing identificatie"):
+            ZaakIdentificatie.objects.create(identificatie="A00000006")
+            self.assertEqual(self.uwv.current(), "A00000006")
+
+        with self.subTest("other identificatie"):
+            ZaakIdentificatie.objects.create(identificatie="ZAAK-2026-0000001")
+            self.assertEqual(self.uwv.current(), "A00000006")
+
+        with self.subTest("later identificatie"):
+            ZaakIdentificatie.objects.create(identificatie="B00000001")
+            self.assertEqual(self.uwv.current(), "B00000001")
+
+    def test_split(self):
+        self.assertEqual(self.uwv._split("A00000006"), ("A", "00000006"))
+        self.assertEqual(self.uwv._split("ZZ00000006"), ("ZZ", "00000006"))
+
+    def test_validate(self):
+        self.assertTrue(self.uwv._validate("A00000006"))
+        self.assertTrue(self.uwv._validate("A00000023"))
+
+        self.assertTrue(self.uwv._validate("B00000001"))
+        self.assertTrue(self.uwv._validate("Z99999990"))
+        self.assertTrue(self.uwv._validate("ZZ99999985"))
+
+        self.assertFalse(self.uwv._validate("A00000000"))
+        self.assertFalse(self.uwv._validate("ZZ99999990"))
+
+    def test_increase(self):
+        self.assertEqual(self.uwv._increase("A00000005"), "A00000006")
+        self.assertEqual(self.uwv._increase("A99999999"), "B00000000")
+        self.assertEqual(self.uwv._increase("B99999999"), "C00000000")
+        self.assertEqual(self.uwv._increase("Z99999999"), "AA00000000")
+        self.assertEqual(self.uwv._increase("AA99999999"), "AB00000000")
+        self.assertEqual(self.uwv._increase("ZZ99999998"), "ZZ99999999")
+
+        with self.assertRaises(ValueError):
+            self.uwv._increase("ZZ99999999")
+
+    def test_next(self):
+        self.assertEqual(self.uwv._next("A00000000"), "A00000006")
+        self.assertEqual(self.uwv._next("A00000006"), "A00000023")
+        self.assertEqual(self.uwv._next("A99999999"), "B00000001")
+        self.assertEqual(self.uwv._next("Z99999999"), "AA00000001")
+        self.assertEqual(self.uwv._next("Z99999988"), "Z99999990")
+
+    def test_generate(self):
+        with self.subTest("from 0"):
+            self.uwv.generate()
+
+            self.assertEqual(ZaakIdentificatie.objects.count(), 1)
+            iden = ZaakIdentificatie.objects.get()
+
+            self.assertEqual(iden.identificatie, "A00000006")
+            self.assertEqual(iden.bronorganisatie, "111222333")
+
+        with self.subTest("next"):
+            self.uwv.generate()
+
+            self.assertEqual(ZaakIdentificatie.objects.count(), 2)
+            self.assertEqual(
+                ZaakIdentificatie.objects.last().identificatie, "A00000023"
+            )
+
+        with self.subTest("AA"):
+            ZaakIdentificatie.objects.create(
+                identificatie="Z99999990", bronorganisatie="111222333"
+            )
+            self.uwv.generate()
+            self.assertEqual(
+                ZaakIdentificatie.objects.last().identificatie, "AA00000001"
+            )
+
+    def test_generate_bulk(self):
+        self.uwv.generate_bulk(5)
+
+        self.assertEqual(ZaakIdentificatie.objects.count(), 5)
+
+        expected = ["A00000006", "A00000023", "A00000037", "A00000040", "A00000054"]
+
+        for i, iden in enumerate(ZaakIdentificatie.objects.all()):
+            self.assertEqual(iden.identificatie, expected[i])
+
+
+@freeze_time("2026-01-01")
+class CreationYearIdentificationTests(TestCase):
+    def setUp(self):
+        self.cyi = CreationYearIdentification({"bronorganisatie": "111222333"})
+
+    def test_current(self):
+        with self.subTest("No identificatie"):
+            self.assertEqual(self.cyi.current(), "ZAAK-2026-0000000000")
+
+        with self.subTest("existing identificatie"):
+            ZaakIdentificatie.objects.create(identificatie="ZAAK-2026-0000000001")
+            self.assertEqual(self.cyi.current(), "ZAAK-2026-0000000001")
+
+        with self.subTest("other identificatie"):
+            ZaakIdentificatie.objects.create(identificatie="A00000006")
+            self.assertEqual(self.cyi.current(), "ZAAK-2026-0000000001")
+
+        with self.subTest("later identificatie"):
+            ZaakIdentificatie.objects.create(identificatie="ZAAK-2026-1000000001")
+            self.assertEqual(self.cyi.current(), "ZAAK-2026-1000000001")
+
+    def test_next(self):
+        self.assertEqual(self.cyi._next("ZAAK-2026-0000000001"), "ZAAK-2026-0000000002")
+        self.assertEqual(self.cyi._next("ZAAK-2026-0000000551"), "ZAAK-2026-0000000552")
+        self.assertEqual(
+            self.cyi._next("ZAAK-2026-9999999999"), "ZAAK-2026-10000000000"
+        )  # TODO seems to be allowed in old generate?
+
+    def test_generate(self):
+        with self.subTest("from 0"):
+            self.cyi.generate()
+
+            self.assertEqual(ZaakIdentificatie.objects.count(), 1)
+            iden = ZaakIdentificatie.objects.get()
+
+            self.assertEqual(iden.identificatie, "ZAAK-2026-0000000001")
+            self.assertEqual(iden.bronorganisatie, "111222333")
+
+        with self.subTest("next"):
+            self.cyi.generate()
+
+            self.assertEqual(ZaakIdentificatie.objects.count(), 2)
+            self.assertEqual(
+                ZaakIdentificatie.objects.last().identificatie, "ZAAK-2026-0000000002"
+            )
+
+    def test_generate_bulk(self):
+        self.cyi.generate_bulk(5)
+
+        self.assertEqual(ZaakIdentificatie.objects.count(), 5)
+
+        expected = [
+            "ZAAK-2026-0000000001",
+            "ZAAK-2026-0000000002",
+            "ZAAK-2026-0000000003",
+            "ZAAK-2026-0000000004",
+            "ZAAK-2026-0000000005",
+        ]
+
+        for i, iden in enumerate(ZaakIdentificatie.objects.all()):
+            self.assertEqual(iden.identificatie, expected[i])
+
+
+class StartDatumYearIdentificationTests(TestCase):
+    def setUp(self):
+        self.sdi = StartDatumYearIdentification(
+            {"bronorganisatie": "111222333", "startdatum": date(2025, 1, 1)}
+        )
+
+    def test_current(self):
+        self.assertEqual(self.sdi.current(), "ZAAK-2025-0000000000")
+
+    def test_next(self):
+        self.assertEqual(self.sdi._next("ZAAK-2025-0000000001"), "ZAAK-2025-0000000002")
+
+    def test_generate(self):
+        self.sdi.generate()
+
+        self.assertEqual(ZaakIdentificatie.objects.count(), 1)
+        iden = ZaakIdentificatie.objects.get()
+
+        self.assertEqual(iden.identificatie, "ZAAK-2025-0000000001")
+        self.assertEqual(iden.bronorganisatie, "111222333")

--- a/src/openzaak/components/zaken/tests/test_identification.py
+++ b/src/openzaak/components/zaken/tests/test_identification.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2026 Open Zaak maintainers
+
 from datetime import date
 
 from django.test import TestCase

--- a/src/openzaak/components/zaken/tests/test_identification.py
+++ b/src/openzaak/components/zaken/tests/test_identification.py
@@ -4,17 +4,17 @@ from django.test import TestCase
 
 from freezegun.api import freeze_time
 
-from openzaak.components.zaken.api.identification import (
+from openzaak.components.zaken.models import ZaakIdentificatie
+from openzaak.components.zaken.models.identification_classes import (
     CreationYearIdentification,
     StartDatumYearIdentification,
     UWVIdentification,
 )
-from openzaak.components.zaken.models import ZaakIdentificatie
 
 
 class UWVIdentificationTests(TestCase):
     def setUp(self):
-        self.uwv = UWVIdentification({"bronorganisatie": "111222333"})
+        self.uwv = UWVIdentification("111222333")
 
     def test_current(self):
         with self.subTest("No identificatie"):
@@ -54,6 +54,7 @@ class UWVIdentificationTests(TestCase):
         self.assertEqual(self.uwv._increase("Z99999999"), "AA00000000")
         self.assertEqual(self.uwv._increase("AA99999999"), "AB00000000")
         self.assertEqual(self.uwv._increase("ZZ99999998"), "ZZ99999999")
+        self.assertEqual(self.uwv._increase("AZ99999999"), "BZ00000000")
 
         with self.assertRaises(ValueError):
             self.uwv._increase("ZZ99999999")
@@ -106,7 +107,7 @@ class UWVIdentificationTests(TestCase):
 @freeze_time("2026-01-01")
 class CreationYearIdentificationTests(TestCase):
     def setUp(self):
-        self.cyi = CreationYearIdentification({"bronorganisatie": "111222333"})
+        self.cyi = CreationYearIdentification("111222333")
 
     def test_current(self):
         with self.subTest("No identificatie"):
@@ -168,9 +169,7 @@ class CreationYearIdentificationTests(TestCase):
 
 class StartDatumYearIdentificationTests(TestCase):
     def setUp(self):
-        self.sdi = StartDatumYearIdentification(
-            {"bronorganisatie": "111222333", "startdatum": date(2025, 1, 1)}
-        )
+        self.sdi = StartDatumYearIdentification("111222333", date(2025, 1, 1))
 
     def test_current(self):
         self.assertEqual(self.sdi.current(), "ZAAK-2025-0000000000")

--- a/src/openzaak/components/zaken/tests/test_identification.py
+++ b/src/openzaak/components/zaken/tests/test_identification.py
@@ -6,6 +6,8 @@ from datetime import date
 from django.test import TestCase
 
 from freezegun.api import freeze_time
+from hypothesis import given, strategies as st
+from hypothesis.extra.django import TestCase as HypothesisTestCase
 
 from openzaak.components.zaken.models import ZaakIdentificatie
 from openzaak.components.zaken.models.identification_classes import (
@@ -21,7 +23,7 @@ class UWVIdentificationTests(TestCase):
 
     def test_current(self):
         with self.subTest("No identificatie"):
-            self.assertEqual(self.uwv.current(), "A00000005")
+            self.assertEqual(self.uwv.current(), "A00000000")
 
         with self.subTest("existing identificatie"):
             ZaakIdentificatie.objects.create(identificatie="A00000006")
@@ -35,39 +37,17 @@ class UWVIdentificationTests(TestCase):
             ZaakIdentificatie.objects.create(identificatie="B00000001")
             self.assertEqual(self.uwv.current(), "B00000001")
 
-    def test_split(self):
-        self.assertEqual(self.uwv._split("A00000006"), ("A", "00000006"))
-        self.assertEqual(self.uwv._split("ZZ00000006"), ("ZZ", "00000006"))
-
-    def test_validate(self):
-        self.assertTrue(self.uwv._validate("A00000006"))
-        self.assertTrue(self.uwv._validate("A00000023"))
-
-        self.assertTrue(self.uwv._validate("B00000001"))
-        self.assertTrue(self.uwv._validate("Z99999990"))
-        self.assertTrue(self.uwv._validate("ZZ99999985"))
-
-        self.assertFalse(self.uwv._validate("A00000000"))
-        self.assertFalse(self.uwv._validate("ZZ99999990"))
-
-    def test_increase(self):
-        self.assertEqual(self.uwv._increase("A00000005"), "A00000006")
-        self.assertEqual(self.uwv._increase("A99999999"), "B00000000")
-        self.assertEqual(self.uwv._increase("B99999999"), "C00000000")
-        self.assertEqual(self.uwv._increase("Z99999999"), "AA00000000")
-        self.assertEqual(self.uwv._increase("AA99999999"), "AB00000000")
-        self.assertEqual(self.uwv._increase("ZZ99999998"), "ZZ99999999")
-        self.assertEqual(self.uwv._increase("AZ99999999"), "BZ00000000")
+    def test_next(self):
+        self.assertEqual(next(self.uwv._sequence("A00000000")), "A00000006")
+        self.assertEqual(next(self.uwv._sequence("A00000006")), "A00000023")
+        self.assertEqual(next(self.uwv._sequence("A99999999")), "B00000001")
+        self.assertEqual(next(self.uwv._sequence("Z99999988")), "Z99999990")
+        self.assertEqual(next(self.uwv._sequence("Z99999999")), "AA00000001")
+        self.assertEqual(next(self.uwv._sequence("AA9999999")), "AB00000003")
+        self.assertEqual(next(self.uwv._sequence("AZ9999999")), "BA00000002")
 
         with self.assertRaises(ValueError):
-            self.uwv._increase("ZZ99999999")
-
-    def test_next(self):
-        self.assertEqual(self.uwv._next("A00000000"), "A00000006")
-        self.assertEqual(self.uwv._next("A00000006"), "A00000023")
-        self.assertEqual(self.uwv._next("A99999999"), "B00000001")
-        self.assertEqual(self.uwv._next("Z99999999"), "AA00000001")
-        self.assertEqual(self.uwv._next("Z99999988"), "Z99999990")
+            next(self.uwv._sequence("ZZ99999999"))
 
     def test_generate(self):
         with self.subTest("from 0"):
@@ -107,6 +87,61 @@ class UWVIdentificationTests(TestCase):
             self.assertEqual(iden.identificatie, expected[i])
 
 
+# A, ..., Z, AA, AB, ..., AZ, BA, ... ZZ
+_LETTER_SEQUENCE = [chr(n + 65) for n in range(26)] + [
+    chr(fst + 65) + chr(snd + 65) for fst in range(26) for snd in range(26)
+]
+assert _LETTER_SEQUENCE[0] == "A"
+assert _LETTER_SEQUENCE[_LETTER_SEQUENCE.index("AA") + 1] == "AB"
+assert _LETTER_SEQUENCE[_LETTER_SEQUENCE.index("AZ") + 1] == "BA"
+
+
+def _uwv_identifier() -> st.SearchStrategy[str]:
+    # this composite is better at searching the space for edge cases than
+    # st.from_regex(r"^[A-Z]{1,2}[0-9]{8}$", fullmatch=True))
+    return st.tuples(
+        st.text(alphabet="ABCDEFGHIJKLMNOPQRSTUVWXYZ", min_size=1, max_size=2),
+        st.integers(min_value=0, max_value=99_999_999).map(lambda n: f"{n:08d}"),
+    ).map("".join)
+
+
+def _is_valid_uwv_identifier(identificatie: str) -> bool:
+    """
+    Chars multiplied by their position.
+    A = 0, Z = 25
+    total % 11 should be 10
+    """
+    chars = identificatie.strip("0123456789")
+    digits = identificatie[len(chars) :]
+
+    check = 0
+    i = 1
+    for c in chars:
+        check += (ord(c) - 65) * i
+        i += 1
+
+    for d in digits:
+        check += int(d) * i
+        i += 1
+
+    return check % 11 == 10
+
+
+class UWVRandomTests(HypothesisTestCase):
+    @given(current=_uwv_identifier())
+    def test_uwv_generator(self, current):
+        next_id = next(UWVIdentification("111222333")._sequence(current))
+        self.assertTrue(_is_valid_uwv_identifier(next_id))
+        self.assertTrue(len(next_id) > len(current) or next_id > current)
+
+        # assert there is no other prefix in between current and next
+        current_prefix = current.strip("0123456789")
+        next_prefix = next_id.strip("0123456789")
+        current_pos = _LETTER_SEQUENCE.index(current_prefix)
+        next_pos = _LETTER_SEQUENCE.index(next_prefix)
+        self.assertTrue((next_prefix == current_prefix) or next_pos == current_pos + 1)
+
+
 @freeze_time("2026-01-01")
 class CreationYearIdentificationTests(TestCase):
     def setUp(self):
@@ -129,11 +164,15 @@ class CreationYearIdentificationTests(TestCase):
             self.assertEqual(self.cyi.current(), "ZAAK-2026-1000000001")
 
     def test_next(self):
-        self.assertEqual(self.cyi._next("ZAAK-2026-0000000001"), "ZAAK-2026-0000000002")
-        self.assertEqual(self.cyi._next("ZAAK-2026-0000000551"), "ZAAK-2026-0000000552")
         self.assertEqual(
-            self.cyi._next("ZAAK-2026-9999999999"), "ZAAK-2026-10000000000"
-        )  # TODO seems to be allowed in old generate?
+            next(self.cyi._sequence("ZAAK-2026-0000000001")), "ZAAK-2026-0000000002"
+        )
+        self.assertEqual(
+            next(self.cyi._sequence("ZAAK-2026-0000000551")), "ZAAK-2026-0000000552"
+        )
+        self.assertEqual(
+            next(self.cyi._sequence("ZAAK-2026-9999999999")), "ZAAK-2026-10000000000"
+        )  # seems to be allowed in old generate?
 
     def test_generate(self):
         with self.subTest("from 0"):
@@ -178,7 +217,9 @@ class StartDatumYearIdentificationTests(TestCase):
         self.assertEqual(self.sdi.current(), "ZAAK-2025-0000000000")
 
     def test_next(self):
-        self.assertEqual(self.sdi._next("ZAAK-2025-0000000001"), "ZAAK-2025-0000000002")
+        self.assertEqual(
+            next(self.sdi._sequence("ZAAK-2025-0000000001")), "ZAAK-2025-0000000002"
+        )
 
     def test_generate(self):
         self.sdi.generate()

--- a/src/openzaak/components/zaken/tests/test_zaak_identificatie.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_identificatie.py
@@ -143,3 +143,24 @@ class US164TestCase(JWTAuthMixin, APITestCase):
 
         zaak = Zaak.objects.get()
         self.assertEqual(zaak.identificatie, "ZAAK-2025-0000000001")
+
+    @override_settings(ZAAK_IDENTIFICATIE_GENERATOR="use-uwv-identification")
+    @freeze_time("2025-1-1")
+    def test_zaak_identificatie_with_uwv_identification(self):
+        zaaktype = ZaakTypeFactory.create(concept=False)
+        zaaktype_url = reverse(zaaktype)
+        url = get_operation_url("zaak_create")
+        data = {
+            "zaaktype": f"http://testserver{zaaktype_url}",
+            "vertrouwelijkheidaanduiding": VertrouwelijkheidsAanduiding.openbaar,
+            "verantwoordelijkeOrganisatie": VERANTWOORDELIJKE_ORGANISATIE,
+            "bronorganisatie": "517439943",
+            "startdatum": "2018-06-11",
+        }
+
+        response = self.client.post(url, data, **ZAAK_WRITE_KWARGS)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+
+        zaak = Zaak.objects.get()
+        self.assertEqual(zaak.identificatie, "A00000006")

--- a/src/openzaak/components/zaken/tests/test_zaken.py
+++ b/src/openzaak/components/zaken/tests/test_zaken.py
@@ -782,8 +782,85 @@ class ZakenTests(JWTAuthMixin, APITestCase):
         )
         self.assertEqual(create_response_2.status_code, status.HTTP_400_BAD_REQUEST)
 
+    @override_settings(ZAAK_IDENTIFICATIE_GENERATOR="use-uwv-identification")
+    def test_reserve_zaak_uwv_identity(self):
+        data = {"bronorganisatie": "111222333"}
+
+        response = self.client.post(reverse("zaakidentificatie-list"), data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        self.assertEqual(Zaak.objects.count(), 0)
+        self.assertEqual(ZaakIdentificatie.objects.count(), 1)
+
+        zaak_identificatie = ZaakIdentificatie.objects.get()
+        self.assertEqual(zaak_identificatie.identificatie, "A00000006")
+
+        zaak_id = response.json()["zaaknummer"]
+        zaak_data = {
+            "zaaktype": f"http://testserver{self.zaaktype_url}",
+            "identificatie": zaak_id,
+            "bronorganisatie": "111222333",
+            "verantwoordelijkeOrganisatie": "111222333",
+            "startdatum": "2025-02-05",
+        }
+
+        create_response = self.client.post(
+            reverse("zaak-list"), zaak_data, **ZAAK_WRITE_KWARGS
+        )
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
+
+        self.assertEqual(Zaak.objects.count(), 1)
+        self.assertEqual(ZaakIdentificatie.objects.count(), 1)
+
+        # try to reuse id
+        zaak_data_2 = {
+            "zaaktype": f"http://testserver{self.zaaktype_url}",
+            "identificatie": zaak_id,
+            "bronorganisatie": "111222333",
+            "verantwoordelijkeOrganisatie": "111222333",
+            "startdatum": "2025-02-07",
+        }
+
+        create_response_2 = self.client.post(
+            reverse("zaak-list"), zaak_data_2, **ZAAK_WRITE_KWARGS
+        )
+        self.assertEqual(create_response_2.status_code, status.HTTP_400_BAD_REQUEST)
+
     @tag("gh-1836")
     def test_reserve_zaak_identity_with_different_bronorganisatie(self):
+        data = {"bronorganisatie": "111222333"}
+
+        response = self.client.post(reverse("zaakidentificatie-list"), data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Zaak.objects.count(), 0)
+        self.assertEqual(ZaakIdentificatie.objects.count(), 1)
+
+        reserved_zaak_id = ZaakIdentificatie.objects.get()
+
+        zaaknummer = response.data["zaaknummer"]
+        zaak_data = {
+            "zaaktype": f"http://testserver{self.zaaktype_url}",
+            "identificatie": zaaknummer,
+            "bronorganisatie": "517439943",
+            "verantwoordelijkeOrganisatie": "517439943",
+            "startdatum": "2025-02-04",
+        }
+
+        create_response = self.client.post(
+            reverse("zaak-list"), zaak_data, **ZAAK_WRITE_KWARGS
+        )
+
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Zaak.objects.count(), 1)
+        self.assertEqual(ZaakIdentificatie.objects.count(), 2)
+
+        zaak = Zaak.objects.get()
+        self.assertEqual(zaak.identificatie, zaaknummer)
+        self.assertNotEqual(zaak.identificatie_ptr, reserved_zaak_id)
+
+    @override_settings(ZAAK_IDENTIFICATIE_GENERATOR="use-uwv-identification")
+    def test_reserve_zaak_uwv_identity_with_different_bronorganisatie(self):
         data = {"bronorganisatie": "111222333"}
 
         response = self.client.post(reverse("zaakidentificatie-list"), data)
@@ -821,19 +898,35 @@ class ZakenTests(JWTAuthMixin, APITestCase):
             "bronorganisatie": "517439943",
             "aantal": 1,
         }
-
         url = reverse_lazy("zaakidentificatie-list", kwargs={"version": "1"})
-        response = self.client.post(url, data)
 
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        with self.subTest("year"):
+            response = self.client.post(url, data)
 
-        self.assertEqual(response.data, {"zaaknummer": "ZAAK-2025-0000000001"})
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        self.assertTrue(
-            ZaakIdentificatie.objects.filter(
-                identificatie="ZAAK-2025-0000000001", bronorganisatie="517439943"
-            ).exists()
-        )
+            self.assertEqual(response.data, {"zaaknummer": "ZAAK-2025-0000000001"})
+
+            self.assertTrue(
+                ZaakIdentificatie.objects.filter(
+                    identificatie="ZAAK-2025-0000000001", bronorganisatie="517439943"
+                ).exists()
+            )
+        with (
+            override_settings(ZAAK_IDENTIFICATIE_GENERATOR="use-uwv-identification"),
+            self.subTest("uwv"),
+        ):
+            response = self.client.post(url, data)
+
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+            self.assertEqual(response.data, {"zaaknummer": "A00000006"})
+
+            self.assertTrue(
+                ZaakIdentificatie.objects.filter(
+                    identificatie="A00000006", bronorganisatie="517439943"
+                ).exists()
+            )
 
     @freeze_time("2025-01-01")
     def test_reserve_multiple_zaaknummers(self):
@@ -843,33 +936,65 @@ class ZakenTests(JWTAuthMixin, APITestCase):
         }
 
         url = reverse_lazy("zaakidentificatie-list", kwargs={"version": "1"})
-        response = self.client.post(url, data)
 
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        with self.subTest("year"):
+            response = self.client.post(url, data)
 
-        result = response.data
-        self.assertEqual(len(result), 3)
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        expected_ids = [
-            "ZAAK-2025-0000000001",
-            "ZAAK-2025-0000000002",
-            "ZAAK-2025-0000000003",
-        ]
+            result = response.data
+            self.assertEqual(len(result), 3)
 
-        actual_ids = [item["zaaknummer"] for item in result]
-        self.assertEqual(actual_ids, expected_ids)
+            expected_ids = [
+                "ZAAK-2025-0000000001",
+                "ZAAK-2025-0000000002",
+                "ZAAK-2025-0000000003",
+            ]
 
-        for zaaknummer in expected_ids:
-            self.assertTrue(
-                ZaakIdentificatie.objects.filter(
-                    identificatie=zaaknummer, bronorganisatie="517439943"
-                ).exists()
-            )
+            actual_ids = [item["zaaknummer"] for item in result]
+            self.assertEqual(actual_ids, expected_ids)
+
+            for zaaknummer in expected_ids:
+                self.assertTrue(
+                    ZaakIdentificatie.objects.filter(
+                        identificatie=zaaknummer, bronorganisatie="517439943"
+                    ).exists()
+                )
+
+        with (
+            override_settings(ZAAK_IDENTIFICATIE_GENERATOR="use-uwv-identification"),
+            self.subTest("uwv"),
+        ):
+            response = self.client.post(url, data)
+
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+            result = response.data
+            self.assertEqual(len(result), 3)
+
+            expected_ids = [
+                "A00000006",
+                "A00000023",
+                "A00000037",
+            ]
+
+            actual_ids = [item["zaaknummer"] for item in result]
+            self.assertEqual(actual_ids, expected_ids)
+
+            for zaaknummer in expected_ids:
+                self.assertTrue(
+                    ZaakIdentificatie.objects.filter(
+                        identificatie=zaaknummer, bronorganisatie="517439943"
+                    ).exists()
+                )
 
     @freeze_time("2025-01-01")
     def test_reserve_zaaknummers_continues_from_last_identificatie(self):
         ZaakIdentificatie.objects.create(
             identificatie="ZAAK-2025-0000000010", bronorganisatie="517439943"
+        )
+        ZaakIdentificatie.objects.create(
+            identificatie="A00000006", bronorganisatie="517439943"
         )
 
         data = {
@@ -878,12 +1003,25 @@ class ZakenTests(JWTAuthMixin, APITestCase):
         }
 
         url = reverse_lazy("zaakidentificatie-list", kwargs={"version": "1"})
-        response = self.client.post(url, data)
 
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        with self.subTest("year"):
+            response = self.client.post(url, data)
 
-        self.assertEqual(response.data[0]["zaaknummer"], "ZAAK-2025-0000000011")
-        self.assertEqual(response.data[1]["zaaknummer"], "ZAAK-2025-0000000012")
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+            self.assertEqual(response.data[0]["zaaknummer"], "ZAAK-2025-0000000011")
+            self.assertEqual(response.data[1]["zaaknummer"], "ZAAK-2025-0000000012")
+
+        with (
+            override_settings(ZAAK_IDENTIFICATIE_GENERATOR="use-uwv-identification"),
+            self.subTest("uwv"),
+        ):
+            response = self.client.post(url, data)
+
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+            self.assertEqual(response.data[0]["zaaknummer"], "A00000023")
+            self.assertEqual(response.data[1]["zaaknummer"], "A00000037")
 
     @tag("gh-2011")
     def test_betalingsindicatie_weergave(self):

--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -447,8 +447,9 @@ CONTENT_SECURITY_POLICY["DIRECTIVES"]["style-src"] += [
 
 
 ZAAK_IDENTIFICATIE_GENERATOR_OPTIONS = {
-    "use-creation-year": "openzaak.components.zaken.api.utils.generate_zaak_identificatie_with_creation_year",
-    "use-start-datum-year": "openzaak.components.zaken.api.utils.generate_zaak_identificatie_with_start_datum_year",
+    "use-creation-year": "openzaak.components.zaken.models.identification_classes.CreationYearIdentification",
+    "use-start-datum-year": "openzaak.components.zaken.models.identification_classes.StartDatumYearIdentification",
+    "use-uvw-identification": "openzaak.components.zaken.models.identification_classes.UWVIdentification",
 }
 
 ZAAK_IDENTIFICATIE_GENERATOR = config(

--- a/src/openzaak/conf/includes/base.py
+++ b/src/openzaak/conf/includes/base.py
@@ -449,7 +449,7 @@ CONTENT_SECURITY_POLICY["DIRECTIVES"]["style-src"] += [
 ZAAK_IDENTIFICATIE_GENERATOR_OPTIONS = {
     "use-creation-year": "openzaak.components.zaken.models.identification_classes.CreationYearIdentification",
     "use-start-datum-year": "openzaak.components.zaken.models.identification_classes.StartDatumYearIdentification",
-    "use-uvw-identification": "openzaak.components.zaken.models.identification_classes.UWVIdentification",
+    "use-uwv-identification": "openzaak.components.zaken.models.identification_classes.UWVIdentification",
 }
 
 ZAAK_IDENTIFICATIE_GENERATOR = config(


### PR DESCRIPTION
Closes #2372 

**Changes**
- removes ZaakIdentificatieManager
- Adds Identification classes for existing year identification & UWV identification

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [ ] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/open-zaak/open-zaak/wiki/Architectural-Decision-Records-(ADR))
