### PR TITLE
:construction_worker: Explicitly disable log outgoing requests in performance tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,7 @@ jobs:
           ALLOWED_HOSTS: localhost,127.0.0.1
           FUZZY_PAGINATION: true
           DB_CONN_MAX_AGE: 60
+          LOG_REQUESTS: False
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
OAF 0.14.0 changed the default from False to True, so we have to explicitly disable it now

**Changes**

* Explicitly disable log outgoing requests in performance tests

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [x] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/open-zaak/open-zaak/wiki/Architectural-Decision-Records-(ADR))
