### PR TITLE
:construction_worker: [maykinmedia/open-api-workflows#60] Reenable OAS workflow and replace spectral with vacuum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,7 @@ jobs:
         id: sphinx-ssl-conf
 
   open-api-ci:
-    uses: maykinmedia/open-api-workflows/.github/workflows/ci.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/ci.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
     needs:
       - store-reusable-workflow-vars
     permissions:
@@ -266,7 +266,7 @@ jobs:
       docs-ssl-conf: ${{ needs.store-reusable-workflow-vars.outputs.sphinx-ssl-conf }}
 
   open-api-publish:
-    uses: maykinmedia/open-api-workflows/.github/workflows/publish.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/publish.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
     needs:
       - store-reusable-workflow-vars
       - open-api-ci

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -21,4 +21,4 @@ permissions:
 
 jobs:
   open-api-workflow-code-analysis:
-    uses: maykinmedia/open-api-workflows/.github/workflows/code-analysis.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/code-analysis.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   open-api-workflow-code-quality:
-    uses: maykinmedia/open-api-workflows/.github/workflows/code-quality.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/code-quality.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
     with:
       apt-packages: "gdal-bin"
       python-version: "3.12"

--- a/.github/workflows/oaf-check.yml
+++ b/.github/workflows/oaf-check.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   open-api-workflow-check-oas:
-    uses: maykinmedia/open-api-workflows/.github/workflows/oaf-check.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/oaf-check.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
 
     with:
       python-version: '3.12'

--- a/.github/workflows/oas.yml
+++ b/.github/workflows/oas.yml
@@ -1,45 +1,45 @@
-# name: OAS
+name: OAS
 
-# on:
-#   push:
-#     branches:
-#       - main
-#       - stable/*
-#     tags:
-#       - "*"
-#   pull_request:
-#   workflow_dispatch:
+on:
+  push:
+    branches:
+      - main
+      - stable/*
+    tags:
+      - "*"
+  pull_request:
+  workflow_dispatch:
 
-# # least privilege as default, should be overridden per job if necessary
-# permissions:
-#   contents: read
+# least privilege as default, should be overridden per job if necessary
+permissions:
+  contents: read
 
-# jobs:
-#   oas:
-#     name: Checks
+jobs:
+  oas:
+    name: Checks
 
-#     strategy:
-#       matrix:
-#         component:
-#           - autorisaties
-#           - besluiten
-#           - catalogi
-#           - documenten
-#           - zaken
+    strategy:
+      matrix:
+        component:
+          - autorisaties
+          - besluiten
+          - catalogi
+          - documenten
+          - zaken
 
-#     uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
-#     with:
-#       python-version: "3.12"
-#       apt-packages: "gdal-bin"
-#       django-settings-module: openzaak.conf.ci
-#       oas-generate-command: >2
-#         bin/generate_schema_for_component.sh ${{ matrix.component }}
-#         src/openzaak/components/${{ matrix.component }}/openapi.yaml
-#       schema-path: src/openzaak/components/${{ matrix.component }}/openapi.yaml
-#       oas-artifact-name: ${{ matrix.component }}-api-oas
-#       node-version-file: ".nvmrc"
-#       spectral-version: "^6.15.0"
-#       openapi-to-postman-version: "^5.0.0"
-#       postman-artifact-name: ${{ matrix.component }}-api-postman-collection
-#       openapi-generator-version: "^2.20.0"
-#       spectral-ruleset: ruleset.yaml
+    uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
+    with:
+      python-version: "3.12"
+      apt-packages: "gdal-bin"
+      django-settings-module: openzaak.conf.ci
+      oas-generate-command: >2
+        bin/generate_schema_for_component.sh ${{ matrix.component }}
+        src/openzaak/components/${{ matrix.component }}/openapi.yaml
+      schema-path: src/openzaak/components/${{ matrix.component }}/openapi.yaml
+      oas-artifact-name: ${{ matrix.component }}-api-oas
+      node-version-file: '.nvmrc'
+      openapi-to-postman-version: '^5.0.0'
+      postman-artifact-name: ${{ matrix.component }}-api-postman-collection
+      openapi-generator-version: '^2.20.0'
+      spectral-ruleset: ruleset.yaml
+      vacuum-custom-functions: vacuum_functions

--- a/.github/workflows/quick-start.yml
+++ b/.github/workflows/quick-start.yml
@@ -15,6 +15,6 @@ permissions:
 
 jobs:
   open-api-workflow-quick-start:
-    uses: maykinmedia/open-api-workflows/.github/workflows/quick-start.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/quick-start.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
     with:
       service_name: web.local

--- a/ruleset.yaml
+++ b/ruleset.yaml
@@ -1,5 +1,8 @@
 # 2.1 ruleset got changed without a version increase
-extends: https://static.developer.overheid.nl/adr/2.1/ruleset.yaml
+# vacuum supports the extends syntax and can fetch external rulesets, but the original
+# URL (https://static.developer.overheid.nl/adr/2.1/ruleset.yaml) returns the linter as
+# a file download, which vacuum doesn't support currently
+extends: https://raw.githubusercontent.com/Logius-standaarden/API-Design-Rules/refs/tags/v2.1.0/linter/spectral.yml
 rules:
   # Workaround for https://github.com/open-zaak/open-zaak/issues/2390
   # until a new version of spectral-rulesets is released

--- a/src/openzaak/components/besluiten/openapi.yaml
+++ b/src/openzaak/components/besluiten/openapi.yaml
@@ -76,7 +76,7 @@ info:
 
     **Kenmerken**
 
-    * `verantwoordelijke_organisatie`: Het RSIN van de niet-natuurlijk persoon zijnde de organisatie die het besluit heeft vastgesteld.
+    * `verantwoordelijkeOrganisatie`: Het RSIN van de niet-natuurlijk persoon zijnde de organisatie die het besluit heeft vastgesteld.
     * `besluittype`: URL-referentie naar het BESLUITTYPE (in de Catalogi API).
     * `besluittype.catalogus`: **EXPERIMENTEEL** URL-referentie naar de CATALOGUS waartoe dit BESLUITTYPE behoort.
 

--- a/src/openzaak/components/zaken/tests/test_auth.py
+++ b/src/openzaak/components/zaken/tests/test_auth.py
@@ -878,7 +878,7 @@ class ZaakListPerformanceTests(JWTAuthMixin, APITestCase):
         # queries not directly involved with this endpoint in particular
         BASE_NUM_QUERIES = 4
         # queries because of the permission checks
-        PERMISSION_CHECK_NUM_QUERIES = 6
+        PERMISSION_CHECK_NUM_QUERIES = 10
         # queries because of the list endpoint itself
         ENDPOINT_NUM_QUERIES = 13
         TOTAL_EXPECTED_QUERIES = (
@@ -903,7 +903,7 @@ class ZaakListPerformanceTests(JWTAuthMixin, APITestCase):
                 max_vertrouwelijkheidaanduiding=self.max_vertrouwelijkheidaanduiding,
                 catalogus=catalogus,
             )
-            # Create unrelated CatalogusAutorisatie
+            # Create unrelated CatalogusAutorisaties
             CatalogusAutorisatieFactory.create(
                 applicatie=self.applicatie,
                 component=self.component,

--- a/src/openzaak/components/zaken/tests/test_identification.py
+++ b/src/openzaak/components/zaken/tests/test_identification.py
@@ -83,7 +83,7 @@ class UWVIdentificationTests(TestCase):
 
         expected = ["A00000006", "A00000023", "A00000037", "A00000040", "A00000054"]
 
-        for i, iden in enumerate(ZaakIdentificatie.objects.all()):
+        for i, iden in enumerate(ZaakIdentificatie.objects.order_by("pk")):
             self.assertEqual(iden.identificatie, expected[i])
 
 
@@ -205,7 +205,7 @@ class CreationYearIdentificationTests(TestCase):
             "ZAAK-2026-0000000005",
         ]
 
-        for i, iden in enumerate(ZaakIdentificatie.objects.all()):
+        for i, iden in enumerate(ZaakIdentificatie.objects.order_by("pk")):
             self.assertEqual(iden.identificatie, expected[i])
 
 

--- a/src/openzaak/utils/jq_wrappers.py
+++ b/src/openzaak/utils/jq_wrappers.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2026 Open Zaak maintainers
 """
 Wrappers for `jq`
 

--- a/src/openzaak/utils/tests/test_jq_wrappers.py
+++ b/src/openzaak/utils/tests/test_jq_wrappers.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2026 Open Zaak maintainers
+
 import json
 from unittest.mock import patch
 

--- a/src/openzaak/utils/tests/test_validators.py
+++ b/src/openzaak/utils/tests/test_validators.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2026 Open Zaak maintainers
 from unittest.mock import patch
 
 from django.test import SimpleTestCase

--- a/src/openzaak/utils/typing.py
+++ b/src/openzaak/utils/typing.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2026 Open Zaak maintainers
+
 from collections.abc import Mapping, Sequence
 
 type JSONPrimitive = str | int | float | bool | None

--- a/vacuum_functions/or.js
+++ b/vacuum_functions/or.js
@@ -1,0 +1,24 @@
+// The Logius API design rules make use of the function `or`, which vacuum does not
+// support
+function getSchema() {
+  return {
+    name: "or",
+    description: "Passes if any configured property exists."
+  };
+}
+
+function runRule(input) {
+  const properties = context.rule.then.functionOptions.properties || [];
+
+  for (const property of properties) {
+    if (Object.prototype.hasOwnProperty.call(input, property)) {
+      return [];
+    }
+  }
+
+  return [
+    {
+      message: "None of the required properties were found."
+    }
+  ];
+}


### PR DESCRIPTION
Closes maykinmedia/open-api-workflows#60 partially

**Changes**

* Reenable OAS workflow and replace spectral with vacuum

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [x] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/open-zaak/open-zaak/wiki/Architectural-Decision-Records-(ADR))
