### PR TITLE
:zap: [#2272] Ensure fetch for generic resultaattypeomschrijving is cached

### DIFF
--- a/src/openzaak/components/catalogi/models/resultaattype.py
+++ b/src/openzaak/components/catalogi/models/resultaattype.py
@@ -5,6 +5,7 @@ import uuid
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
+from openzaak.selectielijst.api import retrieve_resultaattype_omschrijvingen
 import requests
 from relativedeltafield.utils import parse_relativedelta
 from structlog import get_logger
@@ -302,12 +303,12 @@ class ResultaatType(ETagMixin, OptionalGeldigheidMixin, models.Model):
         Save some derived fields into local object as a means of caching.
         """
         if self.resultaattypeomschrijving:
-            # TODO should this use a proper client?
-            # Yes, perform all selectielijst requests in save in a single http2
-            # session; with proper caching.
+            # TODO make sure a single session is used for these requests
             try:
-                response = requests.get(self.resultaattypeomschrijving).json()
-                self.omschrijving_generiek = response["omschrijving"]
+                resultaattypeomschrijving = retrieve_resultaattype_omschrijvingen(
+                    self.resultaattypeomschrijving
+                )
+                self.omschrijving_generiek = resultaattypeomschrijving["omschrijving"]
             except requests.RequestException:
                 logger.exception(
                     "fetching_resultaattypeomschrijving_failed",


### PR DESCRIPTION
this should speed up generate_data by a decent bit, as it was not applying caching when saving a decent number of resultaattype

Closes #2272 

**Changes**

[Describe the changes here]

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [ ] Any experimental features added in this PR are backwards compatible
  - [ ] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [ ] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/open-zaak/open-zaak/wiki/Architectural-Decision-Records-(ADR))
