### PR TITLE
:bug: [#2429] Allow closing blijvend_bewaren zaken without archiefact…

### DIFF
--- a/src/openzaak/components/zaken/api/serializers/zaken.py
+++ b/src/openzaak/components/zaken/api/serializers/zaken.py
@@ -903,6 +903,13 @@ class StatusSerializer(serializers.HyperlinkedModelSerializer):
                     afleidingswijze=str(afleidingswijze),
                 )
                 brondatum_calculator = None
+
+            elif (
+                brondatum_calculator.get_archiefnominatie()
+                == Archiefnominatie.blijvend_bewaren
+            ):
+                brondatum_calculator = None
+
             else:
                 raise serializers.ValidationError(
                     _("De archiefactiedatum kon niet worden bepaald."),

--- a/src/openzaak/components/zaken/archiving.py
+++ b/src/openzaak/components/zaken/archiving.py
@@ -32,7 +32,9 @@ def calculate_archiving_data(
         return {}
 
     if archiefactiedatum is None:
-        return {}
+        return {
+            "archiefnominatie": calculator.get_archiefnominatie(),
+        }
 
     return {
         "archiefactiedatum": archiefactiedatum,

--- a/src/openzaak/components/zaken/tests/test_zaak_archive.py
+++ b/src/openzaak/components/zaken/tests/test_zaak_archive.py
@@ -1205,6 +1205,91 @@ class US345TestCase(JWTAuthMixin, APITestCase):
         self.assertEqual(zaak.startdatum_bewaartermijn, date(2025, 1, 1))
         self.assertEqual(zaak.archiefactiedatum, date(2035, 1, 1))
 
+    def test_can_close_zaak_with_blijvend_bewaren_without_archiefactietermijn(self):
+        """
+        Closing a zaak with blijvend_bewaren and no archiefactietermijn succeeds.
+        """
+        zaak = ZaakFactory.create()
+        resultaattype = ResultaatTypeFactory.create(
+            zaaktype=zaak.zaaktype,
+            selectielijstklasse="",
+            archiefactietermijn=None,
+            archiefnominatie=Archiefnominatie.blijvend_bewaren,
+            brondatum_archiefprocedure_afleidingswijze=BrondatumArchiefprocedureAfleidingswijze.afgehandeld,
+        )
+
+        ResultaatFactory.create(
+            zaak=zaak,
+            resultaattype=resultaattype,
+        )
+
+        statustype = StatusTypeFactory.create(zaaktype=zaak.zaaktype)
+
+        self.assertIsNone(zaak.archiefactiedatum)
+        self.assertIsNone(zaak.startdatum_bewaartermijn)
+
+        data = {
+            "zaak": f"http://testserver{reverse(zaak)}",
+            "statustype": f"http://testserver{reverse(statustype)}",
+            "datumStatusGezet": "2025-01-01T00:00:00Z",
+        }
+
+        response = self.client.post(reverse("status-list"), data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+
+        zaak.refresh_from_db()
+
+        self.assertEqual(zaak.einddatum, date(2025, 1, 1))
+        self.assertEqual(
+            zaak.archiefnominatie,
+            Archiefnominatie.blijvend_bewaren,
+        )
+        self.assertIsNone(zaak.archiefactiedatum)
+        self.assertIsNone(zaak.startdatum_bewaartermijn)
+
+    def test_cannot_close_zaak_with_vernietigen_without_archiefactiedatum(self):
+        """
+        Closing a zaak with vernietigen and no archiefactiedatum fails.
+        """
+        zaak = ZaakFactory.create()
+
+        resultaattype = ResultaatTypeFactory.create(
+            zaaktype=zaak.zaaktype,
+            selectielijstklasse="",
+            archiefactietermijn=None,
+            archiefnominatie=Archiefnominatie.vernietigen,
+            brondatum_archiefprocedure_afleidingswijze=BrondatumArchiefprocedureAfleidingswijze.afgehandeld,
+        )
+        ResultaatFactory.create(
+            zaak=zaak,
+            resultaattype=resultaattype,
+        )
+
+        statustype = StatusTypeFactory.create(zaaktype=zaak.zaaktype)
+
+        data = {
+            "zaak": f"http://testserver{reverse(zaak)}",
+            "statustype": f"http://testserver{reverse(statustype)}",
+            "datumStatusGezet": "2025-01-01T00:00:00Z",
+        }
+
+        response = self.client.post(reverse("status-list"), data)
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_400_BAD_REQUEST,
+            response.data,
+        )
+
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "archiefactiedatum-error")
+
+        zaak.refresh_from_db()
+        self.assertIsNone(zaak.einddatum)
+        self.assertIsNone(zaak.archiefactiedatum)
+        self.assertIsNone(zaak.startdatum_bewaartermijn)
+
     def test_user_defined_zaak_startdatum_bewaartermijn(self):
         """
         Use zaak.startdatum_bewaartermijn to calculate archive date


### PR DESCRIPTION
…ietermijn

Closes #2429

**Changes**

- Fix regression when closing zaken with `archiefnominatie=blijvend_bewaren` and no calculated `archiefactiedatum`.
- Preserve `archiefnominatie` for these cases.
- Add regression tests for both the success and error paths.

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [x] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/open-zaak/open-zaak/wiki/Architectural-Decision-Records-(ADR))
