### PR TITLE
:whale: Pin azurite and azure-cli in docker setup to compatible versions

### DIFF
--- a/docker/docker-compose.azurite.yml
+++ b/docker/docker-compose.azurite.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   azurite:
-    image: mcr.microsoft.com/azure-storage/azurite
+    image: mcr.microsoft.com/azure-storage/azurite:3.35.0
     container_name: azurite
     ports:
       - "10000:10000"  # Blob service
@@ -19,7 +19,7 @@ services:
       --debug /data/debug.log
 
   init-storage:
-    image: mcr.microsoft.com/azure-cli
+    image: mcr.microsoft.com/azure-cli:2.80.0
     depends_on:
       - azurite
     entrypoint:

--- a/src/openzaak/components/documenten/tests/azure/admin/files/vcr_cassettes/EnkelvoudigInformatieObjectAdminTests/test_create_informatieobject_save.yaml
+++ b/src/openzaak/components/documenten/tests/azure/admin/files/vcr_cassettes/EnkelvoudigInformatieObjectAdminTests/test_create_informatieobject_save.yaml
@@ -6,16 +6,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:t58xRl26lD06f+wKzLV0gDBy+gbKPdo9IUP93GNNcvQ=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 92410d78-d76e-11f0-b763-f4289da6022f
+      - 432a6000-cead-11f0-8d0c-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:23:54 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -27,7 +25,7 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 12 Dec 2025 15:23:54 GMT
+      - Thu, 11 Jun 2026 10:33:33 GMT
       Keep-Alive:
       - timeout=5
       Server:
@@ -35,7 +33,7 @@ interactions:
       x-ms-error-code:
       - BlobNotFound
       x-ms-request-id:
-      - d436a909-96ba-4768-8e36-8a78d8a88002
+      - 47daa3fa-b090-4439-b53c-becf6a44afae
     status:
       code: 404
       message: The specified blob does not exist.
@@ -46,8 +44,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:NnX5AFntVxz87feQ88KJeYlYGVMCtlB5t1j/hZbKvcY=
       Connection:
       - keep-alive
       Content-Length:
@@ -55,15 +51,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - text/plain
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 92410d79-d76e-11f0-b763-f4289da6022f
+      - 432a6001-cead-11f0-8b81-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:23:54 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -83,15 +79,15 @@ interactions:
       content-md5:
       - rL0Y20zC+Fzt72VPzMSk2A==
       date:
-      - Fri, 12 Dec 2025 15:23:54 GMT
+      - Thu, 11 Jun 2026 10:33:33 GMT
       etag:
-      - '"0x2327B060E3A1BE0"'
+      - '"0x24FBB3D06298040"'
       last-modified:
-      - Fri, 12 Dec 2025 15:23:54 GMT
+      - Thu, 11 Jun 2026 10:33:33 GMT
       x-ms-client-request-id:
-      - 92410d79-d76e-11f0-b763-f4289da6022f
+      - 432a6001-cead-11f0-8b81-a82bdd58bc01
       x-ms-request-id:
-      - c8dc886a-6d4d-4e03-a553-c6179d5ef8c2
+      - 9e381adc-81d1-4023-9be5-089eebc5a482
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -106,16 +102,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:g7gFtlK2u2wNK2XrJqFoMIk+WxcU4QdbWNi0AeDg1aU=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 92410d7a-d76e-11f0-b763-f4289da6022f
+      - 432a6002-cead-11f0-9bf8-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:23:54 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
@@ -141,25 +135,25 @@ interactions:
       content-type:
       - text/plain
       date:
-      - Fri, 12 Dec 2025 15:23:54 GMT
+      - Thu, 11 Jun 2026 10:33:33 GMT
       etag:
-      - '"0x2327B060E3A1BE0"'
+      - '"0x24FBB3D06298040"'
       last-modified:
-      - Fri, 12 Dec 2025 15:23:54 GMT
+      - Thu, 11 Jun 2026 10:33:33 GMT
       x-ms-blob-content-md5:
       - rL0Y20zC+Fzt72VPzMSk2A==
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 92410d7a-d76e-11f0-b763-f4289da6022f
+      - 432a6002-cead-11f0-9bf8-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:23:54 GMT
+      - Thu, 11 Jun 2026 10:33:33 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 743c49bf-e93a-4e77-9887-a872050c5a38
+      - dd34dbb4-121f-44e2-a17c-640ce5c44003
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -174,16 +168,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:VBiFO0uzoXZMAO9FTbYwoC9FmHUKeyPwYWD/DnN+HQo=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 92410d7b-d76e-11f0-b763-f4289da6022f
+      - 432a6003-cead-11f0-8704-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:23:54 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -207,29 +199,29 @@ interactions:
       content-type:
       - text/plain
       date:
-      - Fri, 12 Dec 2025 15:23:54 GMT
+      - Thu, 11 Jun 2026 10:33:33 GMT
       etag:
-      - '"0x2327B060E3A1BE0"'
+      - '"0x24FBB3D06298040"'
       last-modified:
-      - Fri, 12 Dec 2025 15:23:54 GMT
+      - Thu, 11 Jun 2026 10:33:33 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Fri, 12 Dec 2025 15:23:54 GMT
+      - Thu, 11 Jun 2026 10:33:33 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 92410d7b-d76e-11f0-b763-f4289da6022f
+      - 432a6003-cead-11f0-8704-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:23:54 GMT
+      - Thu, 11 Jun 2026 10:33:33 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 23429a5b-be0f-4eea-8f46-b4c967cf7b7f
+      - 3b985c37-5f43-4818-af3f-b92b1bb3f1cc
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/admin/files/vcr_cassettes/EnkelvoudigInformatieObjectAdminTests/test_get_informatieobject_shows_current_file_path.yaml
+++ b/src/openzaak/components/documenten/tests/azure/admin/files/vcr_cassettes/EnkelvoudigInformatieObjectAdminTests/test_get_informatieobject_shows_current_file_path.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:HkrHA9Jb2nVmEhjvI0YSTkFkORx3d/bJbY67Taq/IUo=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 92410d7d-d76e-11f0-b763-f4289da6022f
+      - 432a6005-cead-11f0-b71e-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:23:55 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - HlAhCgICSX+3m8OLat5sNA==
       date:
-      - Fri, 12 Dec 2025 15:23:55 GMT
+      - Thu, 11 Jun 2026 10:33:34 GMT
       etag:
-      - '"0x272109FD1993EC0"'
+      - '"0x2252CF38FB92BA0"'
       last-modified:
-      - Fri, 12 Dec 2025 15:23:55 GMT
+      - Thu, 11 Jun 2026 10:33:34 GMT
       x-ms-client-request-id:
-      - 92410d7d-d76e-11f0-b763-f4289da6022f
+      - 432a6005-cead-11f0-b71e-a82bdd58bc01
       x-ms-request-id:
-      - 5127a7bd-e528-4530-8928-37ec9aff150a
+      - 670b6705-7f09-43f3-90c0-108ef9d3d836
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/admin/files/vcr_cassettes/EnkelvoudigInformatieObjectDownloadAdminTests/test_eio_download_inhoud.yaml
+++ b/src/openzaak/components/documenten/tests/azure/admin/files/vcr_cassettes/EnkelvoudigInformatieObjectDownloadAdminTests/test_eio_download_inhoud.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:DOyZHDgvIPO5HDIlf4Bz9+igbS4rk13tCLeXWxFCOZo=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,13 +13,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 737d6000-6318-11f5-ac8a-a82bdd58bc01
+      - 737d6000-6318-11f5-abff-a82bdd58bc01
       x-ms-date:
       - Tue, 01 Jan 2030 12:00:00 GMT
       x-ms-version:
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - vckNNU4TN7zbzl+o3tjXPQ==
       date:
-      - Fri, 12 Dec 2025 15:23:55 GMT
+      - Thu, 11 Jun 2026 10:33:34 GMT
       etag:
-      - '"0x2206F3FBC178100"'
+      - '"0x2517BF83CF70940"'
       last-modified:
-      - Fri, 12 Dec 2025 15:23:55 GMT
+      - Thu, 11 Jun 2026 10:33:34 GMT
       x-ms-client-request-id:
-      - 737d6000-6318-11f5-ac8a-a82bdd58bc01
+      - 737d6000-6318-11f5-abff-a82bdd58bc01
       x-ms-request-id:
-      - 6df08a6a-e748-4678-b64d-efee2b518c87
+      - 9eafc060-7aa9-42c0-a7f1-3fd2996f528f
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -91,23 +89,23 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 12 Dec 2025 15:23:56 GMT
+      - Thu, 11 Jun 2026 10:33:34 GMT
       etag:
-      - '"0x2206F3FBC178100"'
+      - '"0x2517BF83CF70940"'
       last-modified:
-      - Fri, 12 Dec 2025 15:23:55 GMT
+      - Thu, 11 Jun 2026 10:33:34 GMT
       x-ms-blob-content-md5:
       - vckNNU4TN7zbzl+o3tjXPQ==
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:23:55 GMT
+      - Thu, 11 Jun 2026 10:33:34 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 47782116-ec0c-4f9f-bb22-ce7c4d4aa5e8
+      - 79d11526-4aa5-4289-be2f-d3d601f2dfcc
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/admin/files/vcr_cassettes/EnkelvoudigInformatieObjectDownloadAdminTests/test_eio_download_inhoud_bestandsnaam_empty.yaml
+++ b/src/openzaak/components/documenten/tests/azure/admin/files/vcr_cassettes/EnkelvoudigInformatieObjectDownloadAdminTests/test_eio_download_inhoud_bestandsnaam_empty.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:TUZfm7uzIT85pXfuZyyMYLDoIPkkq5seC24qZNJ6XBA=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,13 +13,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 737d6001-6318-11f5-a746-a82bdd58bc01
+      - 737d6001-6318-11f5-8736-a82bdd58bc01
       x-ms-date:
       - Tue, 01 Jan 2030 12:00:00 GMT
       x-ms-version:
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - vckNNU4TN7zbzl+o3tjXPQ==
       date:
-      - Fri, 12 Dec 2025 15:23:56 GMT
+      - Thu, 11 Jun 2026 10:33:34 GMT
       etag:
-      - '"0x24350E2FA90CFE0"'
+      - '"0x201E263593DB880"'
       last-modified:
-      - Fri, 12 Dec 2025 15:23:56 GMT
+      - Thu, 11 Jun 2026 10:33:34 GMT
       x-ms-client-request-id:
-      - 737d6001-6318-11f5-a746-a82bdd58bc01
+      - 737d6001-6318-11f5-8736-a82bdd58bc01
       x-ms-request-id:
-      - 62f284cd-7dab-42db-bc01-cd8e6e268632
+      - 27b2e806-8ccf-4eaa-a728-501b2bc2e390
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -91,23 +89,23 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 12 Dec 2025 15:23:56 GMT
+      - Thu, 11 Jun 2026 10:33:34 GMT
       etag:
-      - '"0x24350E2FA90CFE0"'
+      - '"0x201E263593DB880"'
       last-modified:
-      - Fri, 12 Dec 2025 15:23:56 GMT
+      - Thu, 11 Jun 2026 10:33:34 GMT
       x-ms-blob-content-md5:
       - vckNNU4TN7zbzl+o3tjXPQ==
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:23:56 GMT
+      - Thu, 11 Jun 2026 10:33:34 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - a89716dd-8125-4524-af46-9c596fd3cbc7
+      - 5c8adb52-c507-4720-b702-52e4e53a55c5
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/AzureStorageTests/test_auth_use_connection_string.yaml
+++ b/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/AzureStorageTests/test_auth_use_connection_string.yaml
@@ -7,7 +7,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - SharedKey devstoreaccount1:ld8GQF7oOc+JwFl8vHGw0npyG8O8UykeRS0bWrsei78=
+      - SharedKey devstoreaccount1:o5LotKZWKnU7fkqOlFzhgc4M+IPAYdyEuhGfg87igQc=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +15,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4c79f06e-d76e-11f0-b763-f4289da6022f
+      - 432a6000-cead-11f0-b202-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +43,15 @@ interactions:
       content-md5:
       - HlAhCgICSX+3m8OLat5sNA==
       date:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       etag:
-      - '"0x1CBF674BAB730B0"'
+      - '"0x26E57069C4CA420"'
       last-modified:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-client-request-id:
-      - 4c79f06e-d76e-11f0-b763-f4289da6022f
+      - 432a6000-cead-11f0-b202-a82bdd58bc01
       x-ms-request-id:
-      - f41c88fd-fe3b-4c60-b977-3c8ad90e31c7
+      - 60d63cd5-9e21-457f-9fc8-be29ed6266ee
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -67,15 +67,15 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - SharedKey devstoreaccount1:xeGsL/RRoS9YO7QykuGMlvrHimui4FbMYL/hhRz6VsI=
+      - SharedKey devstoreaccount1:OTFoDk2mz9q4TudxQonkjCWZ4Rd0Wfmeg34kusb7TMo=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 4c79f06f-d76e-11f0-b763-f4289da6022f
+      - 432a6001-cead-11f0-817f-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -99,29 +99,29 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       etag:
-      - '"0x1CBF674BAB730B0"'
+      - '"0x26E57069C4CA420"'
       last-modified:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4c79f06f-d76e-11f0-b763-f4289da6022f
+      - 432a6001-cead-11f0-817f-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 9930937a-60af-4648-9e50-a95d16798acb
+      - ef5c64de-3fe7-4eda-832e-c5fbef2f99ac
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -137,15 +137,15 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - SharedKey devstoreaccount1:YJrntUCOLAjNzYr0H3jeAzioEx/LXOE/j9W6QAewMY0=
+      - SharedKey devstoreaccount1:SLsEUqiv3cmdFFScWl96wHXtFdENw0d0Wozoa7jCQJo=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 4c79f070-d76e-11f0-b763-f4289da6022f
+      - 432a6002-cead-11f0-8a91-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -169,29 +169,29 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       etag:
-      - '"0x1CBF674BAB730B0"'
+      - '"0x26E57069C4CA420"'
       last-modified:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4c79f070-d76e-11f0-b763-f4289da6022f
+      - 432a6002-cead-11f0-8a91-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 27e3d8bf-6635-4e3d-bf6e-390a05b168db
+      - dba1e8f3-f8fe-4e49-aa2f-aa4044e81cef
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/AzureStorageTests/test_eio_file_path_exists.yaml
+++ b/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/AzureStorageTests/test_eio_file_path_exists.yaml
@@ -7,7 +7,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - SharedKey devstoreaccount1:F3tRpbcd496oCirkU4dgS+x9/UleRdzsnTl049uRRbo=
+      - SharedKey devstoreaccount1:+hwgtrUYHN8gODGlVadeX+XftCDwWekAjzURBmi/IjM=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +15,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4c79f071-d76e-11f0-b763-f4289da6022f
+      - 432a6003-cead-11f0-a042-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +43,15 @@ interactions:
       content-md5:
       - HlAhCgICSX+3m8OLat5sNA==
       date:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       etag:
-      - '"0x1E8F4488F6C2500"'
+      - '"0x23EF4B3F3B0B880"'
       last-modified:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-client-request-id:
-      - 4c79f071-d76e-11f0-b763-f4289da6022f
+      - 432a6003-cead-11f0-a042-a82bdd58bc01
       x-ms-request-id:
-      - b1eeb952-29e5-48bc-93b1-cdb623f81ed8
+      - 2595c5ff-1634-474a-82ea-f94776100c04
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -67,15 +67,15 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - SharedKey devstoreaccount1:AzcVVCS8QlpUJcTbqKt/O8EMXy5Q07sITxaZMY2LrfY=
+      - SharedKey devstoreaccount1:6i+MFFZjW6mwWEwFCjMSoObnB0XD1EwTqgeG6kArIPo=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 4c79f072-d76e-11f0-b763-f4289da6022f
+      - 432a6004-cead-11f0-b982-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -99,29 +99,29 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       etag:
-      - '"0x1E8F4488F6C2500"'
+      - '"0x23EF4B3F3B0B880"'
       last-modified:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4c79f072-d76e-11f0-b763-f4289da6022f
+      - 432a6004-cead-11f0-b982-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 9c8418f8-f066-4c0e-94e7-d79ed4a0da8d
+      - 7f097a78-c412-4c53-b915-8e520031f550
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -137,15 +137,15 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - SharedKey devstoreaccount1:4S2WkZorIQuJZB67UXKXeDTvdG3TVlPgE2TIzCm1gq8=
+      - SharedKey devstoreaccount1:Jfzcn7lg2LCcfMMwecgdg6ML3zdzPESvpCgouYaP59o=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 4c79f073-d76e-11f0-b763-f4289da6022f
+      - 432a6005-cead-11f0-8172-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -169,29 +169,29 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       etag:
-      - '"0x1E8F4488F6C2500"'
+      - '"0x23EF4B3F3B0B880"'
       last-modified:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4c79f073-d76e-11f0-b763-f4289da6022f
+      - 432a6005-cead-11f0-8172-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 8ae935c9-abac-4b73-a9b8-f9aec67a032c
+      - 79d83cbe-de5e-4f01-8ff4-2748aa487564
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/DocumentRegistrerenAuthTests/test_register_document.yaml
+++ b/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/DocumentRegistrerenAuthTests/test_register_document.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:T1vQ/x1a+ooLzLMofd19FgaCnFk2Ll+yVEnnimSL+5w=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,13 +13,13 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - ed31e000-c837-11ef-99be-a82bdd58bc01
+      - ed31e000-c837-11ef-93a0-a82bdd58bc01
       x-ms-date:
       - Wed, 01 Jan 2025 12:00:00 GMT
       x-ms-version:
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - J8OgCaPLumdNCz6Dby1GhQ==
       date:
-      - Fri, 12 Dec 2025 15:21:56 GMT
+      - Thu, 11 Jun 2026 10:33:39 GMT
       etag:
-      - '"0x1EF8583DE28F9D0"'
+      - '"0x212054EC4500DA0"'
       last-modified:
-      - Fri, 12 Dec 2025 15:21:56 GMT
+      - Thu, 11 Jun 2026 10:33:39 GMT
       x-ms-client-request-id:
-      - ed31e000-c837-11ef-99be-a82bdd58bc01
+      - ed31e000-c837-11ef-93a0-a82bdd58bc01
       x-ms-request-id:
-      - ec7f9abb-65df-4e68-a1a7-4704d63a4592
+      - 91ebd5ac-2cc3-40dd-9c51-ed79ae8e419a
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -66,14 +64,12 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:o+pAzx87Cxpg/ABUDe9hmi6fDT/u2GH57PuA3p3N9Rc=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - ed31e001-c837-11ef-81b3-a82bdd58bc01
+      - ed31e001-c837-11ef-bacf-a82bdd58bc01
       x-ms-date:
       - Wed, 01 Jan 2025 12:00:00 GMT
       x-ms-version:
@@ -99,29 +95,29 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 12 Dec 2025 15:21:57 GMT
+      - Thu, 11 Jun 2026 10:33:39 GMT
       etag:
-      - '"0x1EF8583DE28F9D0"'
+      - '"0x212054EC4500DA0"'
       last-modified:
-      - Fri, 12 Dec 2025 15:21:56 GMT
+      - Thu, 11 Jun 2026 10:33:39 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Fri, 12 Dec 2025 15:21:56 GMT
+      - Thu, 11 Jun 2026 10:33:39 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - ed31e001-c837-11ef-81b3-a82bdd58bc01
+      - ed31e001-c837-11ef-bacf-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:21:56 GMT
+      - Thu, 11 Jun 2026 10:33:39 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - b4c80bbd-544c-40f6-bcb4-bc59b244dc80
+      - 7a3bbd92-a171-4d89-adde-58c9c9e59c66
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -136,14 +132,12 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:sV6BwbuBcsId1BMuknvYfdLb2AF+RZ92aQ8cRL4865M=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - ed31e002-c837-11ef-ba60-a82bdd58bc01
+      - ed31e002-c837-11ef-9ef4-a82bdd58bc01
       x-ms-date:
       - Wed, 01 Jan 2025 12:00:00 GMT
       x-ms-range:
@@ -171,25 +165,25 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 12 Dec 2025 15:21:57 GMT
+      - Thu, 11 Jun 2026 10:33:39 GMT
       etag:
-      - '"0x1EF8583DE28F9D0"'
+      - '"0x212054EC4500DA0"'
       last-modified:
-      - Fri, 12 Dec 2025 15:21:56 GMT
+      - Thu, 11 Jun 2026 10:33:39 GMT
       x-ms-blob-content-md5:
       - J8OgCaPLumdNCz6Dby1GhQ==
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - ed31e002-c837-11ef-ba60-a82bdd58bc01
+      - ed31e002-c837-11ef-9ef4-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:21:56 GMT
+      - Thu, 11 Jun 2026 10:33:39 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - bc50fb42-8383-4243-8728-7176cf6e5311
+      - 64d92a6b-2d94-4028-a8b9-9a85c4929842
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/EnkelvoudigInformatieObjectFileAzureBlobStorageTests/test_create_enkelvoudiginformatieobject.yaml
+++ b/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/EnkelvoudigInformatieObjectFileAzureBlobStorageTests/test_create_enkelvoudiginformatieobject.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:jMnCmwwNDI+pFVJQ4xlpvZj49v2iLRYRZQeFRYGrAYI=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4c79f066-d76e-11f0-b763-f4289da6022f
+      - 432a6000-cead-11f0-92bc-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:21:57 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - iLV68LPBXaud2kmhz5UCDg==
       date:
-      - Fri, 12 Dec 2025 15:21:57 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       etag:
-      - '"0x222D308DAC5E560"'
+      - '"0x22DD84EFA3F8F40"'
       last-modified:
-      - Fri, 12 Dec 2025 15:21:57 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-client-request-id:
-      - 4c79f066-d76e-11f0-b763-f4289da6022f
+      - 432a6000-cead-11f0-92bc-a82bdd58bc01
       x-ms-request-id:
-      - 6b73b1d3-9c5a-4f24-ae26-ac45f758113f
+      - f02e502f-f2b3-4ecf-ad05-6471b008f52e
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -66,16 +64,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:nJMeADDBNKhLgyrPAV2BQxF5tdoaZuK2ytMFb9K8vYw=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 4c79f067-d76e-11f0-b763-f4289da6022f
+      - 432a6001-cead-11f0-b903-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:21:57 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -99,29 +95,29 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 12 Dec 2025 15:21:57 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       etag:
-      - '"0x222D308DAC5E560"'
+      - '"0x22DD84EFA3F8F40"'
       last-modified:
-      - Fri, 12 Dec 2025 15:21:57 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Fri, 12 Dec 2025 15:21:57 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4c79f067-d76e-11f0-b763-f4289da6022f
+      - 432a6001-cead-11f0-b903-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:21:57 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - a7081c56-d4dc-4cb2-84a7-406e429cbc55
+      - 0f096e23-9b86-4728-ad3b-d1d042cd6a51
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/EnkelvoudigInformatieObjectFileAzureBlobStorageTests/test_delete_eio_deletes_file.yaml
+++ b/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/EnkelvoudigInformatieObjectFileAzureBlobStorageTests/test_delete_eio_deletes_file.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:oja/wanpBnWDa82VSLTh7SQdDh3cb8T5+XZkRNvZsp0=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,17 +13,17 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.3 (Linux-6.14.0-37-generic-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 432a6003-cead-11f0-9a31-c4efbbb6400f
+      - 432a6003-cead-11f0-aa7c-a82bdd58bc01
       x-ms-date:
       - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
-      - '2021-12-02'
+      - '2025-11-05'
     method: PUT
     uri: http://127.0.0.1:10000/devstoreaccount1/openzaak/documenten/uploads/2025/12/some-file2.bin?timeout=5
   response:
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - HlAhCgICSX+3m8OLat5sNA==
       date:
-      - Mon, 19 Jan 2026 09:53:47 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       etag:
-      - '"0x1C95B4F14D3D120"'
+      - '"0x26E790B8D2D4080"'
       last-modified:
-      - Mon, 19 Jan 2026 09:53:47 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-client-request-id:
-      - 432a6003-cead-11f0-9a31-c4efbbb6400f
+      - 432a6003-cead-11f0-aa7c-a82bdd58bc01
       x-ms-request-id:
-      - 566ff9d2-136c-49a3-b574-f487ac9b84dd
+      - cfa268ef-b601-4638-a3b0-d085a6a9d82e
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -66,18 +64,16 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:5mSA5NE3FBGo3w+giZUPER4ptA7MAi0jup+yexyOgKY=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.3 (Linux-6.14.0-37-generic-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 432a6004-cead-11f0-83ac-c4efbbb6400f
+      - 432a6004-cead-11f0-a48b-a82bdd58bc01
       x-ms-date:
       - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
-      - '2021-12-02'
+      - '2025-11-05'
     method: HEAD
     uri: http://127.0.0.1:10000/devstoreaccount1/openzaak/documenten/uploads/2025/12/some-file2.bin
   response:
@@ -99,29 +95,29 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Mon, 19 Jan 2026 09:53:47 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       etag:
-      - '"0x1C95B4F14D3D120"'
+      - '"0x26E790B8D2D4080"'
       last-modified:
-      - Mon, 19 Jan 2026 09:53:47 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Mon, 19 Jan 2026 09:53:47 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 432a6004-cead-11f0-83ac-c4efbbb6400f
+      - 432a6004-cead-11f0-a48b-a82bdd58bc01
       x-ms-creation-time:
-      - Mon, 19 Jan 2026 09:53:47 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 34915ca3-0d4b-4850-a2ce-2c3b5225b457
+      - c36adc96-f9e5-44f8-94ed-7420df1381bf
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -136,20 +132,18 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:Dik7bSFXrayaevk6NeUBvcWWUm+OLX6ij6rjlOX//s8=
       Connection:
       - keep-alive
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.3 (Linux-6.14.0-37-generic-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 432a6005-cead-11f0-ae36-c4efbbb6400f
+      - 432a6005-cead-11f0-a4db-a82bdd58bc01
       x-ms-date:
       - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
-      - '2021-12-02'
+      - '2025-11-05'
     method: DELETE
     uri: http://127.0.0.1:10000/devstoreaccount1/openzaak/documenten/uploads/2025/12/some-file2.bin?timeout=5
   response:
@@ -165,13 +159,13 @@ interactions:
       Server:
       - Azurite-Blob/3.35.0
       date:
-      - Mon, 19 Jan 2026 09:53:47 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-client-request-id:
-      - 432a6005-cead-11f0-ae36-c4efbbb6400f
+      - 432a6005-cead-11f0-a4db-a82bdd58bc01
       x-ms-delete-type-permanent:
       - 'true'
       x-ms-request-id:
-      - 1ebcf1a5-7361-4677-8f1d-8939203d46a6
+      - 99e66d70-8e06-4bfd-8de1-242a7495ac33
       x-ms-version:
       - '2025-11-05'
     status:
@@ -184,18 +178,16 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:bHKoHqtOekla5tO7nYy2veyF8i38hN07A8ndvB6JvQY=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.3 (Linux-6.14.0-37-generic-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 432a6006-cead-11f0-8c5a-c4efbbb6400f
+      - 432a6006-cead-11f0-992c-a82bdd58bc01
       x-ms-date:
       - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
-      - '2021-12-02'
+      - '2025-11-05'
     method: HEAD
     uri: http://127.0.0.1:10000/devstoreaccount1/openzaak/documenten/uploads/2025/12/some-file2.bin
   response:
@@ -205,7 +197,7 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Mon, 19 Jan 2026 09:53:47 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       Keep-Alive:
       - timeout=5
       Server:
@@ -213,7 +205,7 @@ interactions:
       x-ms-error-code:
       - BlobNotFound
       x-ms-request-id:
-      - 10eff943-e581-4f18-9630-9addfd91754c
+      - 8afbabe6-ec6f-4a11-9a52-667cde5169ad
     status:
       code: 404
       message: The specified blob does not exist.
@@ -224,18 +216,16 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:+/6mZoH0+zFab2PyraicooKStTnMp3LrXHiQwfV+T8w=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.3 (Linux-6.14.0-37-generic-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 432a6007-cead-11f0-9d02-c4efbbb6400f
+      - 432a6007-cead-11f0-9ac8-a82bdd58bc01
       x-ms-date:
       - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
-      - '2021-12-02'
+      - '2025-11-05'
     method: HEAD
     uri: http://127.0.0.1:10000/devstoreaccount1/openzaak/documenten/uploads/2025/12/some-file2.bin
   response:
@@ -245,7 +235,7 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Mon, 19 Jan 2026 09:53:47 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       Keep-Alive:
       - timeout=5
       Server:
@@ -253,7 +243,7 @@ interactions:
       x-ms-error-code:
       - BlobNotFound
       x-ms-request-id:
-      - 0a9edf6c-d358-44e7-85e1-ac73c0240e04
+      - 1f6094ae-42a4-4e01-a8a4-4d8e2c6f4421
     status:
       code: 404
       message: The specified blob does not exist.

--- a/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/EnkelvoudigInformatieObjectFileAzureBlobStorageTests/test_list_file.yaml
+++ b/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/EnkelvoudigInformatieObjectFileAzureBlobStorageTests/test_list_file.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:lGAHNyBP4MkztUmb41kzSjS0KStKBIocABnfregZHls=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4c79f06a-d76e-11f0-b763-f4289da6022f
+      - 432a6008-cead-11f0-9615-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - HlAhCgICSX+3m8OLat5sNA==
       date:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       etag:
-      - '"0x2672E9E472834E0"'
+      - '"0x24D1C9273720D60"'
       last-modified:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-client-request-id:
-      - 4c79f06a-d76e-11f0-b763-f4289da6022f
+      - 432a6008-cead-11f0-9615-a82bdd58bc01
       x-ms-request-id:
-      - ad86dd5c-20c6-42fa-a1ca-d1a0c126aaa5
+      - e7c9728d-42c5-4ec0-9b9e-f5fed9c0041e
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/EnkelvoudigInformatieObjectFileAzureBlobStorageTests/test_read_detail_file.yaml
+++ b/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/EnkelvoudigInformatieObjectFileAzureBlobStorageTests/test_read_detail_file.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:KG9Hp0g+5DsaUr2gmDH63q0+/DWHIeDKsD2+GYlnBrQ=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4c79f06b-d76e-11f0-b763-f4289da6022f
+      - 432a6009-cead-11f0-aea5-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - HlAhCgICSX+3m8OLat5sNA==
       date:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       etag:
-      - '"0x26391B32ED039A0"'
+      - '"0x25C494192D28EA0"'
       last-modified:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-client-request-id:
-      - 4c79f06b-d76e-11f0-b763-f4289da6022f
+      - 432a6009-cead-11f0-aea5-a82bdd58bc01
       x-ms-request-id:
-      - 7e52cde4-461c-4cf7-9bc6-92f1f4d04150
+      - 2cab2a2b-7769-430d-a754-5745c3a793a1
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -66,16 +64,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:rFBTpgPdRqjuIwHO70vhGVmvBAIQE1I5gX6BVB4u2+k=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 4c79f06c-d76e-11f0-b763-f4289da6022f
+      - 432a600a-cead-11f0-89bc-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
@@ -101,25 +97,25 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       etag:
-      - '"0x26391B32ED039A0"'
+      - '"0x25C494192D28EA0"'
       last-modified:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-blob-content-md5:
       - HlAhCgICSX+3m8OLat5sNA==
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4c79f06c-d76e-11f0-b763-f4289da6022f
+      - 432a600a-cead-11f0-89bc-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:21:58 GMT
+      - Thu, 11 Jun 2026 10:33:40 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - c3a48cdd-099a-4e1b-98d2-5412e3ac74a3
+      - ebb5e2cd-80ec-482f-99ef-ff39273b1469
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/LargeFileAPITests/test_create_eio_full_process.yaml
+++ b/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/LargeFileAPITests/test_create_eio_full_process.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:G35dYE+1N2NQ9SpRMJupvf3vpFG57gWl6NlWjhIa3yA=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - text/plain
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4d3d3c4c-d76e-11f0-b763-f4289da6022f
+      - 432a6000-cead-11f0-a1d0-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:21:59 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - vd7zzIWI+8ImXl1GAHmsgA==
       date:
-      - Fri, 12 Dec 2025 15:21:59 GMT
+      - Thu, 11 Jun 2026 10:33:41 GMT
       etag:
-      - '"0x2567743E5060A80"'
+      - '"0x20402B2AAF5DD00"'
       last-modified:
-      - Fri, 12 Dec 2025 15:21:59 GMT
+      - Thu, 11 Jun 2026 10:33:41 GMT
       x-ms-client-request-id:
-      - 4d3d3c4c-d76e-11f0-b763-f4289da6022f
+      - 432a6000-cead-11f0-a1d0-a82bdd58bc01
       x-ms-request-id:
-      - be0a6cb4-9399-41b0-ba5b-f69cdf32409f
+      - b3665a42-0e8a-4597-90c9-b20f75a9e9fe
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -66,16 +64,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:UGB/eI/+FTtxf0raKITQk9yXV9YJHCmI7a8NvA1cg9w=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 4d3d3c4d-d76e-11f0-b763-f4289da6022f
+      - 432a6001-cead-11f0-a2d3-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:21:59 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -99,29 +95,29 @@ interactions:
       content-type:
       - text/plain
       date:
-      - Fri, 12 Dec 2025 15:21:59 GMT
+      - Thu, 11 Jun 2026 10:33:41 GMT
       etag:
-      - '"0x2567743E5060A80"'
+      - '"0x20402B2AAF5DD00"'
       last-modified:
-      - Fri, 12 Dec 2025 15:21:59 GMT
+      - Thu, 11 Jun 2026 10:33:41 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Fri, 12 Dec 2025 15:21:59 GMT
+      - Thu, 11 Jun 2026 10:33:41 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4d3d3c4d-d76e-11f0-b763-f4289da6022f
+      - 432a6001-cead-11f0-a2d3-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:21:59 GMT
+      - Thu, 11 Jun 2026 10:33:41 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - e2efff7a-3765-42f1-884f-2dc8a11200dd
+      - a7b0bb8f-f62e-4d41-adf5-b7ff5b422291
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -136,16 +132,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:2wDjGwyKqhTqFK3x/psjgcdjYYPk0cEm+qD9yFuU2qI=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 4d3d3c4e-d76e-11f0-b763-f4289da6022f
+      - 432a6002-cead-11f0-a62c-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:21:59 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
@@ -171,25 +165,25 @@ interactions:
       content-type:
       - text/plain
       date:
-      - Fri, 12 Dec 2025 15:21:59 GMT
+      - Thu, 11 Jun 2026 10:33:41 GMT
       etag:
-      - '"0x2567743E5060A80"'
+      - '"0x20402B2AAF5DD00"'
       last-modified:
-      - Fri, 12 Dec 2025 15:21:59 GMT
+      - Thu, 11 Jun 2026 10:33:41 GMT
       x-ms-blob-content-md5:
       - vd7zzIWI+8ImXl1GAHmsgA==
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4d3d3c4e-d76e-11f0-b763-f4289da6022f
+      - 432a6002-cead-11f0-a62c-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:21:59 GMT
+      - Thu, 11 Jun 2026 10:33:41 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 0b74583d-cb46-47b6-9c0f-599669048403
+      - b318385e-63bd-49a6-9c1c-7576069649d2
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/LargeFileAPITests/test_update_metadata_set_size_zero.yaml
+++ b/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/LargeFileAPITests/test_update_metadata_set_size_zero.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:1SFHbSgKSSf7lZFYiMeudcWAwekW4FAK24Xwg4+HNeQ=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4e80356e-d76e-11f0-b763-f4289da6022f
+      - 432a6003-cead-11f0-9652-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:01 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - 1B2M2Y8AsgTpgAmY7PhCfg==
       date:
-      - Fri, 12 Dec 2025 15:22:01 GMT
+      - Thu, 11 Jun 2026 10:33:42 GMT
       etag:
-      - '"0x1CFA36E9EC943A0"'
+      - '"0x270DA274509FA20"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:01 GMT
+      - Thu, 11 Jun 2026 10:33:42 GMT
       x-ms-client-request-id:
-      - 4e80356e-d76e-11f0-b763-f4289da6022f
+      - 432a6003-cead-11f0-9652-a82bdd58bc01
       x-ms-request-id:
-      - 0247b2a5-bfdf-4402-8f9e-c7658fa30a3d
+      - 7cc3aec9-cb89-4e76-849b-a19e5493669e
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/SmallFileUpload/test_create_eio.yaml
+++ b/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/SmallFileUpload/test_create_eio.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:UUWeBVAxDZvMRuWOVfv8E9cF+lQ7mMqnbMC57yQLBI4=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4e80356f-d76e-11f0-b763-f4289da6022f
+      - 432a6000-cead-11f0-9160-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:02 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - J8OgCaPLumdNCz6Dby1GhQ==
       date:
-      - Fri, 12 Dec 2025 15:22:02 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       etag:
-      - '"0x1B9EDE4AE6F3360"'
+      - '"0x254C4BBE73B3880"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:02 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-client-request-id:
-      - 4e80356f-d76e-11f0-b763-f4289da6022f
+      - 432a6000-cead-11f0-9160-a82bdd58bc01
       x-ms-request-id:
-      - e3bb82b4-fd74-4fbc-bf5d-783f50533028
+      - af3ac874-dbdd-4ef9-8506-34f37db52ab1
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -66,16 +64,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:o9kjhW5soPUAqkJ/iYavXLZKGoR0WdqcYDieamsAbvQ=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 4e803570-d76e-11f0-b763-f4289da6022f
+      - 432a6001-cead-11f0-9dbd-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:02 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
@@ -101,25 +97,25 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 12 Dec 2025 15:22:02 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       etag:
-      - '"0x1B9EDE4AE6F3360"'
+      - '"0x254C4BBE73B3880"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:02 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-blob-content-md5:
       - J8OgCaPLumdNCz6Dby1GhQ==
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4e803570-d76e-11f0-b763-f4289da6022f
+      - 432a6001-cead-11f0-9dbd-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:22:02 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - f3d56718-cdd4-46b3-bd22-0e5cc849f3e4
+      - 2a01f5cd-3894-45dc-8b14-a8f843f95aa3
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/SmallFileUpload/test_create_empty_file.yaml
+++ b/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/SmallFileUpload/test_create_empty_file.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:g/ngpR5iyQi16qnAQFP/PPsPChF++y9Zf0JWqIuYIpw=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4e803571-d76e-11f0-b763-f4289da6022f
+      - 432a6002-cead-11f0-8dfc-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:02 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - 1B2M2Y8AsgTpgAmY7PhCfg==
       date:
-      - Fri, 12 Dec 2025 15:22:02 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       etag:
-      - '"0x1C4DE572D259730"'
+      - '"0x1F8E12C7CE101E0"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:02 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-client-request-id:
-      - 4e803571-d76e-11f0-b763-f4289da6022f
+      - 432a6002-cead-11f0-8dfc-a82bdd58bc01
       x-ms-request-id:
-      - dd7c9805-1b43-4b9a-ac1c-7b5a012780bb
+      - 49a3b6d8-ec2f-432a-9cbe-df814962dfe6
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -66,16 +64,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:BEwc/PO1p1JEeDW5H1iNo8BZCbQzsMTS9jcTsEwaNs0=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 4e803572-d76e-11f0-b763-f4289da6022f
+      - 432a6003-cead-11f0-84f9-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:02 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
@@ -86,14 +82,14 @@ interactions:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<Error>\n
         \ <Code>InvalidRange</Code>\n  <Message>The range specified is invalid for
-        the current size of the resource.\nRequestId:765a51a6-947d-4863-a90f-892b4797e96e\nTime:2025-12-12T15:22:02.884Z</Message>\n</Error>"
+        the current size of the resource.\nRequestId:dc6bc806-ece7-43e0-ad53-8ba192957f3a\nTime:2026-06-11T10:33:43.365Z</Message>\n</Error>"
     headers:
       Connection:
       - keep-alive
       Content-Range:
       - bytes */0
       Date:
-      - Fri, 12 Dec 2025 15:22:02 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       Keep-Alive:
       - timeout=5
       Server:
@@ -105,7 +101,7 @@ interactions:
       x-ms-error-code:
       - InvalidRange
       x-ms-request-id:
-      - 765a51a6-947d-4863-a90f-892b4797e96e
+      - dc6bc806-ece7-43e0-ad53-8ba192957f3a
     status:
       code: 416
       message: The range specified is invalid for the current size of the resource.
@@ -116,16 +112,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:qKtzUB8M1tayElpxw6iAX2HBUn1EO0JelDWQ3TRYKKw=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 4e803573-d76e-11f0-b763-f4289da6022f
+      - 432a6004-cead-11f0-88dc-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:02 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: GET
@@ -149,25 +143,25 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 12 Dec 2025 15:22:02 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       etag:
-      - '"0x1C4DE572D259730"'
+      - '"0x1F8E12C7CE101E0"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:02 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-blob-content-md5:
       - 1B2M2Y8AsgTpgAmY7PhCfg==
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4e803573-d76e-11f0-b763-f4289da6022f
+      - 432a6004-cead-11f0-88dc-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:22:02 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 6ab053b1-d542-4c31-8066-ce933a9cb784
+      - 6caae779-da92-4a5b-987e-44fb667c8172
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/SmallFileUpload/test_update_eio_file.yaml
+++ b/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/SmallFileUpload/test_update_eio_file.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:Iu7hdeYcLzKdsI1LwdjUrbaHmLat+sr0W5t51VIneyU=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4fb4a398-d76e-11f0-b763-f4289da6022f
+      - 432a6005-cead-11f0-b353-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - HlAhCgICSX+3m8OLat5sNA==
       date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       etag:
-      - '"0x21F8E6EFB4272C0"'
+      - '"0x254FF0D8985BDA0"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-client-request-id:
-      - 4fb4a398-d76e-11f0-b763-f4289da6022f
+      - 432a6005-cead-11f0-b353-a82bdd58bc01
       x-ms-request-id:
-      - 339b9fb4-e2f9-41ad-8653-2af8365b8eb9
+      - 8582157b-9ce7-4418-a724-f01586bbd586
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -66,8 +64,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:QRyYuxEe4IzlvnzHV9NczzdRYwdDd11ZkdFXb/nJgGU=
       Connection:
       - keep-alive
       Content-Length:
@@ -75,15 +71,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4fb4a399-d76e-11f0-b763-f4289da6022f
+      - 432a6006-cead-11f0-a6d5-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -103,15 +99,15 @@ interactions:
       content-md5:
       - qF8rQYcoYZzC4vgkB0Utcw==
       date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       etag:
-      - '"0x2067DCFFD2B58A0"'
+      - '"0x241EFB550182340"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-client-request-id:
-      - 4fb4a399-d76e-11f0-b763-f4289da6022f
+      - 432a6006-cead-11f0-a6d5-a82bdd58bc01
       x-ms-request-id:
-      - 95ec20c2-eda8-4438-88df-72d99494ae7d
+      - 187c1377-4c3a-49ef-99d2-ea12aa310afb
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -126,16 +122,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:4XKjcUo0UPTPM5izAzCjBtZIJ7/GdhCTh8tp9Bu5Tn0=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 4fb4a39a-d76e-11f0-b763-f4289da6022f
+      - 432a6007-cead-11f0-828d-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
@@ -161,25 +155,25 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       etag:
-      - '"0x2067DCFFD2B58A0"'
+      - '"0x241EFB550182340"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-blob-content-md5:
       - qF8rQYcoYZzC4vgkB0Utcw==
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4fb4a39a-d76e-11f0-b763-f4289da6022f
+      - 432a6007-cead-11f0-828d-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 991970ce-ad9f-4fc2-9c70-3b34b81fff93
+      - 06cce750-c151-432f-b567-2855dbdd7802
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/SmallFileUpload/test_update_eio_file_set_empty.yaml
+++ b/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/SmallFileUpload/test_update_eio_file_set_empty.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:2AYszugniy/NFrkor2/P8I5DlI38Ix7b+wSMyZq59bs=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4fb4a39b-d76e-11f0-b763-f4289da6022f
+      - 432a6008-cead-11f0-a667-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - HlAhCgICSX+3m8OLat5sNA==
       date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       etag:
-      - '"0x1EBB86CA4962770"'
+      - '"0x203BEA8D0C504A0"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-client-request-id:
-      - 4fb4a39b-d76e-11f0-b763-f4289da6022f
+      - 432a6008-cead-11f0-a667-a82bdd58bc01
       x-ms-request-id:
-      - 7773d564-a739-4227-95ce-548c431bdfcb
+      - 615c2062-2f8f-4e2e-a607-6598b606681d
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/SmallFileUpload/test_update_eio_metadata.yaml
+++ b/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/SmallFileUpload/test_update_eio_metadata.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:ggdUdJRkU0GMFPf5yUh5gy9gkPZpSmks1vYlxjdeXno=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4fb4a39c-d76e-11f0-b763-f4289da6022f
+      - 432a6009-cead-11f0-9e93-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - gdyb21LQTcIANtvYMT7QVQ==
       date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       etag:
-      - '"0x204307F8843D720"'
+      - '"0x1F70685E8C86630"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-client-request-id:
-      - 4fb4a39c-d76e-11f0-b763-f4289da6022f
+      - 432a6009-cead-11f0-9e93-a82bdd58bc01
       x-ms-request-id:
-      - 711b0093-9592-4609-9b00-ba8ba3d152c6
+      - 8ac38150-9a5e-40ba-8e66-1957166d6a1c
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -66,16 +64,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:RH1E0j+eYtWGzlA8PVOPiLD8Vbe5JqyXbWyFwZHEQHg=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 4fb4a39d-d76e-11f0-b763-f4289da6022f
+      - 432a600a-cead-11f0-b00f-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -99,29 +95,29 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       etag:
-      - '"0x204307F8843D720"'
+      - '"0x1F70685E8C86630"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4fb4a39d-d76e-11f0-b763-f4289da6022f
+      - 432a600a-cead-11f0-b00f-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 0337dd39-2e3c-4b5c-81d8-59899274c247
+      - f6244a2b-b255-4ae6-b2c2-4cb800ddefd3
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -136,16 +132,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:C1ulhME0sUBq9OmClxZ+PDi58Hvu3tt5Iagar/z4eC4=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 4fb4a39e-d76e-11f0-b763-f4289da6022f
+      - 432a600b-cead-11f0-8d6a-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
@@ -171,25 +165,25 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       etag:
-      - '"0x204307F8843D720"'
+      - '"0x1F70685E8C86630"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-blob-content-md5:
       - gdyb21LQTcIANtvYMT7QVQ==
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4fb4a39e-d76e-11f0-b763-f4289da6022f
+      - 432a600b-cead-11f0-8d6a-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 555c8907-7e39-4102-bcae-c081cce083aa
+      - d2da421b-4c9f-4301-9a12-4c19502278b3
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -204,16 +198,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:179Uy5u3YgL41ayiDCAj84AteZs6yri6/oMxMKQvI70=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 4fb4a39f-d76e-11f0-b763-f4289da6022f
+      - 432a600c-cead-11f0-9924-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
@@ -239,25 +231,25 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       etag:
-      - '"0x204307F8843D720"'
+      - '"0x1F70685E8C86630"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-blob-content-md5:
       - gdyb21LQTcIANtvYMT7QVQ==
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4fb4a39f-d76e-11f0-b763-f4289da6022f
+      - 432a600c-cead-11f0-9924-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 807d2160-5bae-4848-a5a3-09ff0c7d6f96
+      - 29d58a71-6482-4ec4-b20e-7fb4de833d5e
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/SmallFileUpload/test_update_eio_only_file_without_size.yaml
+++ b/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/SmallFileUpload/test_update_eio_only_file_without_size.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:MLIRQITPHj8XOIW5Y7GAAYgjrRpb++5OgcGBWOeryVw=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4fb4a3a0-d76e-11f0-b763-f4289da6022f
+      - 432a600d-cead-11f0-828a-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - HlAhCgICSX+3m8OLat5sNA==
       date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       etag:
-      - '"0x2042D4962BC3740"'
+      - '"0x1ED7D3B16122A90"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-client-request-id:
-      - 4fb4a3a0-d76e-11f0-b763-f4289da6022f
+      - 432a600d-cead-11f0-828a-a82bdd58bc01
       x-ms-request-id:
-      - 4491d4fb-da6d-4176-99ef-152bf14c62b4
+      - ad8c99f7-2fef-44ac-ad46-c1cd702068df
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/SmallFileUpload/test_update_eio_only_size.yaml
+++ b/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/SmallFileUpload/test_update_eio_only_size.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:BTedTNlFQIiLspwx/EmR4gGpj/4mxM6oOMPGs/MnY6c=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4fb4a3a1-d76e-11f0-b763-f4289da6022f
+      - 432a600e-cead-11f0-acaa-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - HlAhCgICSX+3m8OLat5sNA==
       date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       etag:
-      - '"0x1F30251988E9360"'
+      - '"0x2442ECC0A95B8A0"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-client-request-id:
-      - 4fb4a3a1-d76e-11f0-b763-f4289da6022f
+      - 432a600e-cead-11f0-acaa-a82bdd58bc01
       x-ms-request-id:
-      - 88888e8f-fa62-4506-b316-5d2c027d0b90
+      - eb258fbc-9e1f-419b-8672-eb91746ac2f4
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -66,16 +64,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:kacbIWkqvssUk2rFuESAw3ITt1snU0qPzJfASq5p7Hk=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 4fb4a3a2-d76e-11f0-b763-f4289da6022f
+      - 432a600f-cead-11f0-81cb-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -99,29 +95,29 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       etag:
-      - '"0x1F30251988E9360"'
+      - '"0x2442ECC0A95B8A0"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4fb4a3a2-d76e-11f0-b763-f4289da6022f
+      - 432a600f-cead-11f0-81cb-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - b00c93bb-310c-456e-82a3-f40d62a61251
+      - 8354e5c6-35aa-4add-83af-54baad3eac08
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/SmallFileUpload/test_update_eio_put.yaml
+++ b/src/openzaak/components/documenten/tests/azure/files/vcr_cassettes/SmallFileUpload/test_update_eio_put.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:IYWAP0w+IHvlVnAAJxixleN1AxR2UTHFcquPyOqLjpI=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4fb4a3a3-d76e-11f0-b763-f4289da6022f
+      - 432a6010-cead-11f0-8fad-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - HlAhCgICSX+3m8OLat5sNA==
       date:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       etag:
-      - '"0x21AC53CE7E7A820"'
+      - '"0x235E00C73274A60"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:03 GMT
+      - Thu, 11 Jun 2026 10:33:43 GMT
       x-ms-client-request-id:
-      - 4fb4a3a3-d76e-11f0-b763-f4289da6022f
+      - 432a6010-cead-11f0-8fad-a82bdd58bc01
       x-ms-request-id:
-      - 562b08a7-06ff-4430-8d56-aef3cb37072d
+      - b4f3c02b-4063-4d78-913d-6dbbc42433d2
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -66,8 +64,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:36vlDhLl2hxbZKV235ZOt9YoDRdZ5JRUWR7td56gIoE=
       Connection:
       - keep-alive
       Content-Length:
@@ -75,15 +71,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4fb4a3a4-d76e-11f0-b763-f4289da6022f
+      - 432a6011-cead-11f0-a27c-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:04 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -103,15 +99,15 @@ interactions:
       content-md5:
       - WU+AOzgKQTlu1j3KOVA1Qg==
       date:
-      - Fri, 12 Dec 2025 15:22:04 GMT
+      - Thu, 11 Jun 2026 10:33:44 GMT
       etag:
-      - '"0x26384DAB722B120"'
+      - '"0x209D6B060DBD8A0"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:04 GMT
+      - Thu, 11 Jun 2026 10:33:44 GMT
       x-ms-client-request-id:
-      - 4fb4a3a4-d76e-11f0-b763-f4289da6022f
+      - 432a6011-cead-11f0-a27c-a82bdd58bc01
       x-ms-request-id:
-      - 190c2856-d381-4e7f-aeb7-119e1cda9070
+      - 0ba1fea1-6d93-496d-acd6-59ff31276f3a
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -126,16 +122,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:dbXg+2kaZ1W5PfIXJmpmD3w6oorNuA3xYGL3134jyFc=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 4fb4a3a5-d76e-11f0-b763-f4289da6022f
+      - 432a6012-cead-11f0-8b4f-a82bdd58bc01
       x-ms-date:
-      - Fri, 12 Dec 2025 15:22:04 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
@@ -161,25 +155,25 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 12 Dec 2025 15:22:04 GMT
+      - Thu, 11 Jun 2026 10:33:44 GMT
       etag:
-      - '"0x26384DAB722B120"'
+      - '"0x209D6B060DBD8A0"'
       last-modified:
-      - Fri, 12 Dec 2025 15:22:04 GMT
+      - Thu, 11 Jun 2026 10:33:44 GMT
       x-ms-blob-content-md5:
       - WU+AOzgKQTlu1j3KOVA1Qg==
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 4fb4a3a5-d76e-11f0-b763-f4289da6022f
+      - 432a6012-cead-11f0-8b4f-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 12 Dec 2025 15:22:04 GMT
+      - Thu, 11 Jun 2026 10:33:44 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 9b56fedb-55d5-4210-853d-f4208de74f1b
+      - a32e03d9-9dde-4169-8cf2-0a2f1362c300
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_all_fields.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_all_fields.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:PphbYIe/e9sATKKYO2cCipPk4ywTd2VzFf5MoALTDu0=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - text/plain
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 56584958-dc27-11f0-b763-f4289da6022f
+      - 432a6000-cead-11f0-aa3f-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:35 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - 0Z/SbkbbQS/tG4uU0xTrww==
       date:
-      - Thu, 18 Dec 2025 15:36:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x1D78ADB99A259D0"'
+      - '"0x23DB3F2E019C2C0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-client-request-id:
-      - 56584958-dc27-11f0-b763-f4289da6022f
+      - 432a6000-cead-11f0-aa3f-a82bdd58bc01
       x-ms-request-id:
-      - ad775911-1673-4abf-a525-d88eb630907d
+      - 9fb2c825-3ca3-44bd-9ee2-0192bbb2c845
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -66,16 +64,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:WaDqHQblyOdsLHFyOiunLeQM2nraRZC/c0Xsolonuv8=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 56584959-dc27-11f0-b763-f4289da6022f
+      - 432a6001-cead-11f0-8dc8-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:35 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
@@ -101,25 +97,25 @@ interactions:
       content-type:
       - text/plain
       date:
-      - Thu, 18 Dec 2025 15:36:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x1D78ADB99A259D0"'
+      - '"0x23DB3F2E019C2C0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-blob-content-md5:
       - 0Z/SbkbbQS/tG4uU0xTrww==
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 56584959-dc27-11f0-b763-f4289da6022f
+      - 432a6001-cead-11f0-8dc8-a82bdd58bc01
       x-ms-creation-time:
-      - Thu, 18 Dec 2025 15:36:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 1e8598d0-ef24-43cc-9cef-b9067c9b60cf
+      - 6a667b2c-1be7-4c46-a541-a2b253710565
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -134,16 +130,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:FL5kO9are58v4MwfUQzsYDeu9EQJtLBM4Wd/jBewXMY=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5658495a-dc27-11f0-b763-f4289da6022f
+      - 432a6002-cead-11f0-8eb5-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:35 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -167,29 +161,29 @@ interactions:
       content-type:
       - text/plain
       date:
-      - Thu, 18 Dec 2025 15:36:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x1D78ADB99A259D0"'
+      - '"0x23DB3F2E019C2C0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Thu, 18 Dec 2025 15:36:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5658495a-dc27-11f0-b763-f4289da6022f
+      - 432a6002-cead-11f0-8eb5-a82bdd58bc01
       x-ms-creation-time:
-      - Thu, 18 Dec 2025 15:36:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 8b1d1a43-031c-4e83-8b74-adae9288f1ca
+      - f512448a-c646-4884-b5e8-76ee4601e7db
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_directory_as_path.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_directory_as_path.yaml
@@ -6,16 +6,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:m6Kf1XkMLYHlt+zKItAJzu0dTjgzjfCQPd9EUol0Xzk=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5658495b-dc27-11f0-b763-f4289da6022f
+      - 432a6003-cead-11f0-b4b6-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:35 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -27,7 +25,7 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Thu, 18 Dec 2025 15:36:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       Keep-Alive:
       - timeout=5
       Server:
@@ -35,7 +33,7 @@ interactions:
       x-ms-error-code:
       - BlobNotFound
       x-ms-request-id:
-      - 8ee6eae0-234a-4f75-bc28-550b158eb1de
+      - b7cf08a8-3e53-448f-9641-e4dd9ad9d774
     status:
       code: 404
       message: The specified blob does not exist.

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_existing_uuid.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_existing_uuid.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:/EoF8jUXldRjmf/ZMTE2de1N8ZKiG3lVW+ORvGyTPAQ=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5658495c-dc27-11f0-b763-f4289da6022f
+      - 432a6004-cead-11f0-aeba-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:35 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - HlAhCgICSX+3m8OLat5sNA==
       date:
-      - Thu, 18 Dec 2025 15:36:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x226E348C12BDA00"'
+      - '"0x2234219E0ECB560"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-client-request-id:
-      - 5658495c-dc27-11f0-b763-f4289da6022f
+      - 432a6004-cead-11f0-aeba-a82bdd58bc01
       x-ms-request-id:
-      - 59bca020-2a24-4ef8-a61d-df8b64a91331
+      - 1b6124d6-5fdc-43bb-af0e-754f8794bb3b
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -66,16 +64,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:xum9o5WTe+0ewndD021KPknaZDRoQtkrLXq6EyAmmEA=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5658495d-dc27-11f0-b763-f4289da6022f
+      - 432a6005-cead-11f0-848a-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -87,7 +83,7 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       Keep-Alive:
       - timeout=5
       Server:
@@ -95,7 +91,7 @@ interactions:
       x-ms-error-code:
       - BlobNotFound
       x-ms-request-id:
-      - c4f7a3d4-4753-4553-85e0-c27444d944dc
+      - 7704fb12-7269-4f23-a23d-2a8bb7e23956
     status:
       code: 404
       message: The specified blob does not exist.

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_invalid_host_header.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_invalid_host_header.yaml
@@ -6,16 +6,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:Eh0NSg14X6Yo5sR0qpWdQ3lp6ovvCVfRXDyeWa+5KPk=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5658495e-dc27-11f0-b763-f4289da6022f
+      - 432a6006-cead-11f0-8644-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -27,7 +25,7 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       Keep-Alive:
       - timeout=5
       Server:
@@ -35,7 +33,7 @@ interactions:
       x-ms-error-code:
       - BlobNotFound
       x-ms-request-id:
-      - d7cd5187-9967-42fa-b42d-fd21ff8e6bae
+      - d6843dda-2b90-4a46-b4fc-77c0874cbf01
     status:
       code: 404
       message: The specified blob does not exist.

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_invalid_uuid.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_invalid_uuid.yaml
@@ -6,16 +6,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:3j9Bu+8CXMDqxUz/sX/ZcmjXpHtGe0wH2apOWeHLh84=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5658495f-dc27-11f0-b763-f4289da6022f
+      - 432a6007-cead-11f0-b719-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -27,7 +25,7 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       Keep-Alive:
       - timeout=5
       Server:
@@ -35,7 +33,7 @@ interactions:
       x-ms-error-code:
       - BlobNotFound
       x-ms-request-id:
-      - d47ce7c9-f858-4bb8-ae22-94854808703a
+      - 9bdcf900-c174-47b1-8217-435d75fe7d36
     status:
       code: 404
       message: The specified blob does not exist.

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_lower_column_count.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_lower_column_count.yaml
@@ -6,16 +6,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:K2srJr7GF2lTIq5+hv/NXus32tvCQEE1IXQ0FHJyueo=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 56584960-dc27-11f0-b763-f4289da6022f
+      - 432a6008-cead-11f0-9e04-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -27,7 +25,7 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       Keep-Alive:
       - timeout=5
       Server:
@@ -35,7 +33,7 @@ interactions:
       x-ms-error-code:
       - BlobNotFound
       x-ms-request-id:
-      - 2525d252-f504-4b36-b973-b45a71a017d4
+      - 99c44653-1e2d-4a63-9b67-cd335dc29f67
     status:
       code: 404
       message: The specified blob does not exist.

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_minimum_fields.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_minimum_fields.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:0Aou76wqb1pBfU2MoMbZDaE4fmcXl6k0gdmN99YzcDI=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - text/plain
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 56584961-dc27-11f0-b763-f4289da6022f
+      - 432a6009-cead-11f0-94f3-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - 7z9xyOFXz/f4/2E36ZeTAQ==
       date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x258175DA4BE4B60"'
+      - '"0x23603AFEE7975A0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-client-request-id:
-      - 56584961-dc27-11f0-b763-f4289da6022f
+      - 432a6009-cead-11f0-94f3-a82bdd58bc01
       x-ms-request-id:
-      - b15ec454-5253-4ab6-9345-cec50e145333
+      - f4776ad9-6a69-48af-9d65-43d5cbda3cf7
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -66,16 +64,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:hQ3+mMnhQFo+qPezemIh9VREDST1NjyVRxQhnf+90vg=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 56584962-dc27-11f0-b763-f4289da6022f
+      - 432a600a-cead-11f0-bd3b-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
@@ -101,25 +97,25 @@ interactions:
       content-type:
       - text/plain
       date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x258175DA4BE4B60"'
+      - '"0x23603AFEE7975A0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-blob-content-md5:
       - 7z9xyOFXz/f4/2E36ZeTAQ==
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 56584962-dc27-11f0-b763-f4289da6022f
+      - 432a600a-cead-11f0-bd3b-a82bdd58bc01
       x-ms-creation-time:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 90f13929-9c94-4e75-bc4a-c604398390d8
+      - 3858d178-2ce8-40f9-8d61-984f0c4cf5e9
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -134,16 +130,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:cDYcMuj8cMVxxrbIIVMAXH/5cbiI/r8xQmPijr6eukE=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 56584963-dc27-11f0-b763-f4289da6022f
+      - 432a600b-cead-11f0-baa3-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -167,29 +161,29 @@ interactions:
       content-type:
       - text/plain
       date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x258175DA4BE4B60"'
+      - '"0x23603AFEE7975A0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 56584963-dc27-11f0-b763-f4289da6022f
+      - 432a600b-cead-11f0-baa3-a82bdd58bc01
       x-ms-creation-time:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 9f5c8d8d-7bc8-411a-a6c7-4ee05f08aec1
+      - 53a12175-c3f3-4a62-8c69-f8590ff4ac3e
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_non_existent_file.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_non_existent_file.yaml
@@ -6,16 +6,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:9mlRWhRA/d3QrADzTo6HDgU2M8sQBq7piDKFgR5jb/k=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 56584964-dc27-11f0-b763-f4289da6022f
+      - 432a600c-cead-11f0-a7ef-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -27,7 +25,7 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       Keep-Alive:
       - timeout=5
       Server:
@@ -35,7 +33,7 @@ interactions:
       x-ms-error-code:
       - BlobNotFound
       x-ms-request-id:
-      - 49bec07a-c3db-4ca4-a17d-8ca8d86ec03e
+      - 88f7d1c7-930a-4bed-a762-d672a1300e26
     status:
       code: 404
       message: The specified blob does not exist.

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_unable_to_copy_file.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_unable_to_copy_file.yaml
@@ -6,16 +6,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:3XjUmZyXVfBPluirwHBixjOhPpc9or/jsb+T+ZqV3uI=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 56584965-dc27-11f0-b763-f4289da6022f
+      - 432a600d-cead-11f0-b9c9-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -27,7 +25,7 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       Keep-Alive:
       - timeout=5
       Server:
@@ -35,7 +33,7 @@ interactions:
       x-ms-error-code:
       - BlobNotFound
       x-ms-request-id:
-      - 7e7b6d55-cfe6-4c75-a3b2-23dec874c25b
+      - 146d4599-b71d-436b-87d2-03fc1d88a1c0
     status:
       code: 404
       message: The specified blob does not exist.

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_unknown_zaak_uuid.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_unknown_zaak_uuid.yaml
@@ -6,16 +6,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:iEDoamZNpvroRL0eJ4KyrhLlDBnKAH8QvCdSFPAHZjE=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 56584966-dc27-11f0-b763-f4289da6022f
+      - 432a600e-cead-11f0-bd27-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -27,7 +25,7 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       Keep-Alive:
       - timeout=5
       Server:
@@ -35,7 +33,7 @@ interactions:
       x-ms-error-code:
       - BlobNotFound
       x-ms-request-id:
-      - d06e956d-75ae-44d9-9bb8-7264775f2ad7
+      - c483c2b5-be7d-48ae-8c96-96b309c43ee8
     status:
       code: 404
       message: The specified blob does not exist.

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_upload_dir_does_not_exist.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_upload_dir_does_not_exist.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:QcJw25kmVZMEacwd8D+1BqL7U/nYd3aCKoMO22mFlqI=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - text/plain
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 56584967-dc27-11f0-b763-f4289da6022f
+      - 432a600f-cead-11f0-820f-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - 7z9xyOFXz/f4/2E36ZeTAQ==
       date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x251E2CD1337F460"'
+      - '"0x258AF7E651CD000"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-client-request-id:
-      - 56584967-dc27-11f0-b763-f4289da6022f
+      - 432a600f-cead-11f0-820f-a82bdd58bc01
       x-ms-request-id:
-      - be02e476-5e46-4c43-94b6-712b43507a2a
+      - 5b877014-c103-43dc-a1bf-f7fecd1a5d0f
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -66,16 +64,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:GvvQHa8mCkTIbs3ihswLcuTtGxVj0LS/ybkFYH3W6A4=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 56584968-dc27-11f0-b763-f4289da6022f
+      - 432a6010-cead-11f0-8c1e-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-range:
       - bytes=0-33554431
       x-ms-version:
@@ -101,25 +97,25 @@ interactions:
       content-type:
       - text/plain
       date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x251E2CD1337F460"'
+      - '"0x258AF7E651CD000"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-blob-content-md5:
       - 7z9xyOFXz/f4/2E36ZeTAQ==
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 56584968-dc27-11f0-b763-f4289da6022f
+      - 432a6010-cead-11f0-8c1e-a82bdd58bc01
       x-ms-creation-time:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - e11db3ad-097b-4464-b45f-144581c6f3bc
+      - 59a40bfc-ef45-417b-ab13-8e279c4eab53
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -134,16 +130,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:+HWvzEUmX7nFFY4RLWSZJc0lZeID+PXs1Fd2uPV3BIA=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 56584969-dc27-11f0-b763-f4289da6022f
+      - 432a6011-cead-11f0-9946-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -167,29 +161,29 @@ interactions:
       content-type:
       - text/plain
       date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x251E2CD1337F460"'
+      - '"0x258AF7E651CD000"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 56584969-dc27-11f0-b763-f4289da6022f
+      - 432a6011-cead-11f0-9946-a82bdd58bc01
       x-ms-creation-time:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 5e0de100-aa5b-4b55-8b14-f7e196a72973
+      - fa424a78-26a9-47f2-86d7-ec938399f166
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_validation_error.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowTests/test_validation_error.yaml
@@ -6,16 +6,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:VmRZhzOKd5pgmGEE3PkAFcy4LZyirAP4EKdGnb+zMIM=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5658496a-dc27-11f0-b763-f4289da6022f
+      - 432a6012-cead-11f0-8b74-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -27,7 +25,7 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       Keep-Alive:
       - timeout=5
       Server:
@@ -35,7 +33,7 @@ interactions:
       x-ms-error-code:
       - BlobNotFound
       x-ms-request-id:
-      - ec92ca3a-8db4-43cb-9fb4-64fc84d69064
+      - c907e894-1446-45dd-8a37-faaa67cc6908
     status:
       code: 404
       message: The specified blob does not exist.

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowWithoutOverwriteTests/test_file_already_exists_in_storage.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentRowWithoutOverwriteTests/test_file_already_exists_in_storage.yaml
@@ -6,14 +6,12 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:Mtp0rckOn0fjwfN1TmKZn+JYSCeZKS1IGVFrn3hQC2Y=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1018-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 737d6000-6318-11f5-b822-a82bdd58bc01
+      - 737d6000-6318-11f5-bf74-a82bdd58bc01
       x-ms-date:
       - Tue, 01 Jan 2030 12:00:00 GMT
       x-ms-version:
@@ -27,7 +25,7 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 19 Dec 2025 14:48:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       Keep-Alive:
       - timeout=5
       Server:
@@ -35,7 +33,7 @@ interactions:
       x-ms-error-code:
       - BlobNotFound
       x-ms-request-id:
-      - 912ae3bb-aca6-4b94-a726-20b8e669d55e
+      - 237c08fc-5db7-4d4a-bd84-d72f0e4e100f
     status:
       code: 404
       message: The specified blob does not exist.
@@ -46,8 +44,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:tOUMWj7Py2IXgsZRnmRJo0vmQW9OxgbHhtE4cvHfGqs=
       Connection:
       - keep-alive
       Content-Length:
@@ -57,13 +53,13 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1018-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - text/plain
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 737d6001-6318-11f5-9411-a82bdd58bc01
+      - 737d6001-6318-11f5-ab7c-a82bdd58bc01
       x-ms-date:
       - Tue, 01 Jan 2030 12:00:00 GMT
       x-ms-version:
@@ -85,15 +81,15 @@ interactions:
       content-md5:
       - ECd5Z2/u/9OF9wOFQsBUQQ==
       date:
-      - Fri, 19 Dec 2025 14:48:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x1E7BDA1C2C4E820"'
+      - '"0x2736F19918E97A0"'
       last-modified:
-      - Fri, 19 Dec 2025 14:48:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-client-request-id:
-      - 737d6001-6318-11f5-9411-a82bdd58bc01
+      - 737d6001-6318-11f5-ab7c-a82bdd58bc01
       x-ms-request-id:
-      - 4299124b-59b1-48af-a994-847182b1cbd6
+      - ca95d051-16f2-4b23-99c1-59e929c61637
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -108,14 +104,12 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:mQ0296XYk7WjcTQlCm2t/4crnL5AyLW+ww07wN5eRtc=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1018-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 737d6002-6318-11f5-a952-a82bdd58bc01
+      - 737d6002-6318-11f5-bdb8-a82bdd58bc01
       x-ms-date:
       - Tue, 01 Jan 2030 12:00:00 GMT
       x-ms-version:
@@ -141,29 +135,29 @@ interactions:
       content-type:
       - text/plain
       date:
-      - Fri, 19 Dec 2025 14:48:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x1E7BDA1C2C4E820"'
+      - '"0x2736F19918E97A0"'
       last-modified:
-      - Fri, 19 Dec 2025 14:48:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Fri, 19 Dec 2025 14:48:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 737d6002-6318-11f5-a952-a82bdd58bc01
+      - 737d6002-6318-11f5-bdb8-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 19 Dec 2025 14:48:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - ab82a481-df2c-4bdd-95a3-7e6b4434c63a
+      - a4799ef8-274d-4fdd-be79-e4137c5ad641
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -178,14 +172,12 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:leN7RZYIQ+B6y0wpccRr4gstvwooT9fnl2kT74TAsVw=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1018-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 737d6003-6318-11f5-af2b-a82bdd58bc01
+      - 737d6003-6318-11f5-a1e9-a82bdd58bc01
       x-ms-date:
       - Tue, 01 Jan 2030 12:00:00 GMT
       x-ms-version:
@@ -199,7 +191,7 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 19 Dec 2025 14:48:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       Keep-Alive:
       - timeout=5
       Server:
@@ -207,7 +199,7 @@ interactions:
       x-ms-error-code:
       - BlobNotFound
       x-ms-request-id:
-      - 2da5857b-4d54-4984-ae82-49af2cff0167
+      - 642b808d-169d-428c-81db-12ce5c2f8284
     status:
       code: 404
       message: The specified blob does not exist.
@@ -218,8 +210,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:wA0Ag8TWVKC9SICddWqbG8kpBGi0e/xWNAd3dcWuWHo=
       Connection:
       - keep-alive
       Content-Length:
@@ -229,13 +219,13 @@ interactions:
       If-None-Match:
       - '*'
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1018-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - text/plain
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 737d6004-6318-11f5-8793-a82bdd58bc01
+      - 737d6004-6318-11f5-8674-a82bdd58bc01
       x-ms-date:
       - Tue, 01 Jan 2030 12:00:00 GMT
       x-ms-version:
@@ -257,15 +247,15 @@ interactions:
       content-md5:
       - ECd5Z2/u/9OF9wOFQsBUQQ==
       date:
-      - Fri, 19 Dec 2025 14:48:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x23EEBB15D193D00"'
+      - '"0x2512AF8ABDB4F80"'
       last-modified:
-      - Fri, 19 Dec 2025 14:48:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-client-request-id:
-      - 737d6004-6318-11f5-8793-a82bdd58bc01
+      - 737d6004-6318-11f5-8674-a82bdd58bc01
       x-ms-request-id:
-      - 60bcbc93-6a25-4a31-b0f7-5ec3b1e2b19a
+      - 690370d8-a819-44b4-a323-ca9e42bf4636
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -280,14 +270,12 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:8e/qlXlgn0OnGipBGf7f0zBQJMWq7xMbknHeFb6BfV4=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1018-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 737d6005-6318-11f5-aff2-a82bdd58bc01
+      - 737d6005-6318-11f5-9367-a82bdd58bc01
       x-ms-date:
       - Tue, 01 Jan 2030 12:00:00 GMT
       x-ms-range:
@@ -315,25 +303,25 @@ interactions:
       content-type:
       - text/plain
       date:
-      - Fri, 19 Dec 2025 14:48:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x23EEBB15D193D00"'
+      - '"0x2512AF8ABDB4F80"'
       last-modified:
-      - Fri, 19 Dec 2025 14:48:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-blob-content-md5:
       - ECd5Z2/u/9OF9wOFQsBUQQ==
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 737d6005-6318-11f5-aff2-a82bdd58bc01
+      - 737d6005-6318-11f5-9367-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 19 Dec 2025 14:48:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - f270fdb6-c54a-4f0b-93e6-b07feba8a437
+      - 61759206-fa45-4eab-a18b-ebb5521d3684
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -348,14 +336,12 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:fPOC0jFXQVUEt48LoqiLtiakQe6i3xXmLzIOwQFfU54=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1018-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 737d6006-6318-11f5-ac4f-a82bdd58bc01
+      - 737d6006-6318-11f5-841c-a82bdd58bc01
       x-ms-date:
       - Tue, 01 Jan 2030 12:00:00 GMT
       x-ms-version:
@@ -381,29 +367,29 @@ interactions:
       content-type:
       - text/plain
       date:
-      - Fri, 19 Dec 2025 14:48:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x1E7BDA1C2C4E820"'
+      - '"0x2736F19918E97A0"'
       last-modified:
-      - Fri, 19 Dec 2025 14:48:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Fri, 19 Dec 2025 14:48:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 737d6006-6318-11f5-ac4f-a82bdd58bc01
+      - 737d6006-6318-11f5-841c-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 19 Dec 2025 14:48:35 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - bc276633-6658-4928-a0e2-c7fc18cceeb1
+      - 7963643f-6f46-478e-bec2-1c5504c27981
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -418,14 +404,12 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:NG62ypFRbnZyCXwY2BBayEW9MsDXYYlVF/dI0wV4t8c=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1018-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 737d6007-6318-11f5-a2be-a82bdd58bc01
+      - 737d6007-6318-11f5-aed4-a82bdd58bc01
       x-ms-date:
       - Tue, 01 Jan 2030 12:00:00 GMT
       x-ms-version:
@@ -451,29 +435,29 @@ interactions:
       content-type:
       - text/plain
       date:
-      - Fri, 19 Dec 2025 14:48:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x23EEBB15D193D00"'
+      - '"0x2512AF8ABDB4F80"'
       last-modified:
-      - Fri, 19 Dec 2025 14:48:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Fri, 19 Dec 2025 14:48:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 737d6007-6318-11f5-a2be-a82bdd58bc01
+      - 737d6007-6318-11f5-aed4-a82bdd58bc01
       x-ms-creation-time:
-      - Fri, 19 Dec 2025 14:48:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 9b7f8351-5db2-4984-bca5-1b5ab6010ab5
+      - 9d98a49f-159c-4c32-aea7-63cd520a519d
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_batch_validation_errors.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_batch_validation_errors.yaml
@@ -338,8 +338,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:LYl4YWQaKD/jEk4isQR6mNE7FHESDJ/7MeEeGbZWccA=
       Connection:
       - keep-alive
       Content-Length:
@@ -347,15 +345,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5658496b-dc27-11f0-b763-f4289da6022f
+      - 432a6000-cead-11f0-a378-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -375,15 +373,15 @@ interactions:
       content-md5:
       - Wqz9xUg6VEEikc4F4lczag==
       date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x1CC2F93593EA580"'
+      - '"0x24B02BE00CA6E40"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-client-request-id:
-      - 5658496b-dc27-11f0-b763-f4289da6022f
+      - 432a6000-cead-11f0-a378-a82bdd58bc01
       x-ms-request-id:
-      - e70f8218-d6cf-4ac3-8cd6-f24898664c59
+      - 64ac15a9-eb88-499b-a075-5b2dde4b8288
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -730,8 +728,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:DS1bRY1egAFALi5SBE6qVC0bFNBhoGEsCjdb3tuViM4=
       Connection:
       - keep-alive
       Content-Length:
@@ -739,15 +735,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5658496c-dc27-11f0-b763-f4289da6022f
+      - 432a6001-cead-11f0-be70-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -767,15 +763,15 @@ interactions:
       content-md5:
       - 3+GvKbe94tVqwtpqDsF81Q==
       date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x1BA35B797F5D1E0"'
+      - '"0x20333577268D1C0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-client-request-id:
-      - 5658496c-dc27-11f0-b763-f4289da6022f
+      - 432a6001-cead-11f0-be70-a82bdd58bc01
       x-ms-request-id:
-      - e31632b6-25cc-45bc-850b-64386c0ac9b8
+      - 3e9a9ec2-ee37-4389-a177-736754f702d2
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -1122,8 +1118,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:jNrQWJFD5jQstb9UVc7fRA+PVrBTnw7gx4dZ6HpLsgM=
       Connection:
       - keep-alive
       Content-Length:
@@ -1131,15 +1125,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5658496d-dc27-11f0-b763-f4289da6022f
+      - 432a6002-cead-11f0-ab00-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -1159,15 +1153,15 @@ interactions:
       content-md5:
       - 4Th75UY/hdMmecN/cogSrA==
       date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       etag:
-      - '"0x1ECF9C037307E00"'
+      - '"0x200B036D373FB80"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:35 GMT
       x-ms-client-request-id:
-      - 5658496d-dc27-11f0-b763-f4289da6022f
+      - 432a6002-cead-11f0-ab00-a82bdd58bc01
       x-ms-request-id:
-      - c5bba52c-187a-492a-8aae-ef2664d35731
+      - 97efe04f-3301-43fc-81ba-863b1b43d8c5
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_database_connection_loss.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_database_connection_loss.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:7ClSu4KVFrS2ly1+PmKkQMXzdKa7CyGyoRLIw1wJzlc=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5658496e-dc27-11f0-b763-f4289da6022f
+      - 432a6003-cead-11f0-838d-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - HlAhCgICSX+3m8OLat5sNA==
       date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x1DE0FBBFA228FC0"'
+      - '"0x209E544A1BCAB60"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5658496e-dc27-11f0-b763-f4289da6022f
+      - 432a6003-cead-11f0-838d-a82bdd58bc01
       x-ms-request-id:
-      - d65f5a5e-e1ab-4505-9108-54f9c8804c48
+      - 5d3e357d-e5f6-411b-8a24-d14146de10fc
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -66,8 +64,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:XzoO63QkAA5oBd/uKlw7WKfLgYYqzkuYgNmkOz7RxfE=
       Connection:
       - keep-alive
       Content-Length:
@@ -75,15 +71,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5658496f-dc27-11f0-b763-f4289da6022f
+      - 432a6004-cead-11f0-b581-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -103,15 +99,15 @@ interactions:
       content-md5:
       - HlAhCgICSX+3m8OLat5sNA==
       date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x1CB0CD8ED301EF0"'
+      - '"0x243B6EB31E5E1E0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5658496f-dc27-11f0-b763-f4289da6022f
+      - 432a6004-cead-11f0-b581-a82bdd58bc01
       x-ms-request-id:
-      - 00caed34-4406-4419-8fc1-46bfbd15b015
+      - 131c4dcb-963b-45e2-82be-23d198aace3d
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -458,8 +454,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:zhYc0MXSxuB11ARGkuaRo2RM59h03yFkaIunAiiEXKY=
       Connection:
       - keep-alive
       Content-Length:
@@ -467,15 +461,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 56584970-dc27-11f0-b763-f4289da6022f
+      - 432a6005-cead-11f0-8a48-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -495,15 +489,15 @@ interactions:
       content-md5:
       - c1zeeixHoMD3Z+T4wrvFEQ==
       date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x1EC760A2B7FD560"'
+      - '"0x1CED2DD1D676B20"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 56584970-dc27-11f0-b763-f4289da6022f
+      - 432a6005-cead-11f0-8a48-a82bdd58bc01
       x-ms-request-id:
-      - 3e44bf67-5e3b-43e5-80c6-d085e6aef82f
+      - 9479020c-8ba8-4f16-936c-b10a609f9a2d
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -850,8 +844,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:g16ek0wNKWgdRg99/uR+cmIYYwTsbPZpHfz7S/Q6xWw=
       Connection:
       - keep-alive
       Content-Length:
@@ -859,15 +851,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 56584971-dc27-11f0-b763-f4289da6022f
+      - 432a6006-cead-11f0-9aa2-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -887,15 +879,15 @@ interactions:
       content-md5:
       - Wqz9xUg6VEEikc4F4lczag==
       date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x2314DA1AE16EAC0"'
+      - '"0x1E0E240DB555A50"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 56584971-dc27-11f0-b763-f4289da6022f
+      - 432a6006-cead-11f0-9aa2-a82bdd58bc01
       x-ms-request-id:
-      - a5bb53bf-c692-4c63-9d56-698c8cf36b3e
+      - 100ed827-2f5c-4f30-9dde-f13daf3af1b2
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -1242,8 +1234,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:Py1ej1KvUOSw1+Q2CdO6xgGkshXmJXXDfndvBrFFeiE=
       Connection:
       - keep-alive
       Content-Length:
@@ -1251,15 +1241,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 56584972-dc27-11f0-b763-f4289da6022f
+      - 432a6007-cead-11f0-82eb-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:36 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -1279,15 +1269,15 @@ interactions:
       content-md5:
       - 3+GvKbe94tVqwtpqDsF81Q==
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x21D96D8B56454C0"'
+      - '"0x1BB2E7B66A77100"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 56584972-dc27-11f0-b763-f4289da6022f
+      - 432a6007-cead-11f0-82eb-a82bdd58bc01
       x-ms-request-id:
-      - ab236acc-f354-4f48-9f08-c7df08534358
+      - 34ee97f9-8064-492f-ae5a-cfa6983e9d8f
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -1634,8 +1624,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:ZthfYqDm2yWXV4B8To+EvVsUFV7rExCU0g+8/ReZExI=
       Connection:
       - keep-alive
       Content-Length:
@@ -1643,15 +1631,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c69c-dc27-11f0-b763-f4289da6022f
+      - 432a6008-cead-11f0-9856-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -1671,15 +1659,15 @@ interactions:
       content-md5:
       - 4Th75UY/hdMmecN/cogSrA==
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x1D6836F854F9F60"'
+      - '"0x1DF845716C0D8A0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c69c-dc27-11f0-b763-f4289da6022f
+      - 432a6008-cead-11f0-9856-a82bdd58bc01
       x-ms-request-id:
-      - a52380d4-40a3-4003-85b9-0713f926bd52
+      - 06bebf75-5b1b-4168-89b8-8737ff9e085e
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -1694,16 +1682,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:lpSChzeoUN+ag33xFsuFKmzxvt1J/nugtT/wR+qrKYI=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5704c69d-dc27-11f0-b763-f4289da6022f
+      - 432a6009-cead-11f0-9e29-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -1727,29 +1713,29 @@ interactions:
       content-type:
       - application/vnd.oasis.opendocument.text
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x21D96D8B56454C0"'
+      - '"0x1BB2E7B66A77100"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c69d-dc27-11f0-b763-f4289da6022f
+      - 432a6009-cead-11f0-9e29-a82bdd58bc01
       x-ms-creation-time:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - d54de537-9914-40d5-a4d9-821f88019563
+      - c0e1ee96-913a-47c0-9f70-e7bd6424abe9
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -1764,18 +1750,16 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:VN1ccCxq9UjcFgxuCzPTs4MbjExzKKMINaHzIKrj2p8=
       Connection:
       - keep-alive
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5704c69e-dc27-11f0-b763-f4289da6022f
+      - 432a600a-cead-11f0-b3f3-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: DELETE
@@ -1793,13 +1777,13 @@ interactions:
       Server:
       - Azurite-Blob/3.35.0
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c69e-dc27-11f0-b763-f4289da6022f
+      - 432a600a-cead-11f0-b3f3-a82bdd58bc01
       x-ms-delete-type-permanent:
       - 'true'
       x-ms-request-id:
-      - b4432a4b-a44d-4bd8-9f76-9165b9037df8
+      - c40b1a4e-0d51-4564-a859-8c276e8cd0df
       x-ms-version:
       - '2025-11-05'
     status:
@@ -1812,16 +1796,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:uXskO+IT0/2lZdMPNYiooKHM2bovbaxRtDn+9S+HHvA=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5704c69f-dc27-11f0-b763-f4289da6022f
+      - 432a600b-cead-11f0-aad0-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -1845,29 +1827,29 @@ interactions:
       content-type:
       - application/vnd.oasis.opendocument.text
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x1D6836F854F9F60"'
+      - '"0x1DF845716C0D8A0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c69f-dc27-11f0-b763-f4289da6022f
+      - 432a600b-cead-11f0-aad0-a82bdd58bc01
       x-ms-creation-time:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - c5abd5b7-8a89-461e-b8c8-490e6559e04a
+      - a96a11cb-5aa4-4830-a77a-097f34572579
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -1882,18 +1864,16 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:wtD9mXUkrlAklyrL7LwsJOE5Nj6kV9jjScCXQV2/WvQ=
       Connection:
       - keep-alive
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5704c6a0-dc27-11f0-b763-f4289da6022f
+      - 432a600c-cead-11f0-ae9f-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: DELETE
@@ -1911,13 +1891,13 @@ interactions:
       Server:
       - Azurite-Blob/3.35.0
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c6a0-dc27-11f0-b763-f4289da6022f
+      - 432a600c-cead-11f0-ae9f-a82bdd58bc01
       x-ms-delete-type-permanent:
       - 'true'
       x-ms-request-id:
-      - e2cb2647-e7d9-43ed-956f-d826d2cf974e
+      - ae67ba5a-b90f-4510-b447-1d6fd2733970
       x-ms-version:
       - '2025-11-05'
     status:
@@ -1930,16 +1910,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:WYUAqG8YbkZ8gHj+06oQPF0KkRb8KOSQDj7Ynzpgigo=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5704c6a1-dc27-11f0-b763-f4289da6022f
+      - 432a600d-cead-11f0-b38b-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -1951,7 +1929,7 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       Keep-Alive:
       - timeout=5
       Server:
@@ -1959,7 +1937,7 @@ interactions:
       x-ms-error-code:
       - BlobNotFound
       x-ms-request-id:
-      - ae05be02-9fbf-4a19-9569-7d0e8fbb8c47
+      - 335a9d07-32fc-4df5-b235-756fad57b263
     status:
       code: 404
       message: The specified blob does not exist.
@@ -1970,16 +1948,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:yYpSUrydMY8/afRU0WoDVvkq3rbWsBN0KinrnVpvgzw=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5704c6a2-dc27-11f0-b763-f4289da6022f
+      - 432a600e-cead-11f0-a5b8-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -1991,7 +1967,7 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       Keep-Alive:
       - timeout=5
       Server:
@@ -1999,7 +1975,7 @@ interactions:
       x-ms-error-code:
       - BlobNotFound
       x-ms-request-id:
-      - ebbb0b03-be9b-4a0d-bed5-c126ba738807
+      - 9d208513-25d6-4c92-a3ff-e31071960ee6
     status:
       code: 404
       message: The specified blob does not exist.

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_generate_unique_identificatie.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_generate_unique_identificatie.yaml
@@ -338,8 +338,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:eFIkEySOTKWTViNsksrZHh9AThdxo2eSuI/xOKE/vCY=
       Connection:
       - keep-alive
       Content-Length:
@@ -347,15 +345,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6a3-dc27-11f0-b763-f4289da6022f
+      - 432a600f-cead-11f0-8fe7-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -375,15 +373,15 @@ interactions:
       content-md5:
       - c1zeeixHoMD3Z+T4wrvFEQ==
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x1FB2CA8279EA360"'
+      - '"0x22917B644C84060"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c6a3-dc27-11f0-b763-f4289da6022f
+      - 432a600f-cead-11f0-8fe7-a82bdd58bc01
       x-ms-request-id:
-      - 7184f336-7720-48ec-8807-efcbdaf48224
+      - 313ddcbb-ad63-44e2-a058-0ae65f303d6f
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -730,8 +728,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:RT8lAx5UCRxR1WsMuO3xQk6ip1aeRAwqke3csGd82Zs=
       Connection:
       - keep-alive
       Content-Length:
@@ -739,15 +735,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6a4-dc27-11f0-b763-f4289da6022f
+      - 432a6010-cead-11f0-bb32-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -767,15 +763,15 @@ interactions:
       content-md5:
       - Wqz9xUg6VEEikc4F4lczag==
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x1E883B81095E9D0"'
+      - '"0x221AD1BEE4AD4E0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c6a4-dc27-11f0-b763-f4289da6022f
+      - 432a6010-cead-11f0-bb32-a82bdd58bc01
       x-ms-request-id:
-      - 524a2a79-bb4c-4c25-95ea-96182f9ab7c4
+      - a417d382-7ade-4dfb-abe2-13daeb958793
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -1122,8 +1118,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:NPTZYXxxgbeX4s56oMdwUerRDCVWQ7VPP1YVAcY16VY=
       Connection:
       - keep-alive
       Content-Length:
@@ -1131,15 +1125,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6a5-dc27-11f0-b763-f4289da6022f
+      - 432a6011-cead-11f0-98b2-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -1159,15 +1153,15 @@ interactions:
       content-md5:
       - 3+GvKbe94tVqwtpqDsF81Q==
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x239DE23DAB4B400"'
+      - '"0x1E41118F1A690B0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c6a5-dc27-11f0-b763-f4289da6022f
+      - 432a6011-cead-11f0-98b2-a82bdd58bc01
       x-ms-request-id:
-      - c9302ef0-4034-4017-9ad9-7de31eb0fc35
+      - eab07844-0799-4eb6-9268-758ae6d29f99
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -1514,8 +1508,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:kDxb4Wzh1cQrLTmkLyUAnA2GAcNjE4V8RuQPWo1kPo4=
       Connection:
       - keep-alive
       Content-Length:
@@ -1523,15 +1515,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6a6-dc27-11f0-b763-f4289da6022f
+      - 432a6012-cead-11f0-986d-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -1551,15 +1543,15 @@ interactions:
       content-md5:
       - 4Th75UY/hdMmecN/cogSrA==
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x1F3B873A2151410"'
+      - '"0x25C2A79F4B6E460"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c6a6-dc27-11f0-b763-f4289da6022f
+      - 432a6012-cead-11f0-986d-a82bdd58bc01
       x-ms-request-id:
-      - 06e5a110-5cc1-4298-aac5-150fd5631394
+      - ac397418-0ab4-41ac-ab81-0c0c7c64fd4a
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_integrity_error.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_integrity_error.yaml
@@ -6,8 +6,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:EnGRpEYiuw0Xa8z34lv2vQoACOa/XKdJLRBBJxrBCYk=
       Connection:
       - keep-alive
       Content-Length:
@@ -15,15 +13,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6a7-dc27-11f0-b763-f4289da6022f
+      - 432a6013-cead-11f0-bdd1-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -43,15 +41,15 @@ interactions:
       content-md5:
       - HlAhCgICSX+3m8OLat5sNA==
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x237AD908CC20140"'
+      - '"0x21CC4038154F080"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c6a7-dc27-11f0-b763-f4289da6022f
+      - 432a6013-cead-11f0-bdd1-a82bdd58bc01
       x-ms-request-id:
-      - eb0cb956-5827-4c61-9825-5737c17debac
+      - c1821647-db58-4e75-b88e-0f21993db71e
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -66,8 +64,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:475u1KMTUcQjKurGiAquaxAZko4uVHnCIzEeuCVfGWY=
       Connection:
       - keep-alive
       Content-Length:
@@ -75,15 +71,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/octet-stream
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6a8-dc27-11f0-b763-f4289da6022f
+      - 432a6014-cead-11f0-a592-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -103,15 +99,15 @@ interactions:
       content-md5:
       - HlAhCgICSX+3m8OLat5sNA==
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x23168F004F66BC0"'
+      - '"0x1E39C75B0B7F4E0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c6a8-dc27-11f0-b763-f4289da6022f
+      - 432a6014-cead-11f0-a592-a82bdd58bc01
       x-ms-request-id:
-      - 6fcace2d-53e3-49e3-a054-92db54b973d8
+      - 50f5b5e7-cd65-466b-91ba-38c8cc644251
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -458,8 +454,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:k2hf9Ae896EneIIF6U/4TCPCIMwjZsCEPDAVonXzAyE=
       Connection:
       - keep-alive
       Content-Length:
@@ -467,15 +461,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6a9-dc27-11f0-b763-f4289da6022f
+      - 432a6015-cead-11f0-af40-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -495,15 +489,15 @@ interactions:
       content-md5:
       - c1zeeixHoMD3Z+T4wrvFEQ==
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x25F0FE42048DB60"'
+      - '"0x206297CA0074E80"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c6a9-dc27-11f0-b763-f4289da6022f
+      - 432a6015-cead-11f0-af40-a82bdd58bc01
       x-ms-request-id:
-      - 87ae9c51-9bd3-43c8-81e7-ed485d378eaf
+      - 5acb6cce-dc7c-4901-ba73-2ad1a5a5b2d2
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -850,8 +844,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:CmPbYP9aQ9uvQEfWSgHZGxOaXtozrtS7gdxN4HYoxt4=
       Connection:
       - keep-alive
       Content-Length:
@@ -859,15 +851,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6aa-dc27-11f0-b763-f4289da6022f
+      - 432a6016-cead-11f0-97c5-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -887,15 +879,15 @@ interactions:
       content-md5:
       - Wqz9xUg6VEEikc4F4lczag==
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x23C825D42C572A0"'
+      - '"0x209CB59407E5D00"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c6aa-dc27-11f0-b763-f4289da6022f
+      - 432a6016-cead-11f0-97c5-a82bdd58bc01
       x-ms-request-id:
-      - a57f205f-6632-4a5e-b660-f790e050bf62
+      - f0637bf6-92ca-41a9-9408-06cc750ce87d
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -910,16 +902,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:u5WtHRbjepj2zRIdxyiUQdW9QCrACvgiXPncfL+5NFg=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5704c6ab-dc27-11f0-b763-f4289da6022f
+      - 432a6017-cead-11f0-9689-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -943,29 +933,29 @@ interactions:
       content-type:
       - application/vnd.oasis.opendocument.text
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x25F0FE42048DB60"'
+      - '"0x206297CA0074E80"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6ab-dc27-11f0-b763-f4289da6022f
+      - 432a6017-cead-11f0-9689-a82bdd58bc01
       x-ms-creation-time:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - c0a00bd3-706e-45eb-8d6d-d58594e181c2
+      - 20ac3e29-4918-49da-a734-a440d36a253d
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -980,18 +970,16 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:dazZhm6PfwgA8CI3BLgUr/9iqXhZXlgurvZbr8W5yzI=
       Connection:
       - keep-alive
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5704c6ac-dc27-11f0-b763-f4289da6022f
+      - 432a6018-cead-11f0-82bd-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: DELETE
@@ -1009,13 +997,13 @@ interactions:
       Server:
       - Azurite-Blob/3.35.0
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c6ac-dc27-11f0-b763-f4289da6022f
+      - 432a6018-cead-11f0-82bd-a82bdd58bc01
       x-ms-delete-type-permanent:
       - 'true'
       x-ms-request-id:
-      - 7fcf5de1-9474-46ae-bad5-37ce1645e525
+      - 4127c5e6-a5a6-4e52-ab04-6bb6fccbf47f
       x-ms-version:
       - '2025-11-05'
     status:
@@ -1028,16 +1016,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:Fzk9//Fp2y2Bkyjo8VVMPRgvTPtzNT/cmZfBf9z+ZH8=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5704c6ad-dc27-11f0-b763-f4289da6022f
+      - 432a6019-cead-11f0-8584-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -1061,29 +1047,29 @@ interactions:
       content-type:
       - application/vnd.oasis.opendocument.text
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x23C825D42C572A0"'
+      - '"0x209CB59407E5D00"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6ad-dc27-11f0-b763-f4289da6022f
+      - 432a6019-cead-11f0-8584-a82bdd58bc01
       x-ms-creation-time:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 64e9df86-b12e-4627-94eb-842a97ebe3c2
+      - 892fff74-ba63-45ef-8069-84b319e6f412
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -1098,18 +1084,16 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:o5Ush0BAmFhr7Y908mxJ3rCKdykvJuaSUC1qnac+1Mo=
       Connection:
       - keep-alive
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5704c6ae-dc27-11f0-b763-f4289da6022f
+      - 432a601a-cead-11f0-8ca8-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: DELETE
@@ -1127,13 +1111,13 @@ interactions:
       Server:
       - Azurite-Blob/3.35.0
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c6ae-dc27-11f0-b763-f4289da6022f
+      - 432a601a-cead-11f0-8ca8-a82bdd58bc01
       x-ms-delete-type-permanent:
       - 'true'
       x-ms-request-id:
-      - 553596c4-256b-4eaf-851c-39bd1524e3f7
+      - ff6a54cd-1fe6-4096-b8dd-d5856850419d
       x-ms-version:
       - '2025-11-05'
     status:
@@ -1478,8 +1462,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:TwgZM+Z9s4l+sjfe2gQts7glIxcKGmqXB/9veSb8GqM=
       Connection:
       - keep-alive
       Content-Length:
@@ -1487,15 +1469,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6af-dc27-11f0-b763-f4289da6022f
+      - 432a601b-cead-11f0-9bc6-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -1515,15 +1497,15 @@ interactions:
       content-md5:
       - 3+GvKbe94tVqwtpqDsF81Q==
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x26D8170B0CF27A0"'
+      - '"0x2116EA681F5F1A0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c6af-dc27-11f0-b763-f4289da6022f
+      - 432a601b-cead-11f0-9bc6-a82bdd58bc01
       x-ms-request-id:
-      - 7251b7be-51ce-4388-a3c6-cf97490c9896
+      - 73b9a489-03d9-46d6-a29e-5b4bd933e514
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -1870,8 +1852,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:SCqep7geLjTM/dWQrNU+rrcX8BdOrKmgrjDlBb8Q7AA=
       Connection:
       - keep-alive
       Content-Length:
@@ -1879,15 +1859,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6b0-dc27-11f0-b763-f4289da6022f
+      - 432a601c-cead-11f0-b3c8-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -1907,15 +1887,15 @@ interactions:
       content-md5:
       - 4Th75UY/hdMmecN/cogSrA==
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x22D14A2F8A915A0"'
+      - '"0x256BAEC7224FA20"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c6b0-dc27-11f0-b763-f4289da6022f
+      - 432a601c-cead-11f0-b3c8-a82bdd58bc01
       x-ms-request-id:
-      - f344e8f9-a505-4207-8955-5faf19dd2c79
+      - d21a7cde-874c-47cd-9932-912368a9aca6
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_last_batch_is_not_full_batch.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_last_batch_is_not_full_batch.yaml
@@ -338,8 +338,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:ty4fTeGIkCveSQbld4yB3nrBE6hxl+OZhf4zjPOWmDE=
       Connection:
       - keep-alive
       Content-Length:
@@ -347,15 +345,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6b1-dc27-11f0-b763-f4289da6022f
+      - 432a601d-cead-11f0-94db-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -375,15 +373,15 @@ interactions:
       content-md5:
       - c1zeeixHoMD3Z+T4wrvFEQ==
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x249D465CB65FDE0"'
+      - '"0x1FE47019C881380"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c6b1-dc27-11f0-b763-f4289da6022f
+      - 432a601d-cead-11f0-94db-a82bdd58bc01
       x-ms-request-id:
-      - 985d3368-6e6b-4531-b85c-43c6689fe08b
+      - a8b4aed7-edfd-4e2f-95ad-99671dfbf119
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -730,8 +728,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:GW+d+LUx4gkhnw0aiA06yEMZxySIIHSSMhsKteQXxaE=
       Connection:
       - keep-alive
       Content-Length:
@@ -739,15 +735,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6b2-dc27-11f0-b763-f4289da6022f
+      - 432a601e-cead-11f0-a469-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -767,15 +763,15 @@ interactions:
       content-md5:
       - Wqz9xUg6VEEikc4F4lczag==
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x1D7BCA6B3F80ED0"'
+      - '"0x1E1ACBFDB3B78E0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c6b2-dc27-11f0-b763-f4289da6022f
+      - 432a601e-cead-11f0-a469-a82bdd58bc01
       x-ms-request-id:
-      - 23d3a157-05a0-4d1e-9774-3eee302e2f52
+      - 7c51f6da-08e6-4c6c-bb63-e63869b6fb62
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -1122,8 +1118,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:mjg3WePxhwEQYNlzDi5KfMG3EIFiVA9eXZzjpmJJcIs=
       Connection:
       - keep-alive
       Content-Length:
@@ -1131,15 +1125,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6b3-dc27-11f0-b763-f4289da6022f
+      - 432a601f-cead-11f0-b99e-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -1159,15 +1153,15 @@ interactions:
       content-md5:
       - 3+GvKbe94tVqwtpqDsF81Q==
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x1F59D88C0EF6D30"'
+      - '"0x2262CE818BBD560"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c6b3-dc27-11f0-b763-f4289da6022f
+      - 432a601f-cead-11f0-b99e-a82bdd58bc01
       x-ms-request-id:
-      - 0277aaa1-97fc-452c-8803-373fee113295
+      - d70574a2-a2af-4b96-ba65-e9c574fafdd1
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -1514,8 +1508,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:aSocSipAPQWfXCkhaAbUmjCEF8LQpBY7ezSkpqhbiBM=
       Connection:
       - keep-alive
       Content-Length:
@@ -1523,15 +1515,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6b4-dc27-11f0-b763-f4289da6022f
+      - 432a6020-cead-11f0-bfd9-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -1551,15 +1543,15 @@ interactions:
       content-md5:
       - 4Th75UY/hdMmecN/cogSrA==
       date:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x1DC57A05E0E9A10"'
+      - '"0x21881C6689C92C0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:37 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c6b4-dc27-11f0-b763-f4289da6022f
+      - 432a6020-cead-11f0-bfd9-a82bdd58bc01
       x-ms-request-id:
-      - 16aac52e-3e5d-44b7-9c64-b039a333a83d
+      - 1c864a50-af2f-46d7-997b-e21cf9abc7ca
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -1906,8 +1898,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:557b7FJ6Wk9CbM8rkobljxLJ831AWViFwCH9VzmZjnM=
       Connection:
       - keep-alive
       Content-Length:
@@ -1915,15 +1905,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6b5-dc27-11f0-b763-f4289da6022f
+      - 432a6021-cead-11f0-a83d-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -1943,15 +1933,15 @@ interactions:
       content-md5:
       - DhNd4IMLtxbxbORcZBX42Q==
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       etag:
-      - '"0x24D3E3045C38660"'
+      - '"0x23CE973EDBCF340"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:36 GMT
       x-ms-client-request-id:
-      - 5704c6b5-dc27-11f0-b763-f4289da6022f
+      - 432a6021-cead-11f0-a83d-a82bdd58bc01
       x-ms-request-id:
-      - 0e568eaa-5b99-4472-a478-fc5099539e95
+      - d0ef871b-f1a5-4e6b-9dca-b8f968eb7882
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_simple_import.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_simple_import.yaml
@@ -338,8 +338,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:xMH1MQ28ZRYUX4QvWUuTN40tDZIl/1H9tDXNRqqKPi4=
       Connection:
       - keep-alive
       Content-Length:
@@ -347,15 +345,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6b6-dc27-11f0-b763-f4289da6022f
+      - 432a6022-cead-11f0-8ea5-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -375,15 +373,15 @@ interactions:
       content-md5:
       - c1zeeixHoMD3Z+T4wrvFEQ==
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       etag:
-      - '"0x25CF768C472F480"'
+      - '"0x1EFC2CC88991B20"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-client-request-id:
-      - 5704c6b6-dc27-11f0-b763-f4289da6022f
+      - 432a6022-cead-11f0-8ea5-a82bdd58bc01
       x-ms-request-id:
-      - f39509ea-b2ab-4e2e-a028-86e99e7a4a56
+      - 53c14b27-73c4-4d28-85f2-08d93fec9f88
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -730,8 +728,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:rMR18HdqCVPrbafOE3iHs9m3ROSbCDIGvBi8wRhKC8g=
       Connection:
       - keep-alive
       Content-Length:
@@ -739,15 +735,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6b7-dc27-11f0-b763-f4289da6022f
+      - 432a6023-cead-11f0-8462-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -767,15 +763,15 @@ interactions:
       content-md5:
       - Wqz9xUg6VEEikc4F4lczag==
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       etag:
-      - '"0x2167AFBF98CD380"'
+      - '"0x1CBD7DBD485B370"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-client-request-id:
-      - 5704c6b7-dc27-11f0-b763-f4289da6022f
+      - 432a6023-cead-11f0-8462-a82bdd58bc01
       x-ms-request-id:
-      - 97ccfe8c-c4df-4c3e-8008-3b96ab593c3f
+      - 073fa21e-c9a8-41d2-85f3-c66410369e3f
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -1122,8 +1118,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:zbxwiyCxO8XQu2JvCXdx/os9T7mQU0reC4v0Oi1yt9I=
       Connection:
       - keep-alive
       Content-Length:
@@ -1131,15 +1125,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6b8-dc27-11f0-b763-f4289da6022f
+      - 432a6024-cead-11f0-9b2c-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -1159,15 +1153,15 @@ interactions:
       content-md5:
       - 3+GvKbe94tVqwtpqDsF81Q==
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       etag:
-      - '"0x20E514655CB6240"'
+      - '"0x1E4B4B6DB9954B0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-client-request-id:
-      - 5704c6b8-dc27-11f0-b763-f4289da6022f
+      - 432a6024-cead-11f0-9b2c-a82bdd58bc01
       x-ms-request-id:
-      - e7be409b-2f11-45af-b1a8-cfa81e7b3a7b
+      - 31b67d7a-04b9-497a-b028-4788332789ec
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -1514,8 +1508,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:dz0m+M2ib/ISEK9sZepmIwdjA+kJ5ujCb88VDv9Hlzo=
       Connection:
       - keep-alive
       Content-Length:
@@ -1523,15 +1515,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6b9-dc27-11f0-b763-f4289da6022f
+      - 432a6025-cead-11f0-906e-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -1551,15 +1543,15 @@ interactions:
       content-md5:
       - 4Th75UY/hdMmecN/cogSrA==
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       etag:
-      - '"0x200A8813D185860"'
+      - '"0x1F1ADA63D13EC20"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-client-request-id:
-      - 5704c6b9-dc27-11f0-b763-f4289da6022f
+      - 432a6025-cead-11f0-906e-a82bdd58bc01
       x-ms-request-id:
-      - 2a05dc67-3994-43c8-95a0-fa8c54abf64f
+      - c304ae99-c663-447e-99b3-4fcb661f674c
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_total_smaller_than_batch_size.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_total_smaller_than_batch_size.yaml
@@ -338,8 +338,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:x5SPzeRThD2/8LDXOYtri6lQwe16usqa88w/8nXQWts=
       Connection:
       - keep-alive
       Content-Length:
@@ -347,15 +345,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6ba-dc27-11f0-b763-f4289da6022f
+      - 432a6026-cead-11f0-a29d-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -375,15 +373,15 @@ interactions:
       content-md5:
       - c1zeeixHoMD3Z+T4wrvFEQ==
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       etag:
-      - '"0x1D70725982FFF00"'
+      - '"0x24733857908C1A0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-client-request-id:
-      - 5704c6ba-dc27-11f0-b763-f4289da6022f
+      - 432a6026-cead-11f0-a29d-a82bdd58bc01
       x-ms-request-id:
-      - 30a1d661-87c2-46bc-bd21-ca1a75e6180c
+      - b3cb264d-fff6-43bd-b585-242c780ac396
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_unknown_zaak_uuid.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_unknown_zaak_uuid.yaml
@@ -338,8 +338,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:Djm/BOb8E5ZkkLAgtVOMWVyEmpXQsY/3sOEBInCoqnE=
       Connection:
       - keep-alive
       Content-Length:
@@ -347,15 +345,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6bb-dc27-11f0-b763-f4289da6022f
+      - 432a6027-cead-11f0-8873-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -375,15 +373,15 @@ interactions:
       content-md5:
       - Wqz9xUg6VEEikc4F4lczag==
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       etag:
-      - '"0x1C7FD01709CEE40"'
+      - '"0x244E917C517AB40"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-client-request-id:
-      - 5704c6bb-dc27-11f0-b763-f4289da6022f
+      - 432a6027-cead-11f0-8873-a82bdd58bc01
       x-ms-request-id:
-      - f9061f33-499f-421b-9b29-01e64189d6af
+      - 0a859dc6-e87c-4cef-9519-a4e1ace2c14c
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -730,8 +728,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:/6Th6mHsIpMXLpSaOPQ09hFmTnFN1wfzYNsIamW/CPY=
       Connection:
       - keep-alive
       Content-Length:
@@ -739,15 +735,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6bc-dc27-11f0-b763-f4289da6022f
+      - 432a6028-cead-11f0-b222-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -767,15 +763,15 @@ interactions:
       content-md5:
       - 3+GvKbe94tVqwtpqDsF81Q==
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       etag:
-      - '"0x216D82555906940"'
+      - '"0x1F2FB5CE4B37770"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-client-request-id:
-      - 5704c6bc-dc27-11f0-b763-f4289da6022f
+      - 432a6028-cead-11f0-b222-a82bdd58bc01
       x-ms-request-id:
-      - 2df007db-c5e7-4f3c-a8e2-ce93af414a4c
+      - 5a0e7338-9fc7-4b84-bf38-fb3e15f752e4
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -1122,8 +1118,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:nvaE7pqW5dToeKgxk+WV/FngCBM35GqEC75i/fuwBu0=
       Connection:
       - keep-alive
       Content-Length:
@@ -1131,15 +1125,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6bd-dc27-11f0-b763-f4289da6022f
+      - 432a6029-cead-11f0-a607-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -1159,15 +1153,15 @@ interactions:
       content-md5:
       - 4Th75UY/hdMmecN/cogSrA==
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       etag:
-      - '"0x1DB29A794FD40E0"'
+      - '"0x23A004477E9B5E0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-client-request-id:
-      - 5704c6bd-dc27-11f0-b763-f4289da6022f
+      - 432a6029-cead-11f0-a607-a82bdd58bc01
       x-ms-request-id:
-      - 0c5306c1-66b2-4f1c-8e90-d2824d76f05d
+      - 02205d39-4fb8-486a-b38e-989e1b7532b4
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_zaak_database_error.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_zaak_database_error.yaml
@@ -338,8 +338,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:m9s20YB9DYa4FwVPqtQB/KGFyje27PDS/nE6hT894JU=
       Connection:
       - keep-alive
       Content-Length:
@@ -347,15 +345,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6be-dc27-11f0-b763-f4289da6022f
+      - 432a602a-cead-11f0-b6fb-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -375,15 +373,15 @@ interactions:
       content-md5:
       - c1zeeixHoMD3Z+T4wrvFEQ==
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       etag:
-      - '"0x1C92C956F82B3A0"'
+      - '"0x1F7798A56F53810"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-client-request-id:
-      - 5704c6be-dc27-11f0-b763-f4289da6022f
+      - 432a602a-cead-11f0-b6fb-a82bdd58bc01
       x-ms-request-id:
-      - a384eabd-5b9a-4fba-b4d7-5bef80731bd2
+      - 85c278ae-96a8-40cc-9ac6-750bbfeb0c30
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -730,8 +728,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:+iwgEOFF7qrN3UXavY1O0q52BWCjbz/yEwgmnz8JLk8=
       Connection:
       - keep-alive
       Content-Length:
@@ -739,15 +735,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6bf-dc27-11f0-b763-f4289da6022f
+      - 432a602b-cead-11f0-9d4d-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -767,15 +763,15 @@ interactions:
       content-md5:
       - Wqz9xUg6VEEikc4F4lczag==
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       etag:
-      - '"0x20A7BDDC18CB080"'
+      - '"0x1E4BE6F230C48F0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-client-request-id:
-      - 5704c6bf-dc27-11f0-b763-f4289da6022f
+      - 432a602b-cead-11f0-9d4d-a82bdd58bc01
       x-ms-request-id:
-      - 238bc0e9-fdcd-4aa9-8e0f-5d0e2b393a6f
+      - b7af323d-3b83-419e-bc52-0a754fd37789
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -790,16 +786,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:FPtlRLcbl1xKP0eQAVTIsnGQcAO7B90qZMRnTFi4iOI=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5704c6c0-dc27-11f0-b763-f4289da6022f
+      - 432a602c-cead-11f0-924f-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -823,29 +817,29 @@ interactions:
       content-type:
       - application/vnd.oasis.opendocument.text
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       etag:
-      - '"0x1C92C956F82B3A0"'
+      - '"0x1F7798A56F53810"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6c0-dc27-11f0-b763-f4289da6022f
+      - 432a602c-cead-11f0-924f-a82bdd58bc01
       x-ms-creation-time:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - 39da5579-cd0a-4e29-b559-d19a7af23e2d
+      - c9a11e99-bb28-4a5b-a51e-c963d1e6f74a
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -860,18 +854,16 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:37k0xPm0emQ6oVsSVs06bOQj60yvBQp0Cc1C+b6TYvQ=
       Connection:
       - keep-alive
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5704c6c1-dc27-11f0-b763-f4289da6022f
+      - 432a602d-cead-11f0-b5c6-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: DELETE
@@ -889,13 +881,13 @@ interactions:
       Server:
       - Azurite-Blob/3.35.0
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-client-request-id:
-      - 5704c6c1-dc27-11f0-b763-f4289da6022f
+      - 432a602d-cead-11f0-b5c6-a82bdd58bc01
       x-ms-delete-type-permanent:
       - 'true'
       x-ms-request-id:
-      - 4df162db-c712-4f44-bdef-798d819dc555
+      - cd194608-aaad-4a7f-bf2c-2f2c8e4830f2
       x-ms-version:
       - '2025-11-05'
     status:
@@ -908,16 +900,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:INlmUYSul7TC9Png4BaGSzjheBY30U4zYIG7kQQGjas=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5704c6c2-dc27-11f0-b763-f4289da6022f
+      - 432a602e-cead-11f0-9dbb-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -941,29 +931,29 @@ interactions:
       content-type:
       - application/vnd.oasis.opendocument.text
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       etag:
-      - '"0x20A7BDDC18CB080"'
+      - '"0x1E4BE6F230C48F0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6c2-dc27-11f0-b763-f4289da6022f
+      - 432a602e-cead-11f0-9dbb-a82bdd58bc01
       x-ms-creation-time:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - c1519ab3-1767-46f3-97e5-212c46da99e7
+      - 6ff47aff-888d-4058-83e2-3813b2aa115a
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -978,18 +968,16 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:BVhPuJyu7JotEkzivegAoJ3OeyIF9vKH24kX5qa9Rj8=
       Connection:
       - keep-alive
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5704c6c3-dc27-11f0-b763-f4289da6022f
+      - 432a602f-cead-11f0-b30d-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: DELETE
@@ -1007,13 +995,13 @@ interactions:
       Server:
       - Azurite-Blob/3.35.0
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-client-request-id:
-      - 5704c6c3-dc27-11f0-b763-f4289da6022f
+      - 432a602f-cead-11f0-b30d-a82bdd58bc01
       x-ms-delete-type-permanent:
       - 'true'
       x-ms-request-id:
-      - 2b9a8dae-6664-4dcd-abbe-4807372e7e2e
+      - 44f90acf-1b29-4ad5-b6fd-303cd9d2f3d6
       x-ms-version:
       - '2025-11-05'
     status:

--- a/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_zaak_integrity_error.yaml
+++ b/src/openzaak/components/documenten/tests/azure/import/files/vcr_cassettes/ImportDocumentTestCase/test_zaak_integrity_error.yaml
@@ -338,8 +338,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:eskUzjidUKmFbsXiQCMUJN9YE3TaR6VUyt9mCtHV52g=
       Connection:
       - keep-alive
       Content-Length:
@@ -347,15 +345,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6c4-dc27-11f0-b763-f4289da6022f
+      - 432a6030-cead-11f0-aea7-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -375,15 +373,15 @@ interactions:
       content-md5:
       - c1zeeixHoMD3Z+T4wrvFEQ==
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       etag:
-      - '"0x1FF13BBED693040"'
+      - '"0x1CD273133C25630"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-client-request-id:
-      - 5704c6c4-dc27-11f0-b763-f4289da6022f
+      - 432a6030-cead-11f0-aea7-a82bdd58bc01
       x-ms-request-id:
-      - f1b9cb00-e79e-4bf0-bf36-a776f678c84c
+      - 5c4dbff4-d07a-4c12-a046-f18e74b509f8
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -730,8 +728,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:PlNNgGiZTVapA50sjrjCOe+prwyUeAhPuGRuxhM1waE=
       Connection:
       - keep-alive
       Content-Length:
@@ -739,15 +735,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6c5-dc27-11f0-b763-f4289da6022f
+      - 432a6031-cead-11f0-bed1-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -767,15 +763,15 @@ interactions:
       content-md5:
       - Wqz9xUg6VEEikc4F4lczag==
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       etag:
-      - '"0x24F5375462376E0"'
+      - '"0x2090278FF9E1D60"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-client-request-id:
-      - 5704c6c5-dc27-11f0-b763-f4289da6022f
+      - 432a6031-cead-11f0-bed1-a82bdd58bc01
       x-ms-request-id:
-      - f5ae477c-0af6-4a93-8f54-005aa57188eb
+      - 1af6816d-85cd-4585-892f-135fd94a1165
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -790,16 +786,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:Ab/P7knTFbf7jlUTjF4saIUhq4Umf6g+SKM3Ozi5iZc=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5704c6c6-dc27-11f0-b763-f4289da6022f
+      - 432a6032-cead-11f0-b672-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -823,29 +817,29 @@ interactions:
       content-type:
       - application/vnd.oasis.opendocument.text
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       etag:
-      - '"0x1FF13BBED693040"'
+      - '"0x1CD273133C25630"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6c6-dc27-11f0-b763-f4289da6022f
+      - 432a6032-cead-11f0-b672-a82bdd58bc01
       x-ms-creation-time:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - aefd0a75-e598-4194-9bd6-2af72e10deb2
+      - e60fcf05-6182-4f2a-b8aa-11d17877548e
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -860,18 +854,16 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:nJp8uQFExdNPZyllxp42BlTNQNU94xfn7wf2l2D3N9I=
       Connection:
       - keep-alive
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5704c6c7-dc27-11f0-b763-f4289da6022f
+      - 432a6033-cead-11f0-bbad-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: DELETE
@@ -889,13 +881,13 @@ interactions:
       Server:
       - Azurite-Blob/3.35.0
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-client-request-id:
-      - 5704c6c7-dc27-11f0-b763-f4289da6022f
+      - 432a6033-cead-11f0-bbad-a82bdd58bc01
       x-ms-delete-type-permanent:
       - 'true'
       x-ms-request-id:
-      - 1fe28e83-4039-4fdd-b135-2cc2bdfe43c5
+      - 6e89e831-6deb-49fe-b3e9-2b061b914dcf
       x-ms-version:
       - '2025-11-05'
     status:
@@ -908,16 +900,14 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:RcgbmzrSh7Na/359Ww3/PAVavwQ21jiuLmH5cO63tiI=
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5704c6c8-dc27-11f0-b763-f4289da6022f
+      - 432a6034-cead-11f0-82be-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: HEAD
@@ -941,29 +931,29 @@ interactions:
       content-type:
       - application/vnd.oasis.opendocument.text
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       etag:
-      - '"0x24F5375462376E0"'
+      - '"0x2090278FF9E1D60"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-access-tier:
       - Hot
       x-ms-access-tier-change-time:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-access-tier-inferred:
       - 'true'
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 5704c6c8-dc27-11f0-b763-f4289da6022f
+      - 432a6034-cead-11f0-82be-a82bdd58bc01
       x-ms-creation-time:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
       x-ms-request-id:
-      - cfc81897-7720-4b3d-aa91-08021e26e9d8
+      - 56504d4d-dbf4-4cb1-83c5-2ff23273b9fe
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
@@ -978,18 +968,16 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:wU3WdN0qMwvHKx6IBgoQu+eQ8VBshojy3S6gREsN7zg=
       Connection:
       - keep-alive
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-client-request-id:
-      - 5704c6c9-dc27-11f0-b763-f4289da6022f
+      - 432a6035-cead-11f0-8720-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: DELETE
@@ -1007,13 +995,13 @@ interactions:
       Server:
       - Azurite-Blob/3.35.0
       date:
-      - Thu, 18 Dec 2025 15:36:38 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-client-request-id:
-      - 5704c6c9-dc27-11f0-b763-f4289da6022f
+      - 432a6035-cead-11f0-8720-a82bdd58bc01
       x-ms-delete-type-permanent:
       - 'true'
       x-ms-request-id:
-      - 13eccd42-d816-47d2-8e16-e9f9d608825a
+      - 737cae39-2619-402a-aab7-aa69f017c09c
       x-ms-version:
       - '2025-11-05'
     status:
@@ -1358,8 +1346,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:4NInd5U6v3c6wggjYOOuH9ulUQbaiVr7hjh/K25et5g=
       Connection:
       - keep-alive
       Content-Length:
@@ -1367,15 +1353,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 58325002-dc27-11f0-b763-f4289da6022f
+      - 432a6036-cead-11f0-9882-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:39 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -1395,15 +1381,15 @@ interactions:
       content-md5:
       - 3+GvKbe94tVqwtpqDsF81Q==
       date:
-      - Thu, 18 Dec 2025 15:36:39 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       etag:
-      - '"0x2701DA224D87EA0"'
+      - '"0x26DA672F24485E0"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:39 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-client-request-id:
-      - 58325002-dc27-11f0-b763-f4289da6022f
+      - 432a6036-cead-11f0-9882-a82bdd58bc01
       x-ms-request-id:
-      - d7efe433-be5c-49b0-b3f9-99f6d28f52de
+      - 5cc011b1-1566-4582-b704-52bc765eed7c
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
@@ -1750,8 +1736,6 @@ interactions:
       - application/xml
       Accept-Encoding:
       - gzip, deflate
-      Authorization:
-      - SharedKey devstoreaccount1:ddhBvbK0oS7QiTYuAIig0/RSeoDGcqjuJ1sAv4Tm01E=
       Connection:
       - keep-alive
       Content-Length:
@@ -1759,15 +1743,15 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.14.0-1017-oem-x86_64-with-glibc2.39)
+      - azsdk-python-storage-blob/12.27.1 Python/3.12.12 (Linux-6.17.0-1025-oem-x86_64-with-glibc2.39)
       x-ms-blob-content-type:
       - application/vnd.oasis.opendocument.text
       x-ms-blob-type:
       - BlockBlob
       x-ms-client-request-id:
-      - 58325003-dc27-11f0-b763-f4289da6022f
+      - 432a6037-cead-11f0-9d5c-a82bdd58bc01
       x-ms-date:
-      - Thu, 18 Dec 2025 15:36:39 GMT
+      - Mon, 01 Dec 2025 12:00:00 GMT
       x-ms-version:
       - '2025-11-05'
     method: PUT
@@ -1787,15 +1771,15 @@ interactions:
       content-md5:
       - 4Th75UY/hdMmecN/cogSrA==
       date:
-      - Thu, 18 Dec 2025 15:36:39 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       etag:
-      - '"0x1BD472A57A8B9E0"'
+      - '"0x243BF04CA984C60"'
       last-modified:
-      - Thu, 18 Dec 2025 15:36:39 GMT
+      - Thu, 11 Jun 2026 10:33:37 GMT
       x-ms-client-request-id:
-      - 58325003-dc27-11f0-b763-f4289da6022f
+      - 432a6037-cead-11f0-9d5c-a82bdd58bc01
       x-ms-request-id:
-      - f145c5d1-9813-47c4-9d48-be99ce1bef34
+      - 89caeac2-35f3-4cf7-8208-1ba66e945ed6
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:


### PR DESCRIPTION
The versions were previously unpinned, and when trying to re-record VCR cassettes for the Documenten API azure blob storage backend, I ran into issues because the latest azure-cli version was unsupported by the latest Azurite version

**Changes**

* Pin azurite and azure-cli in docker setup to compatible versions
* Re-record VCR cassettes for Documenten API azure backend

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [ ] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/open-zaak/open-zaak/wiki/Architectural-Decision-Records-(ADR))
