### PR TITLE
Fixes #2313 -- use Service mTLS certificates when validating remote URLs

### DIFF
--- a/src/openzaak/nlx/__init__.py
+++ b/src/openzaak/nlx/__init__.py
@@ -7,11 +7,29 @@ from zgw_consumers.models import Service
 def fetcher(url: str, *args, **kwargs):
     """
     Fetch the URL using requests.
+
     If the NLX address is configured, rewrite absolute url to NLX url.
+
+    If the matching :class:`zgw_consumers.models.Service` has TLS certificates
+    configured, use them so that endpoints requiring a server and/or client
+    certificate (mutual TLS) can be reached during validation. See #2313.
     """
     service = Service.get_service(url)
-    if service and service.nlx:
-        # rewrite url
-        url = url.replace(service.api_root, service.nlx, 1)
+    if service:
+        if service.nlx:
+            # rewrite url
+            url = url.replace(service.api_root, service.nlx, 1)
+
+        # apply the (mutual) TLS configuration of the service, mirroring
+        # zgw_consumers.client.ServiceConfigAdapter.get_client_session_kwargs
+        if "verify" not in kwargs and (server_cert := service.server_certificate):
+            kwargs["verify"] = server_cert.public_certificate.path
+        if "cert" not in kwargs and (client_cert := service.client_certificate):
+            client_cert_path = client_cert.public_certificate.path
+            kwargs["cert"] = (
+                (client_cert_path, privkey.path)
+                if (privkey := client_cert.private_key)
+                else client_cert_path
+            )
 
     return requests.get(url, *args, **kwargs)

--- a/src/openzaak/nlx/tests/__init__.py
+++ b/src/openzaak/nlx/tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2024 Dimpact

--- a/src/openzaak/nlx/tests/test_fetcher.py
+++ b/src/openzaak/nlx/tests/test_fetcher.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2024 Dimpact
+"""
+Tests for the ``LINK_FETCHER`` used to validate remote (loose-fk) URLs.
+
+Regression tests for https://github.com/open-zaak/open-zaak/issues/2313: when a
+:class:`zgw_consumers.models.Service` has (mutual) TLS certificates configured,
+those must be used when fetching the URL, so that endpoints requiring a server
+and/or client certificate can be validated.
+"""
+
+from django.test import TestCase
+
+import requests_mock
+from simple_certmanager.test.factories import CertificateFactory
+from zgw_consumers.constants import APITypes, AuthTypes
+from zgw_consumers.test.factories import ServiceFactory
+
+from openzaak.nlx import fetcher
+
+API_ROOT = "https://bag.basisregistraties.overheid.nl/api/v1/"
+OBJECT_URL = f"{API_ROOT}panden/0344100000011708"
+
+
+class FetcherTests(TestCase):
+    @requests_mock.Mocker()
+    def test_no_service_no_certificates(self, m):
+        m.get(OBJECT_URL, status_code=200)
+
+        fetcher(OBJECT_URL)
+
+        self.assertIsNone(m.last_request.cert)
+        # requests defaults verify to True
+        self.assertNotEqual(m.last_request.verify, False)
+
+    @requests_mock.Mocker()
+    def test_service_without_certificates(self, m):
+        m.get(OBJECT_URL, status_code=200)
+        ServiceFactory.create(
+            api_root=API_ROOT,
+            api_type=APITypes.orc,
+            auth_type=AuthTypes.no_auth,
+        )
+
+        fetcher(OBJECT_URL)
+
+        self.assertIsNone(m.last_request.cert)
+
+    @requests_mock.Mocker()
+    def test_server_certificate_used_as_verify(self, m):
+        m.get(OBJECT_URL, status_code=200)
+        server_certificate = CertificateFactory.create()
+        ServiceFactory.create(
+            api_root=API_ROOT,
+            api_type=APITypes.orc,
+            auth_type=AuthTypes.no_auth,
+            server_certificate=server_certificate,
+        )
+
+        fetcher(OBJECT_URL)
+
+        self.assertEqual(
+            m.last_request.verify, server_certificate.public_certificate.path
+        )
+
+    @requests_mock.Mocker()
+    def test_client_certificate_with_private_key_used_as_cert(self, m):
+        m.get(OBJECT_URL, status_code=200)
+        client_certificate = CertificateFactory.create(with_private_key=True)
+        ServiceFactory.create(
+            api_root=API_ROOT,
+            api_type=APITypes.orc,
+            auth_type=AuthTypes.no_auth,
+            client_certificate=client_certificate,
+        )
+
+        fetcher(OBJECT_URL)
+
+        self.assertEqual(
+            m.last_request.cert,
+            (
+                client_certificate.public_certificate.path,
+                client_certificate.private_key.path,
+            ),
+        )
+
+    @requests_mock.Mocker()
+    def test_client_certificate_without_private_key_used_as_cert(self, m):
+        m.get(OBJECT_URL, status_code=200)
+        client_certificate = CertificateFactory.create()
+        ServiceFactory.create(
+            api_root=API_ROOT,
+            api_type=APITypes.orc,
+            auth_type=AuthTypes.no_auth,
+            client_certificate=client_certificate,
+        )
+
+        fetcher(OBJECT_URL)
+
+        self.assertEqual(
+            m.last_request.cert, client_certificate.public_certificate.path
+        )
+
+    @requests_mock.Mocker()
+    def test_explicit_kwargs_take_precedence(self, m):
+        m.get(OBJECT_URL, status_code=200)
+        server_certificate = CertificateFactory.create()
+        client_certificate = CertificateFactory.create(with_private_key=True)
+        ServiceFactory.create(
+            api_root=API_ROOT,
+            api_type=APITypes.orc,
+            auth_type=AuthTypes.no_auth,
+            server_certificate=server_certificate,
+            client_certificate=client_certificate,
+        )
+
+        fetcher(OBJECT_URL, verify=False, cert="/some/explicit/path")
+
+        self.assertEqual(m.last_request.verify, False)
+        self.assertEqual(m.last_request.cert, "/some/explicit/path")
+
+    @requests_mock.Mocker()
+    def test_nlx_rewrite_still_applies(self, m):
+        nlx_url = "http://outway.nlx:8443/kadaster/bag/panden/0344100000011708"
+        m.get(nlx_url, status_code=200)
+        ServiceFactory.create(
+            api_root=API_ROOT,
+            api_type=APITypes.orc,
+            auth_type=AuthTypes.no_auth,
+            nlx="http://outway.nlx:8443/kadaster/bag/",
+        )
+
+        fetcher(OBJECT_URL)
+
+        self.assertEqual(m.last_request.url, nlx_url)


### PR DESCRIPTION
Closes #2313

**Changes**

Creating a `ZaakObject` whose `object` URL points to a service requiring mutual TLS (mTLS) failed during URL validation. The `LINK_FETCHER (openzaak.nlx.fetcher)` already resolves the matching `zgw_consumers Service` to apply NLX rewriting, but it then called `requests.get()` without the client/server certificates that are already configurable on that `Service` — so the certificates were never used.

This change passes the Service's `server_certificate` and `client_certificate` to requests as the `verify` and `cert` arguments, mirroring `zgw_consumers.client.ServiceConfigAdapter.get_client_session_kwargs` so behaviour is consistent with the rest of the stack. Explicitly supplied `verify`/`cert` kwargs still take precedence. No model or admin changes are required, since the certificate fields already exist on `Service`.

Regression tests are added in `openzaak/nlx/tests/test_fetcher.py` covering: server certificate → `verify`, client certificate (with and without private key) → `cert`, the no-service and no-certificate no-op cases, explicit-kwargs precedence, and preservation of NLX rewriting.

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [x] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/open-zaak/open-zaak/wiki/Architectural-Decision-Records-(ADR)) `(N/A — bugfix; uses existing certificate configuration, no functional design decision)`

**Note:** I recently submitted a vulnerability report and had some spare time, so I looked into open issues I could put together a PR for. Apologies in advance if anything here is off — happy to adjust based on your feedback.