### PR TITLE
:white_check_mark: Fix flaky ZIO validation that made actual HTTP calls

### DIFF
--- a/src/openzaak/components/zaken/tests/test_validation.py
+++ b/src/openzaak/components/zaken/tests/test_validation.py
@@ -51,15 +51,18 @@ class ZaakInformatieObjectValidationTests(JWTAuthMixin, APITestCase):
 
     @override_settings(ALLOWED_HOSTS=["testserver"])
     def test_informatieobject_invalid(self):
-        ServiceFactory.create(api_root="https://drc.nl/", api_type=APITypes.drc)
+        ServiceFactory.create(api_root="https://some-api.local/", api_type=APITypes.drc)
         zaak = ZaakFactory.create()
         zaak_url = reverse(zaak)
 
         url = reverse(ZaakInformatieObject)
 
-        response = self.client.post(
-            url, {"zaak": zaak_url, "informatieobject": "https://drc.nl/api/v1"}
-        )
+        with requests_mock.Mocker() as m:
+            m.get("https://some-api.local/api/v1", status_code=404)
+            response = self.client.post(
+                url,
+                {"zaak": zaak_url, "informatieobject": "https://some-api.local/api/v1"},
+            )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
**Changes**
* Fix flaky ZIO validation that made actual HTTP calls

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [x] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/open-zaak/open-zaak/wiki/Architectural-Decision-Records-(ADR))
