### PR TITLE
Feature/2451 besluiten audittrails

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -30,7 +30,7 @@ drf-extra-fields
 drf-writable-nested
 humanize
 
-commonground-api-common[setup-configuration,testutils,oas] @ git+https://github.com/maykinmedia/commonground-api-common.git@release/2.15.1
+commonground-api-common[setup-configuration,testutils,oas]
 maykin-common[axes,mfa,otel,cli,health-checks]
 psycopg[pool, binary]
 zgw-consumers[oauth2]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -85,7 +85,7 @@ click-repl==0.2.0
     # via celery
 cloudevents==1.12.0
     # via -r requirements/base.in
-commonground-api-common @ git+https://github.com/maykinmedia/commonground-api-common.git@0d24d37625484211ad0f46cdd4093fe478cfdb66
+commonground-api-common==2.15.1
     # via
     #   -r requirements/base.in
     #   open-api-framework

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -154,7 +154,7 @@ cloudevents==1.12.0
     #   -r requirements/base.txt
 codecov==2.1.13
     # via -r requirements/test-tools.in
-commonground-api-common @ git+https://github.com/maykinmedia/commonground-api-common.git@0d24d37625484211ad0f46cdd4093fe478cfdb66
+commonground-api-common==2.15.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -181,7 +181,7 @@ codecov==2.1.13
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-commonground-api-common @ git+https://github.com/maykinmedia/commonground-api-common.git@0d24d37625484211ad0f46cdd4093fe478cfdb66
+commonground-api-common==2.15.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/openzaak/components/besluiten/admin.py
+++ b/src/openzaak/components/besluiten/admin.py
@@ -7,9 +7,9 @@ from django.db.models.functions import Concat
 from django.utils.translation import gettext_lazy as _
 
 from openzaak.utils.admin import (
-    AuditTrailAdminMixin,
     EditInlineAdminMixin,
     ListObjectActionsAdminMixin,
+    MultipleAuditTrailAdminMixin,
     UUIDAdminMixin,
     link_to_related_objects,
 )
@@ -44,7 +44,7 @@ class BesluitInformatieObjectForm(forms.ModelForm):
 
 @admin.register(BesluitInformatieObject)
 class BesluitInformatieObjectAdmin(
-    AuditTrailAdminMixin, UUIDAdminMixin, admin.ModelAdmin
+    MultipleAuditTrailAdminMixin, UUIDAdminMixin, admin.ModelAdmin
 ):
     form = BesluitInformatieObjectForm
     list_display = (
@@ -99,7 +99,10 @@ class BesluitForm(forms.ModelForm):
 
 @admin.register(Besluit)
 class BesluitAdmin(
-    AuditTrailAdminMixin, ListObjectActionsAdminMixin, UUIDAdminMixin, admin.ModelAdmin
+    MultipleAuditTrailAdminMixin,
+    ListObjectActionsAdminMixin,
+    UUIDAdminMixin,
+    admin.ModelAdmin,
 ):
     form = BesluitForm
     list_display = ("verantwoordelijke_organisatie", "identificatie", "datum")

--- a/src/openzaak/components/besluiten/api/viewsets.py
+++ b/src/openzaak/components/besluiten/api/viewsets.py
@@ -441,7 +441,7 @@ class BesluitVerwerkenViewSet(
                 "besluit"
             ].unique_representation(),
             audit=AUDIT_BRC,
-            basename="besluit",
+            basename=Besluit._meta.object_name.lower(),
             main_object=brc_data["url"],
         )
 
@@ -458,7 +458,7 @@ class BesluitVerwerkenViewSet(
                     "besluit"
                 ].unique_representation(),
                 audit=AUDIT_ZRC,
-                basename="besluit",
+                basename=Besluit._meta.object_name.lower(),
                 main_object=zaak,
             )
 
@@ -473,8 +473,8 @@ class BesluitVerwerkenViewSet(
                     i
                 ].unique_representation(),
                 audit=AUDIT_BRC,
-                basename="besluitinformatieobject",
-                main_object=brc_data["url"],
+                basename=BesluitInformatieObject._meta.object_name.lower(),
+                main_object=brc_data["besluit"],
             )
 
             if zaak:
@@ -488,7 +488,7 @@ class BesluitVerwerkenViewSet(
                         "besluitinformatieobjecten"
                     ][i].unique_representation(),
                     audit=AUDIT_ZRC,
-                    basename="besluitinformatieobject",
+                    basename=BesluitInformatieObject._meta.object_name.lower(),
                     main_object=zaak,
                 )
 

--- a/src/openzaak/components/besluiten/api/viewsets.py
+++ b/src/openzaak/components/besluiten/api/viewsets.py
@@ -15,9 +15,6 @@ from rest_framework import mixins, status, viewsets
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
-from vng_api_common.audittrails.viewsets import (
-    AuditTrailMixin,
-)
 from vng_api_common.caching import conditional_retrieve
 from vng_api_common.constants import CommonResourceAction
 from vng_api_common.viewsets import CheckQueryParamsMixin
@@ -35,6 +32,7 @@ from openzaak.utils.api import delete_remote_oio
 from openzaak.utils.audittrails import (
     MultipleAuditTrailsCreateMixin,
     MultipleAuditTrailsDestroyMixin,
+    MultipleAuditTrailsMixin,
     MultipleAuditTrailsViewsetMixin,
 )
 from openzaak.utils.cloudevents import get_url, process_cloudevent
@@ -391,7 +389,7 @@ class BesluitVerwerkenViewSet(
     viewsets.ViewSet,
     MultipleObjectsMultipleChannelNotificationMixin,
     ClosedZaakMixin,
-    AuditTrailMixin,
+    MultipleAuditTrailsMixin,
 ):
     serializer_class = BesluitVerwerkenSerializer
     permission_classes = (BesluitVerwerkenAuthRequired,)
@@ -432,33 +430,71 @@ class BesluitVerwerkenViewSet(
 
         response = Response(serializer.data, status=status.HTTP_201_CREATED)
 
-        # TODO conv namespace audittrails
+        brc_data = self._replace_namespaces(
+            serializer.data["besluit"], ["url"], "besluiten"
+        )
         self.create_audittrail(
             response.status_code,
             CommonResourceAction.create,
             version_before_edit=None,
-            version_after_edit=serializer.data["besluit"],
+            version_after_edit=brc_data,
             unique_representation=serializer.instance[
                 "besluit"
             ].unique_representation(),
             audit=AUDIT_BRC,
             basename="besluit",
-            main_object=serializer.data["besluit"]["url"],
+            main_object=brc_data["url"],
         )
 
-        for i, data in enumerate(serializer.data["besluitinformatieobjecten"]):
+        zaak = serializer.data["besluit"]["zaak"]
+
+        if zaak:
+            zrc_data = self._replace_namespaces(
+                serializer.data["besluit"], ["url"], "zaken"
+            )
             self.create_audittrail(
                 response.status_code,
                 CommonResourceAction.create,
                 version_before_edit=None,
-                version_after_edit=data,
+                version_after_edit=zrc_data,
+                unique_representation=serializer.instance[
+                    "besluit"
+                ].unique_representation(),
+                audit=AUDIT_ZRC,
+                basename="besluit",
+                main_object=zaak,
+            )
+
+        for i, data in enumerate(serializer.data["besluitinformatieobjecten"]):
+            brc_data = self._replace_namespaces(data, ["url", "besluit"], "besluiten")
+            self.create_audittrail(
+                response.status_code,
+                CommonResourceAction.create,
+                version_before_edit=None,
+                version_after_edit=brc_data,
                 unique_representation=serializer.instance["besluitinformatieobjecten"][
                     i
                 ].unique_representation(),
                 audit=AUDIT_BRC,
                 basename="besluitinformatieobject",
-                main_object=data["url"],
+                main_object=brc_data["url"],
             )
+
+            if zaak:
+                zrc_data = self._replace_namespaces(data, ["url", "besluit"], "zaken")
+                self.create_audittrail(
+                    response.status_code,
+                    CommonResourceAction.create,
+                    version_before_edit=None,
+                    version_after_edit=zrc_data,
+                    unique_representation=serializer.instance[
+                        "besluitinformatieobjecten"
+                    ][i].unique_representation(),
+                    audit=AUDIT_ZRC,
+                    basename="besluitinformatieobject",
+                    main_object=zaak,
+                )
+
         self.notify(response.status_code, response.data)
         return response
 

--- a/src/openzaak/components/besluiten/api/viewsets.py
+++ b/src/openzaak/components/besluiten/api/viewsets.py
@@ -16,10 +16,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from vng_api_common.audittrails.viewsets import (
-    AuditTrailCreateMixin,
-    AuditTrailDestroyMixin,
     AuditTrailMixin,
-    AuditTrailViewsetMixin,
 )
 from vng_api_common.caching import conditional_retrieve
 from vng_api_common.constants import CommonResourceAction
@@ -35,6 +32,11 @@ from openzaak.notifications.viewsets import (
     MultipleObjectsMultipleChannelNotificationMixin,
 )
 from openzaak.utils.api import delete_remote_oio
+from openzaak.utils.audittrails import (
+    MultipleAuditTrailsCreateMixin,
+    MultipleAuditTrailsDestroyMixin,
+    MultipleAuditTrailsViewsetMixin,
+)
 from openzaak.utils.cloudevents import get_url, process_cloudevent
 from openzaak.utils.data_filtering import ListFilterByAuthorizationsMixin
 from openzaak.utils.help_text import mark_experimental
@@ -43,6 +45,7 @@ from openzaak.utils.pagination import ExactPagination
 from openzaak.utils.permissions import AuthRequired
 from openzaak.utils.views import AuditTrailViewSet
 
+from ...zaken.api.audits import AUDIT_ZRC
 from ..models import Besluit, BesluitInformatieObject
 from .audits import AUDIT_BRC
 from .cloudevents import BESLUIT_VERWERKT
@@ -131,7 +134,7 @@ logger = structlog.stdlib.get_logger(__name__)
 class BesluitViewSet(
     CheckQueryParamsMixin,
     MultipleChannelNotificationViewSetMixin,
-    AuditTrailViewsetMixin,
+    MultipleAuditTrailsViewsetMixin,
     ListFilterByAuthorizationsMixin,
     ClosedZaakMixin,
     viewsets.ModelViewSet,
@@ -156,7 +159,7 @@ class BesluitViewSet(
         {"kanaal": KANAAL_BESLUITEN, "deprecated": True},
         {"kanaal": KANAAL_ZAKEN},
     ]
-    audit = AUDIT_BRC
+    audits = [AUDIT_BRC, AUDIT_ZRC]
 
     def perform_create(self, serializer):
         super().perform_create(serializer)
@@ -249,8 +252,8 @@ class BesluitInformatieObjectViewSet(
     CacheQuerysetMixin,  # should be applied before other mixins
     MultipleChannelNotificationCreateMixin,
     MultipleChannelNotificationDestroyMixin,
-    AuditTrailCreateMixin,
-    AuditTrailDestroyMixin,
+    MultipleAuditTrailsCreateMixin,
+    MultipleAuditTrailsDestroyMixin,
     CheckQueryParamsMixin,
     ListFilterByAuthorizationsMixin,
     mixins.CreateModelMixin,
@@ -281,7 +284,9 @@ class BesluitInformatieObjectViewSet(
     ]
     notifications_main_resource_keys = {"zaken": "besluit.zaak"}
     notifications_replace_urls_for = ["besluit"]
-    audit = AUDIT_BRC
+    audits = [AUDIT_BRC, AUDIT_ZRC]
+    audittrail_main_resource_keys = {"ZRC": "besluit.zaak"}
+    audittrail_replace_urls_for = ["besluit"]
 
     @property
     def notifications_wrap_in_atomic_block(self):
@@ -427,6 +432,7 @@ class BesluitVerwerkenViewSet(
 
         response = Response(serializer.data, status=status.HTTP_201_CREATED)
 
+        # TODO conv namespace audittrails
         self.create_audittrail(
             response.status_code,
             CommonResourceAction.create,

--- a/src/openzaak/components/besluiten/api/viewsets.py
+++ b/src/openzaak/components/besluiten/api/viewsets.py
@@ -39,6 +39,7 @@ from openzaak.utils.cloudevents import get_url, process_cloudevent
 from openzaak.utils.data_filtering import ListFilterByAuthorizationsMixin
 from openzaak.utils.help_text import mark_experimental
 from openzaak.utils.mixins import CacheQuerysetMixin
+from openzaak.utils.namespacing import replace_namespaces
 from openzaak.utils.pagination import ExactPagination
 from openzaak.utils.permissions import AuthRequired
 from openzaak.utils.views import AuditTrailViewSet
@@ -430,9 +431,7 @@ class BesluitVerwerkenViewSet(
 
         response = Response(serializer.data, status=status.HTTP_201_CREATED)
 
-        brc_data = self._replace_namespaces(
-            serializer.data["besluit"], ["url"], "besluiten"
-        )
+        brc_data = replace_namespaces(serializer.data["besluit"], ["url"], "besluiten")
         self.create_audittrail(
             response.status_code,
             CommonResourceAction.create,
@@ -449,9 +448,7 @@ class BesluitVerwerkenViewSet(
         zaak = serializer.data["besluit"]["zaak"]
 
         if zaak:
-            zrc_data = self._replace_namespaces(
-                serializer.data["besluit"], ["url"], "zaken"
-            )
+            zrc_data = replace_namespaces(serializer.data["besluit"], ["url"], "zaken")
             self.create_audittrail(
                 response.status_code,
                 CommonResourceAction.create,
@@ -466,7 +463,7 @@ class BesluitVerwerkenViewSet(
             )
 
         for i, data in enumerate(serializer.data["besluitinformatieobjecten"]):
-            brc_data = self._replace_namespaces(data, ["url", "besluit"], "besluiten")
+            brc_data = replace_namespaces(data, ["url", "besluit"], "besluiten")
             self.create_audittrail(
                 response.status_code,
                 CommonResourceAction.create,
@@ -481,7 +478,7 @@ class BesluitVerwerkenViewSet(
             )
 
             if zaak:
-                zrc_data = self._replace_namespaces(data, ["url", "besluit"], "zaken")
+                zrc_data = replace_namespaces(data, ["url", "besluit"], "zaken")
                 self.create_audittrail(
                     response.status_code,
                     CommonResourceAction.create,

--- a/src/openzaak/components/besluiten/api/viewsets.py
+++ b/src/openzaak/components/besluiten/api/viewsets.py
@@ -284,7 +284,7 @@ class BesluitInformatieObjectViewSet(
     notifications_main_resource_keys = {"zaken": "besluit.zaak"}
     notifications_replace_urls_for = ["besluit"]
     audits = [AUDIT_BRC, AUDIT_ZRC]
-    audittrail_main_resource_keys = {"ZRC": "besluit.zaak"}
+    audittrail_main_resource_keys = {AUDIT_ZRC.component_name: "besluit.zaak"}
     audittrail_replace_urls_for = ["besluit"]
 
     @property

--- a/src/openzaak/components/besluiten/tests/test_audittrails.py
+++ b/src/openzaak/components/besluiten/tests/test_audittrails.py
@@ -351,23 +351,127 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
 
         self.assertEqual(AuditTrail.objects.count(), 3)
 
-        besluit_audittrail = AuditTrail.objects.get(
-            hoofd_object=response.data["besluit"]["url"]
-        )
+        besluit_audittrail = AuditTrail.objects.get(resource="besluit")
+
+        besluit = Besluit.objects.get()
 
         self.assertEqual(besluit_audittrail.bron, "BRC")
         self.assertEqual(besluit_audittrail.actie, "create")
-        self.assertEqual(besluit_audittrail.resource, "besluit")
         self.assertEqual(besluit_audittrail.oud, None)
         self.assertEqual(besluit_audittrail.nieuw, response.data["besluit"])
+        self.assertEqual(
+            besluit_audittrail.hoofd_object,
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
 
-        for trail in AuditTrail.objects.filter(
-            nieuw__in=response.data["besluitinformatieobjecten"]
-        ):
+        for trail in AuditTrail.objects.filter(resource="besluitinfromatieobject"):
             self.assertEqual(trail.bron, "BRC")
             self.assertEqual(trail.actie, "create")
-            self.assertEqual(trail.resource, "besluitinformatieobject")
             self.assertEqual(trail.oud, None)
+            self.assertEqual(
+                trail.hoofd_object,
+                f"http://testserver{reverse(besluit, namespace='besluiten')}",
+            )
+
+    @tag("convenience-endpoints")
+    def test_verwerk_besluit__with_zaak_audittrails(self):
+        zaak = ZaakFactory.create()
+        zaak_url = reverse(zaak)
+        besluittype = BesluitTypeFactory.create(concept=False)
+        besluittype.zaaktypen.add(zaak.zaaktype)
+        besluittype_url = reverse(besluittype)
+
+        informatieobjecttype = InformatieObjectTypeFactory.create(
+            concept=False, catalogus=besluittype.catalogus
+        )
+        besluittype.informatieobjecttypen.add(informatieobjecttype)
+
+        informatieobject_1 = EnkelvoudigInformatieObjectFactory.create(
+            informatieobjecttype=informatieobjecttype
+        )
+        informatieobject_url_1 = reverse(informatieobject_1)
+
+        informatieobject_2 = EnkelvoudigInformatieObjectFactory.create(
+            informatieobjecttype=informatieobjecttype
+        )
+        informatieobject_url_2 = reverse(informatieobject_2)
+
+        url = reverse("besluiten:verwerkbesluit-list")
+
+        data = {
+            "besluit": {
+                "verantwoordelijkeOrganisatie": "000000000",
+                "besluittype": f"http://testserver{besluittype_url}",
+                "zaak": f"http://testserver{zaak_url}",
+                "datum": "2019-04-25",
+                "ingangsdatum": "2019-04-26",
+                "vervaldatum": "2019-04-28",
+                "identificatie": "123123",
+            },
+            "besluitinformatieobjecten": [
+                {"informatieobject": f"http://testserver{informatieobject_url_1}"},
+                {"informatieobject": f"http://testserver{informatieobject_url_2}"},
+            ],
+        }
+
+        response = self.client.post(url, data)
+
+        self.assertEqual(response.status_code, 201)
+
+        self.assertEqual(AuditTrail.objects.count(), 6)
+
+        besluit_brc_audittrail = AuditTrail.objects.get(resource="besluit", bron="BRC")
+
+        besluit = Besluit.objects.get()
+
+        self.assertEqual(besluit_brc_audittrail.actie, "create")
+        self.assertEqual(besluit_brc_audittrail.oud, None)
+        self.assertEqual(besluit_brc_audittrail.nieuw, response.data["besluit"])
+        self.assertEqual(
+            besluit_brc_audittrail.hoofd_object,
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
+
+        besluit_zrc_audittrail = AuditTrail.objects.get(resource="besluit", bron="ZRC")
+
+        self.assertEqual(besluit_zrc_audittrail.actie, "create")
+        self.assertEqual(besluit_zrc_audittrail.oud, None)
+        self.assertEqual(
+            besluit_zrc_audittrail.nieuw,
+            response.data["besluit"]
+            | {"url": f"http://testserver{reverse(besluit, namespace='zaken')}"},
+        )
+        self.assertEqual(
+            besluit_zrc_audittrail.hoofd_object, f"http://testserver{zaak_url}"
+        )
+
+        for brc_bio_trail in AuditTrail.objects.filter(
+            resource="besluitinfromatieobject", bron="BRC"
+        ):
+            self.assertEqual(brc_bio_trail.actie, "create")
+            self.assertEqual(brc_bio_trail.oud, None)
+            self.assertEqual(
+                brc_bio_trail.hoofd_object,
+                f"http://testserver{reverse(besluit, namespace='besluiten')}",
+            )
+            self.assertIn(
+                "besluiten/api/besluitinformatieobjecten", brc_bio_trail.nieuw["url"]
+            )
+            self.assertIn("besluiten/api/besluiten", brc_bio_trail.nieuw["besluit"])
+
+        for zrc_bio_trail in AuditTrail.objects.filter(
+            resource="besluitinfromatieobject", bron="ZRC"
+        ):
+            self.assertEqual(zrc_bio_trail.actie, "create")
+            self.assertEqual(zrc_bio_trail.oud, None)
+            self.assertEqual(
+                zrc_bio_trail.hoofd_object,
+                f"http://testserver{reverse(besluit, namespace='besluiten')}",
+            )
+            self.assertIn(
+                "zaken/api/besluitinformatieobjecten", brc_bio_trail.nieuw["url"]
+            )
+            self.assertIn("zaken/api/besluiten", brc_bio_trail.nieuw["besluit"])
 
     def test_delete_besluit_cascade_audittrails(self):
         besluit_data = self._create_besluit()

--- a/src/openzaak/components/besluiten/tests/test_audittrails.py
+++ b/src/openzaak/components/besluiten/tests/test_audittrails.py
@@ -32,6 +32,7 @@ from .factories import BesluitFactory
 class AuditTrailTests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
     NAMESPACE = "besluiten"
+    maxDiff = None
 
     def _create_besluit(self, zaak: Type[Zaak] | None = None, **headers):
         url = reverse(Besluit, namespace=self.NAMESPACE)
@@ -71,11 +72,16 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Verify that the audittrail for the Besluit creation contains the correct
         # information
         besluit_create_audittrail = audittrails.get()
+        besluit = Besluit.objects.get()
         self.assertEqual(besluit_create_audittrail.bron, "BRC")
         self.assertEqual(besluit_create_audittrail.actie, "create")
         self.assertEqual(besluit_create_audittrail.resultaat, 201)
         self.assertEqual(besluit_create_audittrail.oud, None)
-        self.assertEqual(besluit_create_audittrail.nieuw, besluit_response)
+        self.assertEqual(
+            besluit_create_audittrail.nieuw,
+            besluit_response
+            | {"url": f"http://testserver{reverse(besluit, namespace='besluiten')}"},
+        )
 
     def test_create_besluit_audittrail_with_zaak(self):
         zaak = ZaakFactory.create()
@@ -99,7 +105,11 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
             f"http://testserver{reverse(besluit, namespace='besluiten')}",
         )
         self.assertEqual(besluiten_create_audittrail.oud, None)
-        self.assertEqual(besluiten_create_audittrail.nieuw, besluit_response)
+        self.assertEqual(
+            besluiten_create_audittrail.nieuw,
+            besluit_response
+            | {"url": f"http://testserver{reverse(besluit, namespace='besluiten')}"},
+        )
 
         zaken_create_audittrail = audittrails.get(bron="ZRC")
         self.assertEqual(zaken_create_audittrail.actie, "create")
@@ -136,11 +146,20 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Verify that the audittrail for the Besluit update contains the correct
         # information
         besluit_update_audittrail = audittrails.last()
+        besluit = Besluit.objects.get()
         self.assertEqual(besluit_update_audittrail.bron, "BRC")
         self.assertEqual(besluit_update_audittrail.actie, "update")
         self.assertEqual(besluit_update_audittrail.resultaat, 200)
-        self.assertEqual(besluit_update_audittrail.oud, besluit_data)
-        self.assertEqual(besluit_update_audittrail.nieuw, besluit_response)
+        self.assertEqual(
+            besluit_update_audittrail.oud,
+            besluit_data
+            | {"url": f"http://testserver{reverse(besluit, namespace='besluiten')}"},
+        )
+        self.assertEqual(
+            besluit_update_audittrail.nieuw,
+            besluit_response
+            | {"url": f"http://testserver{reverse(besluit, namespace='besluiten')}"},
+        )
 
     def test_partial_update_besluit_audittrails(self):
         besluit_data = self._create_besluit()
@@ -151,14 +170,24 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         audittrails = AuditTrail.objects
         self.assertEqual(audittrails.count(), 2)
 
+        besluit = Besluit.objects.get()
+
         # Verify that the audittrail for the Besluit partial_update contains the
         # correct information
         besluit_update_audittrail = audittrails.last()
         self.assertEqual(besluit_update_audittrail.bron, "BRC")
         self.assertEqual(besluit_update_audittrail.actie, "partial_update")
         self.assertEqual(besluit_update_audittrail.resultaat, 200)
-        self.assertEqual(besluit_update_audittrail.oud, besluit_data)
-        self.assertEqual(besluit_update_audittrail.nieuw, besluit_response)
+        self.assertEqual(
+            besluit_update_audittrail.oud,
+            besluit_data
+            | {"url": f"http://testserver{reverse(besluit, namespace='besluiten')}"},
+        )
+        self.assertEqual(
+            besluit_update_audittrail.nieuw,
+            besluit_response
+            | {"url": f"http://testserver{reverse(besluit, namespace='besluiten')}"},
+        )
 
     def test_partial_update_besluit_audittrails_add_zaak(self):
         besluit_data = self._create_besluit()
@@ -180,8 +209,16 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # correct information
         besluit_update_audittrail = audittrails.get(bron="BRC", actie="partial_update")
         self.assertEqual(besluit_update_audittrail.resultaat, 200)
-        self.assertEqual(besluit_update_audittrail.oud, besluit_data)
-        self.assertEqual(besluit_update_audittrail.nieuw, response.data)
+        self.assertEqual(
+            besluit_update_audittrail.oud,
+            besluit_data
+            | {"url": f"http://testserver{reverse(besluit, namespace='besluiten')}"},
+        )
+        self.assertEqual(
+            besluit_update_audittrail.nieuw,
+            response.data
+            | {"url": f"http://testserver{reverse(besluit, namespace='besluiten')}"},
+        )
         self.assertEqual(
             besluit_update_audittrail.resource_url,
             f"http://testserver{reverse(besluit, namespace='besluiten')}",
@@ -237,6 +274,8 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         audittrails = AuditTrail.objects
         self.assertEqual(audittrails.count(), 2)
 
+        bio = BesluitInformatieObject.objects.get()
+
         # Verify that the audittrail for the BesluitInformatieObject creation
         # contains the correct information
         bio_create_audittrail = audittrails.last()
@@ -244,7 +283,14 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         self.assertEqual(bio_create_audittrail.actie, "create")
         self.assertEqual(bio_create_audittrail.resultaat, 201)
         self.assertEqual(bio_create_audittrail.oud, None)
-        self.assertEqual(bio_create_audittrail.nieuw, besluitinformatieobject_response)
+        self.assertEqual(
+            bio_create_audittrail.nieuw,
+            besluitinformatieobject_response
+            | {
+                "url": f"http://testserver{reverse(bio, namespace='besluiten')}",
+                "besluit": f"http://testserver{reverse(besluit, namespace='besluiten')}",
+            },
+        )
 
     def test_create_besluitinformatieobject_audittrail_with_zaak(self):
         zaak = ZaakFactory.create()
@@ -358,7 +404,11 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         self.assertEqual(besluit_audittrail.bron, "BRC")
         self.assertEqual(besluit_audittrail.actie, "create")
         self.assertEqual(besluit_audittrail.oud, None)
-        self.assertEqual(besluit_audittrail.nieuw, response.data["besluit"])
+        self.assertEqual(
+            besluit_audittrail.nieuw,
+            response.data["besluit"]
+            | {"url": f"http://testserver{reverse(besluit, namespace='besluiten')}"},
+        )
         self.assertEqual(
             besluit_audittrail.hoofd_object,
             f"http://testserver{reverse(besluit, namespace='besluiten')}",
@@ -591,11 +641,9 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         self.assertEqual(audittrails.count(), 0)
 
     def test_audittrail_applicatie_information(self):
-        besluit_response = self._create_besluit()
+        self._create_besluit()
 
-        audittrail = AuditTrail.objects.filter(
-            hoofd_object=besluit_response["url"]
-        ).get()
+        audittrail = AuditTrail.objects.get()
 
         # Verify that the application id stored in the AuditTrail matches
         # the id of the Application used for the request
@@ -606,11 +654,9 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         self.assertEqual(audittrail.applicatie_weergave, self.applicatie.label)
 
     def test_audittrail_user_information(self):
-        besluit_response = self._create_besluit()
+        self._create_besluit()
 
-        audittrail = AuditTrail.objects.filter(
-            hoofd_object=besluit_response["url"]
-        ).get()
+        audittrail = AuditTrail.objects.get()
 
         # Verify that the user id stored in the AuditTrail matches
         # the user id in the JWT token for the request
@@ -622,9 +668,9 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
 
     def test_audittrail_toelichting(self):
         toelichting = "blaaaa"
-        besluit_data = self._create_besluit(HTTP_X_AUDIT_TOELICHTING=toelichting)
+        self._create_besluit(HTTP_X_AUDIT_TOELICHTING=toelichting)
 
-        audittrail = AuditTrail.objects.filter(hoofd_object=besluit_data["url"]).get()
+        audittrail = AuditTrail.objects.get()
 
         # Verify that the toelichting stored in the AuditTrail matches
         # the X-Audit-Toelichting header in the HTTP request
@@ -651,9 +697,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
             uuid=besluit_uuid
         ).unique_representation()
 
-        audittrail = AuditTrail.objects.filter(
-            hoofd_object=besluit_response["url"]
-        ).get()
+        audittrail = AuditTrail.objects.get()
 
         # Verify that the resource weergave stored in the AuditTrail matches
         # the unique representation as defined in the besluit model

--- a/src/openzaak/components/besluiten/tests/test_audittrails.py
+++ b/src/openzaak/components/besluiten/tests/test_audittrails.py
@@ -374,7 +374,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
             )
 
     @tag("convenience-endpoints")
-    def test_verwerk_besluit__with_zaak_audittrails(self):
+    def test_verwerk_besluit_with_zaak_audittrails(self):
         zaak = ZaakFactory.create()
         zaak_url = reverse(zaak)
         besluittype = BesluitTypeFactory.create(concept=False)
@@ -499,6 +499,77 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         zrc_delete_trail = audittrails.get(actie="destroy")
         self.assertEqual(zrc_delete_trail.bron, "ZRC")
         self.assertEqual(zrc_delete_trail.hoofd_object, f"http://testserver{zaak_url}")
+
+    def test_delete_besluitinformatieobject(self):
+        besluit_data = self._create_besluit()
+
+        besluit = Besluit.objects.get()
+        io = EnkelvoudigInformatieObjectFactory.create(
+            informatieobjecttype__concept=False
+        )
+        io_url = reverse(io)
+        besluit.besluittype.informatieobjecttypen.add(io.informatieobjecttype)
+        url = reverse(BesluitInformatieObject, namespace="besluiten")
+
+        response = self.client.post(
+            url,
+            {
+                "besluit": besluit_data["url"],
+                "informatieobject": f"http://testserver{io_url}",
+            },
+        )
+        bio_data = response.json()
+
+        # Delete the Besluit
+        response = self.client.delete(bio_data["url"])
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        audittrails = AuditTrail.objects
+        self.assertEqual(audittrails.count(), 3)
+
+        bio_delete_trail = audittrails.get(actie="destroy")
+        self.assertEqual(bio_delete_trail.bron, "BRC")
+
+    def test_delete_besluitinformatieobject_with_zaak(self):
+        zaak = ZaakFactory.create()
+        besluit_data = self._create_besluit(zaak=zaak)
+
+        besluit = Besluit.objects.get()
+        io = EnkelvoudigInformatieObjectFactory.create(
+            informatieobjecttype__concept=False
+        )
+        io_url = reverse(io)
+        besluit.besluittype.informatieobjecttypen.add(io.informatieobjecttype)
+        url = reverse(BesluitInformatieObject, namespace="besluiten")
+
+        response = self.client.post(
+            url,
+            {
+                "besluit": besluit_data["url"],
+                "informatieobject": f"http://testserver{io_url}",
+            },
+        )
+        bio_data = response.json()
+        bio = BesluitInformatieObject.objects.get()
+
+        # Delete the Besluit
+        response = self.client.delete(bio_data["url"])
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        audittrails = AuditTrail.objects
+        self.assertEqual(audittrails.count(), 6)
+
+        bio_delete_trail = audittrails.get(actie="destroy", bron="ZRC")
+        self.assertEqual(
+            bio_delete_trail.oud,
+            bio_data
+            | {
+                "url": f"http://testserver{reverse(bio, namespace='zaken')}",
+                "besluit": f"http://testserver{reverse(besluit, namespace='zaken')}",
+            },
+        )
 
     def test_delete_zaak(self):
         zaak = ZaakFactory.create()

--- a/src/openzaak/components/besluiten/tests/test_audittrails.py
+++ b/src/openzaak/components/besluiten/tests/test_audittrails.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2022 Dimpact
 from copy import deepcopy
+from typing import Type
 
 from django.test import override_settings, tag
 
@@ -9,6 +10,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 from vng_api_common.audittrails.models import AuditTrail
 from vng_api_common.authorizations.utils import generate_jwt
+from vng_api_common.tests import get_validation_errors
 from vng_api_common.utils import get_uuid_from_path
 
 from openzaak.components.catalogi.tests.factories import (
@@ -21,6 +23,8 @@ from openzaak.components.documenten.tests.factories import (
 from openzaak.tests.utils import JWTAuthMixin
 from openzaak.utils.urls import reverse
 
+from ...zaken.models import Zaak
+from ...zaken.tests.factories import ZaakFactory
 from ..models import Besluit, BesluitInformatieObject
 from .factories import BesluitFactory
 
@@ -29,10 +33,14 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
     NAMESPACE = "besluiten"
 
-    def _create_besluit(self, **headers):
+    def _create_besluit(self, zaak: Type[Zaak] | None = None, **headers):
         url = reverse(Besluit, namespace=self.NAMESPACE)
         besluittype = BesluitTypeFactory.create(concept=False)
         besluittype_url = reverse(besluittype)
+
+        if zaak:
+            besluittype.zaaktypen.add(zaak.zaaktype)
+            zaak_url = reverse(zaak)
 
         besluit_data = {
             "verantwoordelijkeOrganisatie": "000000000",
@@ -42,6 +50,14 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
             "vervaldatum": "2019-04-28",
             "identificatie": "123123",
         }
+
+        if zaak:
+            besluit_data.update(
+                {
+                    "zaak": f"http://testserver{zaak_url}",
+                }
+            )
+
         response = self.client.post(url, besluit_data, **headers)
 
         return response.data
@@ -49,7 +65,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
     def test_create_besluit_audittrail(self):
         besluit_response = self._create_besluit()
 
-        audittrails = AuditTrail.objects.filter(hoofd_object=besluit_response["url"])
+        audittrails = AuditTrail.objects
         self.assertEqual(audittrails.count(), 1)
 
         # Verify that the audittrail for the Besluit creation contains the correct
@@ -60,6 +76,47 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         self.assertEqual(besluit_create_audittrail.resultaat, 201)
         self.assertEqual(besluit_create_audittrail.oud, None)
         self.assertEqual(besluit_create_audittrail.nieuw, besluit_response)
+
+    def test_create_besluit_audittrail_with_zaak(self):
+        zaak = ZaakFactory.create()
+        zaak_url = reverse(zaak)
+        besluit_response = self._create_besluit(zaak=zaak)
+
+        besluit = Besluit.objects.get()
+
+        audittrails = AuditTrail.objects
+        self.assertEqual(audittrails.count(), 2)
+
+        besluiten_create_audittrail = audittrails.get(bron="BRC")
+        self.assertEqual(besluiten_create_audittrail.actie, "create")
+        self.assertEqual(besluiten_create_audittrail.resultaat, 201)
+        self.assertEqual(
+            besluiten_create_audittrail.resource_url,
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
+        self.assertEqual(
+            besluiten_create_audittrail.hoofd_object,
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
+        self.assertEqual(besluiten_create_audittrail.oud, None)
+        self.assertEqual(besluiten_create_audittrail.nieuw, besluit_response)
+
+        zaken_create_audittrail = audittrails.get(bron="ZRC")
+        self.assertEqual(zaken_create_audittrail.actie, "create")
+        self.assertEqual(zaken_create_audittrail.resultaat, 201)
+        self.assertEqual(
+            zaken_create_audittrail.resource_url,
+            f"http://testserver{reverse(besluit, namespace='zaken')}",
+        )
+        self.assertEqual(
+            zaken_create_audittrail.hoofd_object, f"http://testserver{zaak_url}"
+        )
+        self.assertEqual(zaken_create_audittrail.oud, None)
+        self.assertEqual(
+            zaken_create_audittrail.nieuw,
+            besluit_response
+            | {"url": f"http://testserver{reverse(besluit, namespace='zaken')}"},
+        )
 
     def test_update_besluit_audittrails(self):
         besluit_data = self._create_besluit()
@@ -73,12 +130,12 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         besluit_response = response.data
 
-        audittrails = AuditTrail.objects.filter(hoofd_object=besluit_response["url"])
+        audittrails = AuditTrail.objects
         self.assertEqual(audittrails.count(), 2)
 
         # Verify that the audittrail for the Besluit update contains the correct
         # information
-        besluit_update_audittrail = audittrails[1]
+        besluit_update_audittrail = audittrails.last()
         self.assertEqual(besluit_update_audittrail.bron, "BRC")
         self.assertEqual(besluit_update_audittrail.actie, "update")
         self.assertEqual(besluit_update_audittrail.resultaat, 200)
@@ -91,17 +148,69 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         response = self.client.patch(besluit_data["url"], {"toelichting": "aangepast"})
         besluit_response = response.data
 
-        audittrails = AuditTrail.objects.filter(hoofd_object=besluit_response["url"])
+        audittrails = AuditTrail.objects
         self.assertEqual(audittrails.count(), 2)
 
         # Verify that the audittrail for the Besluit partial_update contains the
         # correct information
-        besluit_update_audittrail = audittrails[1]
+        besluit_update_audittrail = audittrails.last()
         self.assertEqual(besluit_update_audittrail.bron, "BRC")
         self.assertEqual(besluit_update_audittrail.actie, "partial_update")
         self.assertEqual(besluit_update_audittrail.resultaat, 200)
         self.assertEqual(besluit_update_audittrail.oud, besluit_data)
         self.assertEqual(besluit_update_audittrail.nieuw, besluit_response)
+
+    def test_partial_update_besluit_audittrails_add_zaak(self):
+        besluit_data = self._create_besluit()
+
+        zaak = ZaakFactory.create()
+        zaak_url = reverse(zaak)
+
+        besluit = Besluit.objects.get()
+        besluit.besluittype.zaaktypen.add(zaak.zaaktype)
+
+        response = self.client.patch(
+            besluit_data["url"], {"zaak": f"http://testserver{zaak_url}"}
+        )
+
+        audittrails = AuditTrail.objects
+        self.assertEqual(audittrails.count(), 3)
+
+        # Verify that the audittrail for the Besluit partial_update contains the
+        # correct information
+        besluit_update_audittrail = audittrails.get(bron="BRC", actie="partial_update")
+        self.assertEqual(besluit_update_audittrail.resultaat, 200)
+        self.assertEqual(besluit_update_audittrail.oud, besluit_data)
+        self.assertEqual(besluit_update_audittrail.nieuw, response.data)
+        self.assertEqual(
+            besluit_update_audittrail.resource_url,
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
+        self.assertEqual(
+            besluit_update_audittrail.hoofd_object,
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
+
+        zaken_update_audittrail = audittrails.get(bron="ZRC")
+        self.assertEqual(zaken_update_audittrail.actie, "partial_update")
+        self.assertEqual(zaken_update_audittrail.resultaat, 200)
+        self.assertEqual(
+            zaken_update_audittrail.resource_url,
+            f"http://testserver{reverse(besluit, namespace='zaken')}",
+        )
+        self.assertEqual(
+            zaken_update_audittrail.hoofd_object, f"http://testserver{zaak_url}"
+        )
+        self.assertEqual(
+            zaken_update_audittrail.oud,
+            besluit_data
+            | {"url": f"http://testserver{reverse(besluit, namespace='zaken')}"},
+        )
+        self.assertEqual(
+            zaken_update_audittrail.nieuw,
+            response.data
+            | {"url": f"http://testserver{reverse(besluit, namespace='zaken')}"},
+        )
 
     def test_create_besluitinformatieobject_audittrail(self):
         besluit_data = self._create_besluit()
@@ -125,17 +234,79 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         besluitinformatieobject_response = response.data
 
-        audittrails = AuditTrail.objects.filter(hoofd_object=besluit_data["url"])
+        audittrails = AuditTrail.objects
         self.assertEqual(audittrails.count(), 2)
 
         # Verify that the audittrail for the BesluitInformatieObject creation
         # contains the correct information
-        bio_create_audittrail = audittrails[1]
+        bio_create_audittrail = audittrails.last()
         self.assertEqual(bio_create_audittrail.bron, "BRC")
         self.assertEqual(bio_create_audittrail.actie, "create")
         self.assertEqual(bio_create_audittrail.resultaat, 201)
         self.assertEqual(bio_create_audittrail.oud, None)
         self.assertEqual(bio_create_audittrail.nieuw, besluitinformatieobject_response)
+
+    def test_create_besluitinformatieobject_audittrail_with_zaak(self):
+        zaak = ZaakFactory.create()
+        zaak_url = reverse(zaak)
+        besluit_data = self._create_besluit(zaak=zaak)
+
+        besluit = Besluit.objects.get()
+        io = EnkelvoudigInformatieObjectFactory.create(
+            informatieobjecttype__concept=False
+        )
+        io_url = reverse(io)
+        besluit.besluittype.informatieobjecttypen.add(io.informatieobjecttype)
+        url = reverse(BesluitInformatieObject, namespace="besluiten")
+
+        response = self.client.post(
+            url,
+            {
+                "besluit": besluit_data["url"],
+                "informatieobject": f"http://testserver{io_url}",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        besluitinformatieobject_response = response.data
+
+        audittrails = AuditTrail.objects
+        self.assertEqual(audittrails.count(), 4)
+
+        bio = BesluitInformatieObject.objects.get()
+
+        # Verify that the audittrail for the BesluitInformatieObject creation
+        # contains the correct information
+        bio_create_audittrail = audittrails.get(
+            bron="BRC", resource="besluitinformatieobject"
+        )
+        self.assertEqual(bio_create_audittrail.actie, "create")
+        self.assertEqual(bio_create_audittrail.resultaat, 201)
+        self.assertEqual(bio_create_audittrail.oud, None)
+        self.assertEqual(bio_create_audittrail.nieuw, besluitinformatieobject_response)
+        self.assertEqual(
+            bio_create_audittrail.hoofd_object,
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
+
+        bio_zrc_create_audittrail = audittrails.get(
+            bron="ZRC", resource="besluitinformatieobject"
+        )
+        self.assertEqual(bio_zrc_create_audittrail.actie, "create")
+        self.assertEqual(bio_zrc_create_audittrail.resultaat, 201)
+        self.assertEqual(bio_zrc_create_audittrail.oud, None)
+        self.assertEqual(
+            bio_zrc_create_audittrail.nieuw,
+            besluitinformatieobject_response
+            | {
+                "url": f"http://testserver{reverse(bio, namespace='zaken')}",
+                "besluit": f"http://testserver{reverse(besluit, namespace='zaken')}",
+            },
+        )
+        self.assertEqual(
+            bio_zrc_create_audittrail.hoofd_object,
+            f"http://testserver{zaak_url}",
+        )
 
     @tag("convenience-endpoints")
     def test_verwerk_besluit_audittrails(self):
@@ -206,8 +377,43 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
 
         self.assertEqual(response.status_code, 204)
         # Verify that deleting the Besluit deletes all related AuditTrails
-        audittrails = AuditTrail.objects.filter(hoofd_object=besluit_data["url"])
+        audittrails = AuditTrail.objects
         self.assertFalse(audittrails.exists())
+
+    def test_delete_besluit_with_zaak(self):
+        zaak = ZaakFactory.create()
+        zaak_url = reverse(zaak)
+        besluit_data = self._create_besluit(zaak=zaak)
+
+        # Delete the Besluit
+        response = self.client.delete(besluit_data["url"])
+        self.assertEqual(response.status_code, 204)
+
+        audittrails = AuditTrail.objects
+        self.assertEqual(audittrails.count(), 2)
+
+        zrc_delete_trail = audittrails.get(actie="destroy")
+        self.assertEqual(zrc_delete_trail.bron, "ZRC")
+        self.assertEqual(zrc_delete_trail.hoofd_object, f"http://testserver{zaak_url}")
+
+    def test_delete_zaak(self):
+        zaak = ZaakFactory.create()
+        besluit_data = self._create_besluit(zaak=zaak)
+
+        # Delete the zaak first
+        response = self.client.delete(besluit_data["zaak"])
+        self.assertEqual(response.status_code, 400)
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "related-besluiten")
+
+        response = self.client.delete(besluit_data["url"])
+        self.assertEqual(response.status_code, 204)
+
+        response = self.client.delete(besluit_data["zaak"])
+        self.assertEqual(response.status_code, 204)
+
+        audittrails = AuditTrail.objects
+        self.assertEqual(audittrails.count(), 0)
 
     def test_audittrail_applicatie_information(self):
         besluit_response = self._create_besluit()

--- a/src/openzaak/components/besluiten/tests/test_audittrails.py
+++ b/src/openzaak/components/besluiten/tests/test_audittrails.py
@@ -23,8 +23,10 @@ from openzaak.components.documenten.tests.factories import (
 from openzaak.tests.utils import JWTAuthMixin
 from openzaak.utils.urls import reverse
 
+from ...zaken.api.audits import AUDIT_ZRC
 from ...zaken.models import Zaak
 from ...zaken.tests.factories import ZaakFactory
+from ..api.audits import AUDIT_BRC
 from ..models import Besluit, BesluitInformatieObject
 from .factories import BesluitFactory
 
@@ -73,7 +75,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # information
         besluit_create_audittrail = audittrails.get()
         besluit = Besluit.objects.get()
-        self.assertEqual(besluit_create_audittrail.bron, "BRC")
+        self.assertEqual(besluit_create_audittrail.bron, AUDIT_BRC.component_name)
         self.assertEqual(besluit_create_audittrail.actie, "create")
         self.assertEqual(besluit_create_audittrail.resultaat, 201)
         self.assertEqual(besluit_create_audittrail.oud, None)
@@ -93,7 +95,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         audittrails = AuditTrail.objects
         self.assertEqual(audittrails.count(), 2)
 
-        besluiten_create_audittrail = audittrails.get(bron="BRC")
+        besluiten_create_audittrail = audittrails.get(bron=AUDIT_BRC.component_name)
         self.assertEqual(besluiten_create_audittrail.actie, "create")
         self.assertEqual(besluiten_create_audittrail.resultaat, 201)
         self.assertEqual(
@@ -111,7 +113,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
             | {"url": f"http://testserver{reverse(besluit, namespace='besluiten')}"},
         )
 
-        zaken_create_audittrail = audittrails.get(bron="ZRC")
+        zaken_create_audittrail = audittrails.get(bron=AUDIT_ZRC.component_name)
         self.assertEqual(zaken_create_audittrail.actie, "create")
         self.assertEqual(zaken_create_audittrail.resultaat, 201)
         self.assertEqual(
@@ -147,7 +149,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # information
         besluit_update_audittrail = audittrails.last()
         besluit = Besluit.objects.get()
-        self.assertEqual(besluit_update_audittrail.bron, "BRC")
+        self.assertEqual(besluit_update_audittrail.bron, AUDIT_BRC.component_name)
         self.assertEqual(besluit_update_audittrail.actie, "update")
         self.assertEqual(besluit_update_audittrail.resultaat, 200)
         self.assertEqual(
@@ -175,7 +177,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Verify that the audittrail for the Besluit partial_update contains the
         # correct information
         besluit_update_audittrail = audittrails.last()
-        self.assertEqual(besluit_update_audittrail.bron, "BRC")
+        self.assertEqual(besluit_update_audittrail.bron, AUDIT_BRC.component_name)
         self.assertEqual(besluit_update_audittrail.actie, "partial_update")
         self.assertEqual(besluit_update_audittrail.resultaat, 200)
         self.assertEqual(
@@ -207,7 +209,9 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
 
         # Verify that the audittrail for the Besluit partial_update contains the
         # correct information
-        besluit_update_audittrail = audittrails.get(bron="BRC", actie="partial_update")
+        besluit_update_audittrail = audittrails.get(
+            bron=AUDIT_BRC.component_name, actie="partial_update"
+        )
         self.assertEqual(besluit_update_audittrail.resultaat, 200)
         self.assertEqual(
             besluit_update_audittrail.oud,
@@ -228,7 +232,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
             f"http://testserver{reverse(besluit, namespace='besluiten')}",
         )
 
-        zaken_update_audittrail = audittrails.get(bron="ZRC")
+        zaken_update_audittrail = audittrails.get(bron=AUDIT_ZRC.component_name)
         self.assertEqual(zaken_update_audittrail.actie, "partial_update")
         self.assertEqual(zaken_update_audittrail.resultaat, 200)
         self.assertEqual(
@@ -279,7 +283,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Verify that the audittrail for the BesluitInformatieObject creation
         # contains the correct information
         bio_create_audittrail = audittrails.last()
-        self.assertEqual(bio_create_audittrail.bron, "BRC")
+        self.assertEqual(bio_create_audittrail.bron, AUDIT_BRC.component_name)
         self.assertEqual(bio_create_audittrail.actie, "create")
         self.assertEqual(bio_create_audittrail.resultaat, 201)
         self.assertEqual(bio_create_audittrail.oud, None)
@@ -324,7 +328,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Verify that the audittrail for the BesluitInformatieObject creation
         # contains the correct information
         bio_create_audittrail = audittrails.get(
-            bron="BRC", resource="besluitinformatieobject"
+            bron=AUDIT_BRC.component_name, resource="besluitinformatieobject"
         )
         self.assertEqual(bio_create_audittrail.actie, "create")
         self.assertEqual(bio_create_audittrail.resultaat, 201)
@@ -336,7 +340,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         )
 
         bio_zrc_create_audittrail = audittrails.get(
-            bron="ZRC", resource="besluitinformatieobject"
+            bron=AUDIT_ZRC.component_name, resource="besluitinformatieobject"
         )
         self.assertEqual(bio_zrc_create_audittrail.actie, "create")
         self.assertEqual(bio_zrc_create_audittrail.resultaat, 201)
@@ -401,7 +405,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
 
         besluit = Besluit.objects.get()
 
-        self.assertEqual(besluit_audittrail.bron, "BRC")
+        self.assertEqual(besluit_audittrail.bron, AUDIT_BRC.component_name)
         self.assertEqual(besluit_audittrail.actie, "create")
         self.assertEqual(besluit_audittrail.oud, None)
         self.assertEqual(
@@ -415,7 +419,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         )
 
         for trail in AuditTrail.objects.filter(resource="besluitinformatieobject"):
-            self.assertEqual(trail.bron, "BRC")
+            self.assertEqual(trail.bron, AUDIT_BRC.component_name)
             self.assertEqual(trail.actie, "create")
             self.assertEqual(trail.oud, None)
             self.assertEqual(
@@ -470,7 +474,9 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
 
         self.assertEqual(AuditTrail.objects.count(), 6)
 
-        besluit_brc_audittrail = AuditTrail.objects.get(resource="besluit", bron="BRC")
+        besluit_brc_audittrail = AuditTrail.objects.get(
+            resource="besluit", bron=AUDIT_BRC.component_name
+        )
 
         besluit = Besluit.objects.get()
 
@@ -482,7 +488,9 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
             f"http://testserver{reverse(besluit, namespace='besluiten')}",
         )
 
-        besluit_zrc_audittrail = AuditTrail.objects.get(resource="besluit", bron="ZRC")
+        besluit_zrc_audittrail = AuditTrail.objects.get(
+            resource="besluit", bron=AUDIT_ZRC.component_name
+        )
 
         self.assertEqual(besluit_zrc_audittrail.actie, "create")
         self.assertEqual(besluit_zrc_audittrail.oud, None)
@@ -496,7 +504,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         )
 
         for brc_bio_trail in AuditTrail.objects.filter(
-            resource="besluitinformatieobject", bron="BRC"
+            resource="besluitinformatieobject", bron=AUDIT_BRC.component_name
         ):
             self.assertEqual(brc_bio_trail.actie, "create")
             self.assertEqual(brc_bio_trail.oud, None)
@@ -510,7 +518,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
             self.assertIn("besluiten/api/v1/besluiten", brc_bio_trail.nieuw["besluit"])
 
         for zrc_bio_trail in AuditTrail.objects.filter(
-            resource="besluitinformatieobject", bron="ZRC"
+            resource="besluitinformatieobject", bron=AUDIT_ZRC.component_name
         ):
             self.assertEqual(zrc_bio_trail.actie, "create")
             self.assertEqual(zrc_bio_trail.oud, None)
@@ -547,7 +555,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         self.assertEqual(audittrails.count(), 2)
 
         zrc_delete_trail = audittrails.get(actie="destroy")
-        self.assertEqual(zrc_delete_trail.bron, "ZRC")
+        self.assertEqual(zrc_delete_trail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(zrc_delete_trail.hoofd_object, f"http://testserver{zaak_url}")
 
     def test_delete_besluitinformatieobject(self):
@@ -579,7 +587,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         self.assertEqual(audittrails.count(), 3)
 
         bio_delete_trail = audittrails.get(actie="destroy")
-        self.assertEqual(bio_delete_trail.bron, "BRC")
+        self.assertEqual(bio_delete_trail.bron, AUDIT_BRC.component_name)
 
     def test_delete_besluitinformatieobject_with_zaak(self):
         zaak = ZaakFactory.create()
@@ -611,7 +619,9 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         audittrails = AuditTrail.objects
         self.assertEqual(audittrails.count(), 6)
 
-        bio_delete_trail = audittrails.get(actie="destroy", bron="ZRC")
+        bio_delete_trail = audittrails.get(
+            actie="destroy", bron=AUDIT_ZRC.component_name
+        )
         self.assertEqual(
             bio_delete_trail.oud,
             bio_data

--- a/src/openzaak/components/besluiten/tests/test_audittrails.py
+++ b/src/openzaak/components/besluiten/tests/test_audittrails.py
@@ -414,7 +414,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
             f"http://testserver{reverse(besluit, namespace='besluiten')}",
         )
 
-        for trail in AuditTrail.objects.filter(resource="besluitinfromatieobject"):
+        for trail in AuditTrail.objects.filter(resource="besluitinformatieobject"):
             self.assertEqual(trail.bron, "BRC")
             self.assertEqual(trail.actie, "create")
             self.assertEqual(trail.oud, None)
@@ -496,7 +496,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         )
 
         for brc_bio_trail in AuditTrail.objects.filter(
-            resource="besluitinfromatieobject", bron="BRC"
+            resource="besluitinformatieobject", bron="BRC"
         ):
             self.assertEqual(brc_bio_trail.actie, "create")
             self.assertEqual(brc_bio_trail.oud, None)
@@ -510,7 +510,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
             self.assertIn("besluiten/api/besluiten", brc_bio_trail.nieuw["besluit"])
 
         for zrc_bio_trail in AuditTrail.objects.filter(
-            resource="besluitinfromatieobject", bron="ZRC"
+            resource="besluitinformatieobject", bron="ZRC"
         ):
             self.assertEqual(zrc_bio_trail.actie, "create")
             self.assertEqual(zrc_bio_trail.oud, None)

--- a/src/openzaak/components/besluiten/tests/test_audittrails.py
+++ b/src/openzaak/components/besluiten/tests/test_audittrails.py
@@ -505,9 +505,9 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
                 f"http://testserver{reverse(besluit, namespace='besluiten')}",
             )
             self.assertIn(
-                "besluiten/api/besluitinformatieobjecten", brc_bio_trail.nieuw["url"]
+                "besluiten/api/v1/besluitinformatieobjecten", brc_bio_trail.nieuw["url"]
             )
-            self.assertIn("besluiten/api/besluiten", brc_bio_trail.nieuw["besluit"])
+            self.assertIn("besluiten/api/v1/besluiten", brc_bio_trail.nieuw["besluit"])
 
         for zrc_bio_trail in AuditTrail.objects.filter(
             resource="besluitinformatieobject", bron="ZRC"
@@ -516,12 +516,12 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
             self.assertEqual(zrc_bio_trail.oud, None)
             self.assertEqual(
                 zrc_bio_trail.hoofd_object,
-                f"http://testserver{reverse(besluit, namespace='besluiten')}",
+                f"http://testserver{reverse(zaak, namespace='zaken')}",
             )
             self.assertIn(
-                "zaken/api/besluitinformatieobjecten", brc_bio_trail.nieuw["url"]
+                "zaken/api/v1/besluitinformatieobjecten", zrc_bio_trail.nieuw["url"]
             )
-            self.assertIn("zaken/api/besluiten", brc_bio_trail.nieuw["besluit"])
+            self.assertIn("zaken/api/v1/besluiten", zrc_bio_trail.nieuw["besluit"])
 
     def test_delete_besluit_cascade_audittrails(self):
         besluit_data = self._create_besluit()

--- a/src/openzaak/components/catalogi/tests/models/test_resultaattype_validation.py
+++ b/src/openzaak/components/catalogi/tests/models/test_resultaattype_validation.py
@@ -18,6 +18,7 @@ from vng_api_common.constants import (
     BrondatumArchiefprocedureAfleidingswijze as Afleidingswijze,
 )
 
+from openzaak.components.besluiten.api.audits import AUDIT_BRC
 from openzaak.selectielijst.tests.mixins import SelectieLijstMixin
 from openzaak.tests.utils import patch_resource_validator
 
@@ -680,7 +681,7 @@ class ResultaattypeAfleidingswijzeAndParameterFieldsValidationTests(
             **{
                 "brondatum_archiefprocedure_datumkenmerk": "",
                 "brondatum_archiefprocedure_objecttype": "adres",
-                "brondatum_archiefprocedure_registratie": "BRC",
+                "brondatum_archiefprocedure_registratie": AUDIT_BRC.component_name,
             },
         )
 
@@ -723,7 +724,7 @@ class ResultaattypeAfleidingswijzeAndParameterFieldsValidationTests(
             **{
                 "brondatum_archiefprocedure_datumkenmerk": "",
                 "brondatum_archiefprocedure_objecttype": "",
-                "brondatum_archiefprocedure_registratie": "BRC",
+                "brondatum_archiefprocedure_registratie": AUDIT_BRC.component_name,
             },
         )
 

--- a/src/openzaak/components/documenten/tests/admin/test_eio_audittrail.py
+++ b/src/openzaak/components/documenten/tests/admin/test_eio_audittrail.py
@@ -14,6 +14,7 @@ from openzaak.components.catalogi.tests.factories import InformatieObjectTypeFac
 from openzaak.components.documenten.models import EnkelvoudigInformatieObject
 from openzaak.tests.utils import AdminTestMixin
 
+from ...api.audits import AUDIT_DRC
 from ..factories import (
     EnkelvoudigInformatieObjectCanonicalFactory,
     EnkelvoudigInformatieObjectFactory,
@@ -64,7 +65,7 @@ class EnkelvoudigInformatieObjectAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "DRC")
+        self.assertEqual(audittrail.bron, AUDIT_DRC.component_name)
         self.assertEqual(audittrail.actie, "create")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -117,7 +118,7 @@ class EnkelvoudigInformatieObjectAdminTests(AdminTestMixin, TestCase):
         informatieobject.refresh_from_db()
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "DRC")
+        self.assertEqual(audittrail.bron, AUDIT_DRC.component_name)
         self.assertEqual(audittrail.actie, "update")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")

--- a/src/openzaak/components/documenten/tests/admin/test_eiocanonical_inline_audittrail.py
+++ b/src/openzaak/components/documenten/tests/admin/test_eiocanonical_inline_audittrail.py
@@ -13,6 +13,7 @@ from openzaak.components.catalogi.tests.factories import InformatieObjectTypeFac
 from openzaak.components.documenten.models import EnkelvoudigInformatieObject
 from openzaak.tests.utils.admin import AdminTestMixin
 
+from ...api.audits import AUDIT_DRC
 from ..factories import (
     EnkelvoudigInformatieObjectCanonicalFactory,
     EnkelvoudigInformatieObjectFactory,
@@ -35,7 +36,7 @@ class EioAdminInlineTests(AdminTestMixin, WebTest):
         )
 
     def assertEioAudittrail(self, audittrail):
-        self.assertEqual(audittrail.bron, "DRC")
+        self.assertEqual(audittrail.bron, AUDIT_DRC.component_name)
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
         self.assertEqual(audittrail.gebruikers_id, f"{self.user.id}")

--- a/src/openzaak/components/documenten/tests/admin/test_gebruiksrechten_audittrail.py
+++ b/src/openzaak/components/documenten/tests/admin/test_gebruiksrechten_audittrail.py
@@ -13,6 +13,7 @@ from vng_api_common.audittrails.models import AuditTrail
 from openzaak.components.documenten.models import Gebruiksrechten
 from openzaak.tests.utils import AdminTestMixin
 
+from ...api.audits import AUDIT_DRC
 from ..factories import EnkelvoudigInformatieObjectFactory, GebruiksrechtenFactory
 from ..utils import get_operation_url
 
@@ -49,7 +50,7 @@ class GebruiksrechtenAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "DRC")
+        self.assertEqual(audittrail.bron, AUDIT_DRC.component_name)
         self.assertEqual(audittrail.actie, "create")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -99,7 +100,7 @@ class GebruiksrechtenAdminTests(AdminTestMixin, TestCase):
         gebruiksrechten.refresh_from_db()
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "DRC")
+        self.assertEqual(audittrail.bron, AUDIT_DRC.component_name)
         self.assertEqual(audittrail.actie, "update")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -147,7 +148,7 @@ class GebruiksrechtenAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "DRC")
+        self.assertEqual(audittrail.bron, AUDIT_DRC.component_name)
         self.assertEqual(audittrail.actie, "destroy")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -195,7 +196,7 @@ class GebruiksrechtenAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "DRC")
+        self.assertEqual(audittrail.bron, AUDIT_DRC.component_name)
         self.assertEqual(audittrail.actie, "destroy")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")

--- a/src/openzaak/components/documenten/tests/test_audittrails.py
+++ b/src/openzaak/components/documenten/tests/test_audittrails.py
@@ -23,7 +23,9 @@ from openzaak.components.catalogi.tests.factories import (
 from openzaak.tests.utils import JWTAuthMixin
 from openzaak.utils.urls import reverse, reverse_lazy
 
+from ...zaken.api.audits import AUDIT_ZRC
 from ...zaken.tests.factories import StatusFactory, ZaakFactory
+from ..api.audits import AUDIT_DRC
 from ..models import (
     EnkelvoudigInformatieObject,
     EnkelvoudigInformatieObjectCanonical,
@@ -75,7 +77,9 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Verify that the audittrail for the EnkelvoudigInformatieObject creation contains the correct
         # information
         informatieobject_create_audittrail = audittrails.get()
-        self.assertEqual(informatieobject_create_audittrail.bron, "DRC")
+        self.assertEqual(
+            informatieobject_create_audittrail.bron, AUDIT_DRC.component_name
+        )
         self.assertEqual(informatieobject_create_audittrail.actie, "create")
         self.assertEqual(informatieobject_create_audittrail.resultaat, 201)
         self.assertEqual(informatieobject_create_audittrail.oud, None)
@@ -106,7 +110,9 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Verify that the audittrail for the Gebruiksrechten creation
         # contains the correct information
         gebruiksrechten_create_audittrail = audittrails.get()
-        self.assertEqual(gebruiksrechten_create_audittrail.bron, "DRC")
+        self.assertEqual(
+            gebruiksrechten_create_audittrail.bron, AUDIT_DRC.component_name
+        )
         self.assertEqual(gebruiksrechten_create_audittrail.actie, "create")
         self.assertEqual(gebruiksrechten_create_audittrail.resultaat, 201)
         self.assertEqual(gebruiksrechten_create_audittrail.oud, None)
@@ -123,7 +129,9 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Verify that the audittrail for the Gebruiksrechten deletion
         # contains the correct information
         gebruiksrechten_delete_audittrail = audittrails[1]
-        self.assertEqual(gebruiksrechten_delete_audittrail.bron, "DRC")
+        self.assertEqual(
+            gebruiksrechten_delete_audittrail.bron, AUDIT_DRC.component_name
+        )
         self.assertEqual(gebruiksrechten_delete_audittrail.actie, "destroy")
         self.assertEqual(gebruiksrechten_delete_audittrail.resultaat, 204)
         self.assertEqual(
@@ -168,7 +176,9 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Verify that the audittrail for the EnkelvoudigInformatieObject update
         # contains the correct information
         informatieobject_update_audittrail = audittrails[1]
-        self.assertEqual(informatieobject_update_audittrail.bron, "DRC")
+        self.assertEqual(
+            informatieobject_update_audittrail.bron, AUDIT_DRC.component_name
+        )
         self.assertEqual(informatieobject_update_audittrail.actie, "update")
         self.assertEqual(informatieobject_update_audittrail.resultaat, 200)
 
@@ -209,7 +219,9 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Verify that the audittrail for the EnkelvoudigInformatieObject
         # partial update contains the correct information
         informatieobject_partial_update_audittrail = audittrails[1]
-        self.assertEqual(informatieobject_partial_update_audittrail.bron, "DRC")
+        self.assertEqual(
+            informatieobject_partial_update_audittrail.bron, AUDIT_DRC.component_name
+        )
 
         # XXX: tracking down the Heisenbug
         if informatieobject_partial_update_audittrail.actie != "partial_update":
@@ -363,7 +375,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
             hoofd_object=response.data["enkelvoudiginformatieobject"]["url"]
         ).get()
 
-        self.assertEqual(eio_audittrail.bron, "DRC")
+        self.assertEqual(eio_audittrail.bron, AUDIT_DRC.component_name)
         self.assertEqual(eio_audittrail.actie, "create")
         self.assertEqual(eio_audittrail.resource, "enkelvoudiginformatieobject")
         self.assertEqual(eio_audittrail.oud, None)
@@ -375,7 +387,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
             hoofd_object=response.data["zaakinformatieobject"]["zaak"]
         ).get()
 
-        self.assertEqual(zio_audittrail.bron, "ZRC")
+        self.assertEqual(zio_audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(zio_audittrail.actie, "create")
         self.assertEqual(zio_audittrail.resource, "zaakinformatieobject")
         self.assertEqual(zio_audittrail.oud, None)

--- a/src/openzaak/components/zaken/tests/admin/besluiten/test_besluit_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/besluiten/test_besluit_audittrail.py
@@ -47,7 +47,6 @@ class BesluitAdminTests(AdminTestMixin, TestCase):
 
     def test_create_besluit(self):
         besluit = self._create_besluit()
-        besluit_url = reverse(besluit, namespace="zaken")
 
         self.assertEqual(AuditTrail.objects.count(), 1)
 
@@ -59,9 +58,15 @@ class BesluitAdminTests(AdminTestMixin, TestCase):
         self.assertEqual(audittrail.applicatie_weergave, "admin")
         self.assertEqual(audittrail.gebruikers_id, f"{self.user.id}")
         self.assertEqual(audittrail.gebruikers_weergave, self.user.get_full_name())
-        self.assertEqual(audittrail.hoofd_object, f"http://testserver{besluit_url}")
+        self.assertEqual(
+            audittrail.hoofd_object,
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
         self.assertEqual(audittrail.resource, "besluit")
-        self.assertEqual(audittrail.resource_url, f"http://testserver{besluit_url}")
+        self.assertEqual(
+            audittrail.resource_url,
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
         self.assertEqual(audittrail.resource_weergave, besluit.unique_representation())
 
         self.assertEqual(audittrail.oud, None)
@@ -71,7 +76,6 @@ class BesluitAdminTests(AdminTestMixin, TestCase):
 
     def test_change_besluit(self):
         besluit = BesluitFactory.create(toelichting="old")
-        besluit_url = reverse(besluit, namespace="zaken")
         change_url = django_reverse(
             "admin:besluiten_besluit_change", args=(besluit.pk,)
         )
@@ -98,9 +102,15 @@ class BesluitAdminTests(AdminTestMixin, TestCase):
         self.assertEqual(audittrail.applicatie_weergave, "admin")
         self.assertEqual(audittrail.gebruikers_id, f"{self.user.id}")
         self.assertEqual(audittrail.gebruikers_weergave, self.user.get_full_name())
-        self.assertEqual(audittrail.hoofd_object, f"http://testserver{besluit_url}")
+        self.assertEqual(
+            audittrail.hoofd_object,
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
         self.assertEqual(audittrail.resource, "besluit")
-        self.assertEqual(audittrail.resource_url, f"http://testserver{besluit_url}")
+        self.assertEqual(
+            audittrail.resource_url,
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
         self.assertEqual(audittrail.resource_weergave, besluit.unique_representation())
 
         old_data, new_data = audittrail.oud, audittrail.nieuw

--- a/src/openzaak/components/zaken/tests/admin/besluiten/test_besluit_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/besluiten/test_besluit_audittrail.py
@@ -9,9 +9,11 @@ from django.urls import reverse as django_reverse
 from maykin_2fa.test import disable_admin_mfa
 from vng_api_common.audittrails.models import AuditTrail
 
+from openzaak.components.besluiten.api.audits import AUDIT_BRC
 from openzaak.components.besluiten.models import Besluit
 from openzaak.components.besluiten.tests.factories import BesluitFactory
 from openzaak.components.catalogi.tests.factories import BesluitTypeFactory
+from openzaak.components.zaken.api.audits import AUDIT_ZRC
 from openzaak.components.zaken.models import Zaak
 from openzaak.components.zaken.tests.factories import ZaakFactory
 from openzaak.tests.utils import AdminTestMixin
@@ -62,7 +64,7 @@ class BesluitAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "BRC")
+        self.assertEqual(audittrail.bron, AUDIT_BRC.component_name)
         self.assertEqual(audittrail.actie, "create")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -90,7 +92,7 @@ class BesluitAdminTests(AdminTestMixin, TestCase):
 
         self.assertEqual(AuditTrail.objects.count(), 2)
 
-        brc_audittrail = AuditTrail.objects.get(bron="BRC")
+        brc_audittrail = AuditTrail.objects.get(bron=AUDIT_BRC.component_name)
         self.assertEqual(brc_audittrail.actie, "create")
         self.assertEqual(brc_audittrail.resultaat, 0)
         self.assertEqual(brc_audittrail.applicatie_weergave, "admin")
@@ -114,7 +116,7 @@ class BesluitAdminTests(AdminTestMixin, TestCase):
         new_data = brc_audittrail.nieuw
         self.assertEqual(new_data["toelichting"], "desc")
 
-        zrc_audittrail = AuditTrail.objects.get(bron="ZRC")
+        zrc_audittrail = AuditTrail.objects.get(bron=AUDIT_ZRC.component_name)
         self.assertEqual(zrc_audittrail.actie, "create")
         self.assertEqual(zrc_audittrail.resultaat, 0)
         self.assertEqual(zrc_audittrail.applicatie_weergave, "admin")
@@ -160,7 +162,7 @@ class BesluitAdminTests(AdminTestMixin, TestCase):
         besluit.refresh_from_db()
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "BRC")
+        self.assertEqual(audittrail.bron, AUDIT_BRC.component_name)
         self.assertEqual(audittrail.actie, "update")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -189,7 +191,7 @@ class BesluitAdminTests(AdminTestMixin, TestCase):
         )
         data = {
             "uuid": besluit.uuid,
-            "_besluittype": besluit._besluittype.id,
+            "besluittype": besluit.besluittype.id,
             "verantwoordelijke_organisatie": besluit.verantwoordelijke_organisatie,
             "datum": besluit.datum,
             "ingangsdatum": "15-11-2019",
@@ -204,7 +206,7 @@ class BesluitAdminTests(AdminTestMixin, TestCase):
 
         besluit.refresh_from_db()
 
-        brc_audittrail = AuditTrail.objects.get(bron="BRC")
+        brc_audittrail = AuditTrail.objects.get(bron=AUDIT_BRC.component_name)
         self.assertEqual(brc_audittrail.actie, "update")
         self.assertEqual(brc_audittrail.resultaat, 0)
         self.assertEqual(brc_audittrail.applicatie_weergave, "admin")
@@ -227,7 +229,7 @@ class BesluitAdminTests(AdminTestMixin, TestCase):
         self.assertEqual(old_data["toelichting"], "old")
         self.assertEqual(new_data["toelichting"], "new")
 
-        zrc_audittrail = AuditTrail.objects.get(bron="ZRC")
+        zrc_audittrail = AuditTrail.objects.get(bron=AUDIT_ZRC.component_name)
         self.assertEqual(zrc_audittrail.actie, "update")
         self.assertEqual(zrc_audittrail.resultaat, 0)
         self.assertEqual(zrc_audittrail.applicatie_weergave, "admin")
@@ -297,7 +299,7 @@ class BesluitAdminTests(AdminTestMixin, TestCase):
         self.assertEqual(AuditTrail.objects.count(), 2)
 
         zrc_delete_trail = AuditTrail.objects.get(actie="destroy")
-        self.assertEqual(zrc_delete_trail.bron, "ZRC")
+        self.assertEqual(zrc_delete_trail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(
             zrc_delete_trail.hoofd_object,
             f"http://testserver{reverse(zaak, namespace='zaken')}",

--- a/src/openzaak/components/zaken/tests/admin/besluiten/test_besluit_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/besluiten/test_besluit_audittrail.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: EUPL-1.2
 # Copyright (C) 2019 - 2020 Dimpact
 import uuid
+from typing import Type
 
 from django.test import TestCase
 from django.urls import reverse as django_reverse
@@ -11,6 +12,8 @@ from vng_api_common.audittrails.models import AuditTrail
 from openzaak.components.besluiten.models import Besluit
 from openzaak.components.besluiten.tests.factories import BesluitFactory
 from openzaak.components.catalogi.tests.factories import BesluitTypeFactory
+from openzaak.components.zaken.models import Zaak
+from openzaak.components.zaken.tests.factories import ZaakFactory
 from openzaak.tests.utils import AdminTestMixin
 from openzaak.utils.urls import reverse
 
@@ -26,7 +29,7 @@ inline_data = {
 class BesluitAdminTests(AdminTestMixin, TestCase):
     heeft_alle_autorisaties = True
 
-    def _create_besluit(self):
+    def _create_besluit(self, zaak: Type[Zaak] | None = None):
         besluittype = BesluitTypeFactory.create(concept=False)
         add_url = django_reverse("admin:besluiten_besluit_add")
         data = {
@@ -38,6 +41,13 @@ class BesluitAdminTests(AdminTestMixin, TestCase):
             "toelichting": "desc",
         }
         data.update(inline_data)
+
+        if zaak:
+            data.update(
+                {
+                    "_zaak": zaak.id,
+                }
+            )
 
         self.client.post(add_url, data)
 
@@ -72,6 +82,60 @@ class BesluitAdminTests(AdminTestMixin, TestCase):
         self.assertEqual(audittrail.oud, None)
 
         new_data = audittrail.nieuw
+        self.assertEqual(new_data["toelichting"], "desc")
+
+    def test_create_besluit_with_zaak(self):
+        zaak = ZaakFactory.create()
+        besluit = self._create_besluit(zaak)
+
+        self.assertEqual(AuditTrail.objects.count(), 2)
+
+        brc_audittrail = AuditTrail.objects.get(bron="BRC")
+        self.assertEqual(brc_audittrail.actie, "create")
+        self.assertEqual(brc_audittrail.resultaat, 0)
+        self.assertEqual(brc_audittrail.applicatie_weergave, "admin")
+        self.assertEqual(brc_audittrail.gebruikers_id, f"{self.user.id}")
+        self.assertEqual(brc_audittrail.gebruikers_weergave, self.user.get_full_name())
+        self.assertEqual(
+            brc_audittrail.hoofd_object,
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
+        self.assertEqual(brc_audittrail.resource, "besluit")
+        self.assertEqual(
+            brc_audittrail.resource_url,
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
+        self.assertEqual(
+            brc_audittrail.resource_weergave, besluit.unique_representation()
+        )
+
+        self.assertEqual(brc_audittrail.oud, None)
+
+        new_data = brc_audittrail.nieuw
+        self.assertEqual(new_data["toelichting"], "desc")
+
+        zrc_audittrail = AuditTrail.objects.get(bron="ZRC")
+        self.assertEqual(zrc_audittrail.actie, "create")
+        self.assertEqual(zrc_audittrail.resultaat, 0)
+        self.assertEqual(zrc_audittrail.applicatie_weergave, "admin")
+        self.assertEqual(zrc_audittrail.gebruikers_id, f"{self.user.id}")
+        self.assertEqual(zrc_audittrail.gebruikers_weergave, self.user.get_full_name())
+        self.assertEqual(
+            zrc_audittrail.hoofd_object,
+            f"http://testserver{reverse(zaak, namespace='zaken')}",
+        )
+        self.assertEqual(zrc_audittrail.resource, "besluit")
+        self.assertEqual(
+            zrc_audittrail.resource_url,
+            f"http://testserver{reverse(besluit, namespace='zaken')}",
+        )
+        self.assertEqual(
+            zrc_audittrail.resource_weergave, besluit.unique_representation()
+        )
+
+        self.assertEqual(zrc_audittrail.oud, None)
+
+        new_data = zrc_audittrail.nieuw
         self.assertEqual(new_data["toelichting"], "desc")
 
     def test_change_besluit(self):
@@ -117,6 +181,75 @@ class BesluitAdminTests(AdminTestMixin, TestCase):
         self.assertEqual(old_data["toelichting"], "old")
         self.assertEqual(new_data["toelichting"], "new")
 
+    def test_change_besluit_add_zaak(self):
+        besluit = BesluitFactory.create(toelichting="old")
+        zaak = ZaakFactory.create()
+        change_url = django_reverse(
+            "admin:besluiten_besluit_change", args=(besluit.pk,)
+        )
+        data = {
+            "uuid": besluit.uuid,
+            "_besluittype": besluit._besluittype.id,
+            "verantwoordelijke_organisatie": besluit.verantwoordelijke_organisatie,
+            "datum": besluit.datum,
+            "ingangsdatum": "15-11-2019",
+            "toelichting": "new",
+            "_zaak": zaak.id,
+        }
+        data.update(inline_data)
+
+        self.client.post(change_url, data)
+
+        self.assertEqual(AuditTrail.objects.count(), 2)
+
+        besluit.refresh_from_db()
+
+        brc_audittrail = AuditTrail.objects.get(bron="BRC")
+        self.assertEqual(brc_audittrail.actie, "update")
+        self.assertEqual(brc_audittrail.resultaat, 0)
+        self.assertEqual(brc_audittrail.applicatie_weergave, "admin")
+        self.assertEqual(brc_audittrail.gebruikers_id, f"{self.user.id}")
+        self.assertEqual(brc_audittrail.gebruikers_weergave, self.user.get_full_name())
+        self.assertEqual(
+            brc_audittrail.hoofd_object,
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
+        self.assertEqual(brc_audittrail.resource, "besluit")
+        self.assertEqual(
+            brc_audittrail.resource_url,
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
+        self.assertEqual(
+            brc_audittrail.resource_weergave, besluit.unique_representation()
+        )
+
+        old_data, new_data = brc_audittrail.oud, brc_audittrail.nieuw
+        self.assertEqual(old_data["toelichting"], "old")
+        self.assertEqual(new_data["toelichting"], "new")
+
+        zrc_audittrail = AuditTrail.objects.get(bron="ZRC")
+        self.assertEqual(zrc_audittrail.actie, "update")
+        self.assertEqual(zrc_audittrail.resultaat, 0)
+        self.assertEqual(zrc_audittrail.applicatie_weergave, "admin")
+        self.assertEqual(zrc_audittrail.gebruikers_id, f"{self.user.id}")
+        self.assertEqual(zrc_audittrail.gebruikers_weergave, self.user.get_full_name())
+        self.assertEqual(
+            zrc_audittrail.hoofd_object,
+            f"http://testserver{reverse(zaak, namespace='zaken')}",
+        )
+        self.assertEqual(zrc_audittrail.resource, "besluit")
+        self.assertEqual(
+            zrc_audittrail.resource_url,
+            f"http://testserver{reverse(besluit, namespace='zaken')}",
+        )
+        self.assertEqual(
+            zrc_audittrail.resource_weergave, besluit.unique_representation()
+        )
+
+        old_data, new_data = zrc_audittrail.oud, zrc_audittrail.nieuw
+        self.assertEqual(old_data["toelichting"], "old")
+        self.assertEqual(new_data["toelichting"], "new")
+
     def test_delete_besluit_action(self):
         besluit = self._create_besluit()
 
@@ -148,3 +281,24 @@ class BesluitAdminTests(AdminTestMixin, TestCase):
 
         self.assertEqual(Besluit.objects.count(), 0)
         self.assertEqual(AuditTrail.objects.count(), 0)
+
+    def test_delete_besluit_with_zaak(self):
+        zaak = ZaakFactory.create()
+        besluit = self._create_besluit(zaak)
+
+        delete_url = django_reverse(
+            "admin:besluiten_besluit_delete", args=(besluit.pk,)
+        )
+        data = {"post": "yes"}
+
+        self.client.post(delete_url, data)
+
+        self.assertEqual(Besluit.objects.count(), 0)
+        self.assertEqual(AuditTrail.objects.count(), 2)
+
+        zrc_delete_trail = AuditTrail.objects.get(actie="destroy")
+        self.assertEqual(zrc_delete_trail.bron, "ZRC")
+        self.assertEqual(
+            zrc_delete_trail.hoofd_object,
+            f"http://testserver{reverse(zaak, namespace='zaken')}",
+        )

--- a/src/openzaak/components/zaken/tests/admin/besluiten/test_besluitinformatieobject_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/besluiten/test_besluitinformatieobject_audittrail.py
@@ -26,7 +26,6 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
 
     def test_create_bio(self):
         besluit = BesluitFactory.create()
-        besluit_url = reverse(besluit, namespace="zaken")
         informatieobject = EnkelvoudigInformatieObjectFactory.create()
         add_url = django_reverse("admin:besluiten_besluitinformatieobject_add")
         data = {
@@ -40,7 +39,6 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
         self.assertEqual(BesluitInformatieObject.objects.count(), 1)
 
         bio = BesluitInformatieObject.objects.get()
-        bio_url = reverse(bio, namespace="zaken")
 
         self.assertEqual(AuditTrail.objects.count(), 1)
 
@@ -52,19 +50,27 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
         self.assertEqual(audittrail.applicatie_weergave, "admin")
         self.assertEqual(audittrail.gebruikers_id, f"{self.user.id}")
         self.assertEqual(audittrail.gebruikers_weergave, self.user.get_full_name())
-        self.assertEqual(audittrail.hoofd_object, f"http://testserver{besluit_url}")
+        self.assertEqual(
+            audittrail.hoofd_object,
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
         self.assertEqual(audittrail.resource, "besluitinformatieobject")
-        self.assertEqual(audittrail.resource_url, f"http://testserver{bio_url}")
+        self.assertEqual(
+            audittrail.resource_url,
+            f"http://testserver{reverse(bio, namespace='besluiten')}",
+        )
         self.assertEqual(audittrail.resource_weergave, bio.unique_representation())
         self.assertEqual(audittrail.oud, None)
 
         new_data = audittrail.nieuw
-        self.assertEqual(new_data["besluit"], f"http://testserver{besluit_url}")
+        self.assertEqual(
+            new_data["besluit"],
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
 
     def test_change_bio(self):
         besluit_old, besluit_new = BesluitFactory.create_batch(2)
         bio = BesluitInformatieObjectFactory.create(besluit=besluit_old)
-        bio_url = reverse(bio, namespace="zaken")
         change_url = django_reverse(
             "admin:besluiten_besluitinformatieobject_change", args=(bio.pk,)
         )
@@ -80,8 +86,6 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
 
         bio.refresh_from_db()
         audittrail = AuditTrail.objects.get()
-        besluit_old_url = reverse(besluit_old, namespace="zaken")
-        besluit_new_url = reverse(besluit_new, namespace="zaken")
 
         self.assertEqual(audittrail.bron, "BRC")
         self.assertEqual(audittrail.actie, "update")
@@ -89,20 +93,30 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
         self.assertEqual(audittrail.applicatie_weergave, "admin")
         self.assertEqual(audittrail.gebruikers_id, f"{self.user.id}")
         self.assertEqual(audittrail.gebruikers_weergave, self.user.get_full_name())
-        self.assertEqual(audittrail.hoofd_object, f"http://testserver{besluit_new_url}")
+        self.assertEqual(
+            audittrail.hoofd_object,
+            f"http://testserver{reverse(besluit_new, namespace='besluiten')}",
+        )
         self.assertEqual(audittrail.resource, "besluitinformatieobject")
-        self.assertEqual(audittrail.resource_url, f"http://testserver{bio_url}")
+        self.assertEqual(
+            audittrail.resource_url,
+            f"http://testserver{reverse(bio, namespace='besluiten')}",
+        )
         self.assertEqual(audittrail.resource_weergave, bio.unique_representation())
 
         old_data, new_data = audittrail.oud, audittrail.nieuw
 
-        self.assertEqual(old_data["besluit"], f"http://testserver{besluit_old_url}")
-        self.assertEqual(new_data["besluit"], f"http://testserver{besluit_new_url}")
+        self.assertEqual(
+            old_data["besluit"],
+            f"http://testserver{reverse(besluit_old, namespace='besluiten')}",
+        )
+        self.assertEqual(
+            new_data["besluit"],
+            f"http://testserver{reverse(besluit_new, namespace='besluiten')}",
+        )
 
     def test_delete_bio_action(self):
         bio = BesluitInformatieObjectFactory.create()
-        bio_url = reverse(bio, namespace="zaken")
-        besluit_url = reverse(bio.besluit, namespace="zaken")
         change_list_url = django_reverse(
             "admin:besluiten_besluitinformatieobject_changelist"
         )
@@ -124,20 +138,27 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
         self.assertEqual(audittrail.applicatie_weergave, "admin")
         self.assertEqual(audittrail.gebruikers_id, f"{self.user.id}")
         self.assertEqual(audittrail.gebruikers_weergave, self.user.get_full_name())
-        self.assertEqual(audittrail.hoofd_object, f"http://testserver{besluit_url}")
+        self.assertEqual(
+            audittrail.hoofd_object,
+            f"http://testserver{reverse(bio.besluit, namespace='besluiten')}",
+        )
         self.assertEqual(audittrail.resource, "besluitinformatieobject")
-        self.assertEqual(audittrail.resource_url, f"http://testserver{bio_url}")
+        self.assertEqual(
+            audittrail.resource_url,
+            f"http://testserver{reverse(bio, namespace='besluiten')}",
+        )
         self.assertEqual(audittrail.resource_weergave, bio.unique_representation())
         self.assertEqual(audittrail.nieuw, None)
 
         old_data = audittrail.oud
 
-        self.assertEqual(old_data["besluit"], f"http://testserver{besluit_url}")
+        self.assertEqual(
+            old_data["besluit"],
+            f"http://testserver{reverse(bio.besluit, namespace='besluiten')}",
+        )
 
     def test_delete_bio(self):
         bio = BesluitInformatieObjectFactory.create()
-        bio_url = reverse(bio, namespace="zaken")
-        besluit_url = reverse(bio.besluit, namespace="zaken")
         delete_url = django_reverse(
             "admin:besluiten_besluitinformatieobject_delete", args=(bio.pk,)
         )
@@ -155,12 +176,21 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
         self.assertEqual(audittrail.applicatie_weergave, "admin")
         self.assertEqual(audittrail.gebruikers_id, f"{self.user.id}")
         self.assertEqual(audittrail.gebruikers_weergave, self.user.get_full_name())
-        self.assertEqual(audittrail.hoofd_object, f"http://testserver{besluit_url}")
+        self.assertEqual(
+            audittrail.hoofd_object,
+            f"http://testserver{reverse(bio.besluit, namespace='besluiten')}",
+        )
         self.assertEqual(audittrail.resource, "besluitinformatieobject")
-        self.assertEqual(audittrail.resource_url, f"http://testserver{bio_url}")
+        self.assertEqual(
+            audittrail.resource_url,
+            f"http://testserver{reverse(bio, namespace='besluiten')}",
+        )
         self.assertEqual(audittrail.resource_weergave, bio.unique_representation())
         self.assertEqual(audittrail.nieuw, None)
 
         old_data = audittrail.oud
 
-        self.assertEqual(old_data["besluit"], f"http://testserver{besluit_url}")
+        self.assertEqual(
+            old_data["besluit"],
+            f"http://testserver{reverse(bio.besluit, namespace='besluiten')}",
+        )

--- a/src/openzaak/components/zaken/tests/admin/besluiten/test_besluitinformatieobject_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/besluiten/test_besluitinformatieobject_audittrail.py
@@ -8,6 +8,7 @@ from django.urls import reverse as django_reverse
 from maykin_2fa.test import disable_admin_mfa
 from vng_api_common.audittrails.models import AuditTrail
 
+from openzaak.components.besluiten.api.audits import AUDIT_BRC
 from openzaak.components.besluiten.models import BesluitInformatieObject
 from openzaak.components.besluiten.tests.factories import (
     BesluitFactory,
@@ -16,6 +17,7 @@ from openzaak.components.besluiten.tests.factories import (
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
+from openzaak.components.zaken.api.audits import AUDIT_ZRC
 from openzaak.components.zaken.tests.factories import ZaakFactory
 from openzaak.tests.utils import AdminTestMixin
 from openzaak.utils.urls import reverse
@@ -45,7 +47,7 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "BRC")
+        self.assertEqual(audittrail.bron, AUDIT_BRC.component_name)
         self.assertEqual(audittrail.actie, "create")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -87,7 +89,7 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
 
         self.assertEqual(AuditTrail.objects.count(), 2)
 
-        brc_audittrail = AuditTrail.objects.get(bron="BRC")
+        brc_audittrail = AuditTrail.objects.get(bron=AUDIT_BRC.component_name)
         self.assertEqual(brc_audittrail.actie, "create")
         self.assertEqual(brc_audittrail.resultaat, 0)
         self.assertEqual(brc_audittrail.applicatie_weergave, "admin")
@@ -111,7 +113,7 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
             f"http://testserver{reverse(besluit, namespace='besluiten')}",
         )
 
-        zrc_audittrail = AuditTrail.objects.get(bron="ZRC")
+        zrc_audittrail = AuditTrail.objects.get(bron=AUDIT_ZRC.component_name)
         self.assertEqual(zrc_audittrail.actie, "create")
         self.assertEqual(zrc_audittrail.resultaat, 0)
         self.assertEqual(zrc_audittrail.applicatie_weergave, "admin")
@@ -154,7 +156,7 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
         bio.refresh_from_db()
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "BRC")
+        self.assertEqual(audittrail.bron, AUDIT_BRC.component_name)
         self.assertEqual(audittrail.actie, "update")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -203,7 +205,7 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
 
         bio.refresh_from_db()
 
-        audittrail = AuditTrail.objects.get(bron="BRC")
+        audittrail = AuditTrail.objects.get(bron=AUDIT_BRC.component_name)
         self.assertEqual(audittrail.actie, "update")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -231,7 +233,7 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
             f"http://testserver{reverse(besluit_new, namespace='besluiten')}",
         )
 
-        audittrail = AuditTrail.objects.get(bron="ZRC")
+        audittrail = AuditTrail.objects.get(bron=AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "update")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -276,7 +278,7 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "BRC")
+        self.assertEqual(audittrail.bron, AUDIT_BRC.component_name)
         self.assertEqual(audittrail.actie, "destroy")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -314,7 +316,7 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "BRC")
+        self.assertEqual(audittrail.bron, AUDIT_BRC.component_name)
         self.assertEqual(audittrail.actie, "destroy")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -354,7 +356,7 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
         self.assertEqual(BesluitInformatieObject.objects.count(), 0)
         self.assertEqual(AuditTrail.objects.count(), 2)
 
-        brc_audittrail = AuditTrail.objects.get(bron="BRC")
+        brc_audittrail = AuditTrail.objects.get(bron=AUDIT_BRC.component_name)
         self.assertEqual(brc_audittrail.actie, "destroy")
         self.assertEqual(brc_audittrail.resultaat, 0)
         self.assertEqual(brc_audittrail.applicatie_weergave, "admin")
@@ -379,7 +381,7 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
             f"http://testserver{reverse(bio.besluit, namespace='besluiten')}",
         )
 
-        zrc_audittrail = AuditTrail.objects.get(bron="ZRC")
+        zrc_audittrail = AuditTrail.objects.get(bron=AUDIT_ZRC.component_name)
         self.assertEqual(zrc_audittrail.actie, "destroy")
         self.assertEqual(zrc_audittrail.resultaat, 0)
         self.assertEqual(zrc_audittrail.applicatie_weergave, "admin")

--- a/src/openzaak/components/zaken/tests/admin/besluiten/test_besluitinformatieobject_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/besluiten/test_besluitinformatieobject_audittrail.py
@@ -16,6 +16,7 @@ from openzaak.components.besluiten.tests.factories import (
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
+from openzaak.components.zaken.tests.factories import ZaakFactory
 from openzaak.tests.utils import AdminTestMixin
 from openzaak.utils.urls import reverse
 
@@ -68,6 +69,72 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
             f"http://testserver{reverse(besluit, namespace='besluiten')}",
         )
 
+    def test_create_bio_with_zaak(self):
+        besluit = BesluitFactory.create(for_zaak=True)
+        informatieobject = EnkelvoudigInformatieObjectFactory.create()
+        add_url = django_reverse("admin:besluiten_besluitinformatieobject_add")
+        data = {
+            "uuid": uuid.uuid4(),
+            "besluit": besluit.id,
+            "_informatieobject": informatieobject.canonical.id,
+        }
+
+        self.client.post(add_url, data)
+
+        self.assertEqual(BesluitInformatieObject.objects.count(), 1)
+
+        bio = BesluitInformatieObject.objects.get()
+
+        self.assertEqual(AuditTrail.objects.count(), 2)
+
+        brc_audittrail = AuditTrail.objects.get(bron="BRC")
+        self.assertEqual(brc_audittrail.actie, "create")
+        self.assertEqual(brc_audittrail.resultaat, 0)
+        self.assertEqual(brc_audittrail.applicatie_weergave, "admin")
+        self.assertEqual(brc_audittrail.gebruikers_id, f"{self.user.id}")
+        self.assertEqual(brc_audittrail.gebruikers_weergave, self.user.get_full_name())
+        self.assertEqual(
+            brc_audittrail.hoofd_object,
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
+        self.assertEqual(brc_audittrail.resource, "besluitinformatieobject")
+        self.assertEqual(
+            brc_audittrail.resource_url,
+            f"http://testserver{reverse(bio, namespace='besluiten')}",
+        )
+        self.assertEqual(brc_audittrail.resource_weergave, bio.unique_representation())
+        self.assertEqual(brc_audittrail.oud, None)
+
+        new_data = brc_audittrail.nieuw
+        self.assertEqual(
+            new_data["besluit"],
+            f"http://testserver{reverse(besluit, namespace='besluiten')}",
+        )
+
+        zrc_audittrail = AuditTrail.objects.get(bron="ZRC")
+        self.assertEqual(zrc_audittrail.actie, "create")
+        self.assertEqual(zrc_audittrail.resultaat, 0)
+        self.assertEqual(zrc_audittrail.applicatie_weergave, "admin")
+        self.assertEqual(zrc_audittrail.gebruikers_id, f"{self.user.id}")
+        self.assertEqual(zrc_audittrail.gebruikers_weergave, self.user.get_full_name())
+        self.assertEqual(
+            zrc_audittrail.hoofd_object,
+            f"http://testserver{reverse(besluit.zaak, namespace='zaken')}",
+        )
+        self.assertEqual(zrc_audittrail.resource, "besluitinformatieobject")
+        self.assertEqual(
+            zrc_audittrail.resource_url,
+            f"http://testserver{reverse(bio, namespace='zaken')}",
+        )
+        self.assertEqual(zrc_audittrail.resource_weergave, bio.unique_representation())
+        self.assertEqual(zrc_audittrail.oud, None)
+
+        new_data = zrc_audittrail.nieuw
+        self.assertEqual(
+            new_data["besluit"],
+            f"http://testserver{reverse(besluit, namespace='zaken')}",
+        )
+
     def test_change_bio(self):
         besluit_old, besluit_new = BesluitFactory.create_batch(2)
         bio = BesluitInformatieObjectFactory.create(besluit=besluit_old)
@@ -113,6 +180,83 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
         self.assertEqual(
             new_data["besluit"],
             f"http://testserver{reverse(besluit_new, namespace='besluiten')}",
+        )
+
+    def test_change_bio_with_zaak(self):
+        besluit_old, besluit_new = BesluitFactory.create_batch(2)
+        besluit_new.zaak = ZaakFactory.create()
+        besluit_new.save()
+
+        bio = BesluitInformatieObjectFactory.create(besluit=besluit_old)
+        change_url = django_reverse(
+            "admin:besluiten_besluitinformatieobject_change", args=(bio.pk,)
+        )
+        data = {
+            "uuid": bio.uuid,
+            "besluit": besluit_new.id,
+            "_informatieobject": bio.informatieobject.id,
+        }
+
+        self.client.post(change_url, data)
+
+        self.assertEqual(AuditTrail.objects.count(), 2)
+
+        bio.refresh_from_db()
+
+        audittrail = AuditTrail.objects.get(bron="BRC")
+        self.assertEqual(audittrail.actie, "update")
+        self.assertEqual(audittrail.resultaat, 0)
+        self.assertEqual(audittrail.applicatie_weergave, "admin")
+        self.assertEqual(audittrail.gebruikers_id, f"{self.user.id}")
+        self.assertEqual(audittrail.gebruikers_weergave, self.user.get_full_name())
+        self.assertEqual(
+            audittrail.hoofd_object,
+            f"http://testserver{reverse(besluit_new, namespace='besluiten')}",
+        )
+        self.assertEqual(audittrail.resource, "besluitinformatieobject")
+        self.assertEqual(
+            audittrail.resource_url,
+            f"http://testserver{reverse(bio, namespace='besluiten')}",
+        )
+        self.assertEqual(audittrail.resource_weergave, bio.unique_representation())
+
+        old_data, new_data = audittrail.oud, audittrail.nieuw
+
+        self.assertEqual(
+            old_data["besluit"],
+            f"http://testserver{reverse(besluit_old, namespace='besluiten')}",
+        )
+        self.assertEqual(
+            new_data["besluit"],
+            f"http://testserver{reverse(besluit_new, namespace='besluiten')}",
+        )
+
+        audittrail = AuditTrail.objects.get(bron="ZRC")
+        self.assertEqual(audittrail.actie, "update")
+        self.assertEqual(audittrail.resultaat, 0)
+        self.assertEqual(audittrail.applicatie_weergave, "admin")
+        self.assertEqual(audittrail.gebruikers_id, f"{self.user.id}")
+        self.assertEqual(audittrail.gebruikers_weergave, self.user.get_full_name())
+        self.assertEqual(
+            audittrail.hoofd_object,
+            f"http://testserver{reverse(besluit_new.zaak, namespace='zaken')}",
+        )
+        self.assertEqual(audittrail.resource, "besluitinformatieobject")
+        self.assertEqual(
+            audittrail.resource_url,
+            f"http://testserver{reverse(bio, namespace='zaken')}",
+        )
+        self.assertEqual(audittrail.resource_weergave, bio.unique_representation())
+
+        old_data, new_data = audittrail.oud, audittrail.nieuw
+
+        self.assertEqual(
+            old_data["besluit"],
+            f"http://testserver{reverse(besluit_old, namespace='zaken')}",
+        )
+        self.assertEqual(
+            new_data["besluit"],
+            f"http://testserver{reverse(besluit_new, namespace='zaken')}",
         )
 
     def test_delete_bio_action(self):
@@ -193,4 +337,69 @@ class BesluitInformatieObjectAdminTests(AdminTestMixin, TestCase):
         self.assertEqual(
             old_data["besluit"],
             f"http://testserver{reverse(bio.besluit, namespace='besluiten')}",
+        )
+
+    def test_delete_bio_with_zaak(self):
+        bio = BesluitInformatieObjectFactory.create()
+        bio.besluit.zaak = ZaakFactory.create()
+        bio.besluit.save()
+
+        delete_url = django_reverse(
+            "admin:besluiten_besluitinformatieobject_delete", args=(bio.pk,)
+        )
+        data = {"post": "yes"}
+
+        self.client.post(delete_url, data)
+
+        self.assertEqual(BesluitInformatieObject.objects.count(), 0)
+        self.assertEqual(AuditTrail.objects.count(), 2)
+
+        brc_audittrail = AuditTrail.objects.get(bron="BRC")
+        self.assertEqual(brc_audittrail.actie, "destroy")
+        self.assertEqual(brc_audittrail.resultaat, 0)
+        self.assertEqual(brc_audittrail.applicatie_weergave, "admin")
+        self.assertEqual(brc_audittrail.gebruikers_id, f"{self.user.id}")
+        self.assertEqual(brc_audittrail.gebruikers_weergave, self.user.get_full_name())
+        self.assertEqual(
+            brc_audittrail.hoofd_object,
+            f"http://testserver{reverse(bio.besluit, namespace='besluiten')}",
+        )
+        self.assertEqual(brc_audittrail.resource, "besluitinformatieobject")
+        self.assertEqual(
+            brc_audittrail.resource_url,
+            f"http://testserver{reverse(bio, namespace='besluiten')}",
+        )
+        self.assertEqual(brc_audittrail.resource_weergave, bio.unique_representation())
+        self.assertEqual(brc_audittrail.nieuw, None)
+
+        old_data = brc_audittrail.oud
+
+        self.assertEqual(
+            old_data["besluit"],
+            f"http://testserver{reverse(bio.besluit, namespace='besluiten')}",
+        )
+
+        zrc_audittrail = AuditTrail.objects.get(bron="ZRC")
+        self.assertEqual(zrc_audittrail.actie, "destroy")
+        self.assertEqual(zrc_audittrail.resultaat, 0)
+        self.assertEqual(zrc_audittrail.applicatie_weergave, "admin")
+        self.assertEqual(zrc_audittrail.gebruikers_id, f"{self.user.id}")
+        self.assertEqual(zrc_audittrail.gebruikers_weergave, self.user.get_full_name())
+        self.assertEqual(
+            zrc_audittrail.hoofd_object,
+            f"http://testserver{reverse(bio.besluit.zaak, namespace='zaken')}",
+        )
+        self.assertEqual(zrc_audittrail.resource, "besluitinformatieobject")
+        self.assertEqual(
+            zrc_audittrail.resource_url,
+            f"http://testserver{reverse(bio, namespace='zaken')}",
+        )
+        self.assertEqual(zrc_audittrail.resource_weergave, bio.unique_representation())
+        self.assertEqual(zrc_audittrail.nieuw, None)
+
+        old_data = zrc_audittrail.oud
+
+        self.assertEqual(
+            old_data["besluit"],
+            f"http://testserver{reverse(bio.besluit, namespace='zaken')}",
         )

--- a/src/openzaak/components/zaken/tests/admin/test_klantcontact_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/test_klantcontact_audittrail.py
@@ -12,6 +12,7 @@ from vng_api_common.audittrails.models import AuditTrail
 from openzaak.components.zaken.models import KlantContact
 from openzaak.tests.utils import AdminTestMixin
 
+from ...api.audits import AUDIT_ZRC
 from ..factories import KlantContactFactory, ZaakFactory
 from ..utils import get_operation_url
 
@@ -47,7 +48,7 @@ class KlantContactAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "create")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -89,7 +90,7 @@ class KlantContactAdminTests(AdminTestMixin, TestCase):
         klantcontact.refresh_from_db()
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "update")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -127,7 +128,7 @@ class KlantContactAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "destroy")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -162,7 +163,7 @@ class KlantContactAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "destroy")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")

--- a/src/openzaak/components/zaken/tests/admin/test_resultaat_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/test_resultaat_audittrail.py
@@ -12,6 +12,7 @@ from openzaak.components.catalogi.tests.factories import ResultaatTypeFactory
 from openzaak.components.zaken.models import Resultaat
 from openzaak.tests.utils import AdminTestMixin
 
+from ...api.audits import AUDIT_ZRC
 from ..factories import ResultaatFactory, ZaakFactory
 from ..utils import get_operation_url
 
@@ -46,7 +47,7 @@ class ResultaatAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "create")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -85,7 +86,7 @@ class ResultaatAdminTests(AdminTestMixin, TestCase):
         resultaat.refresh_from_db()
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "update")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -121,7 +122,7 @@ class ResultaatAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "destroy")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -155,7 +156,7 @@ class ResultaatAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "destroy")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")

--- a/src/openzaak/components/zaken/tests/admin/test_rol_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/test_rol_audittrail.py
@@ -10,6 +10,7 @@ from openzaak.components.catalogi.tests.factories import RolTypeFactory
 from openzaak.components.zaken.models import Rol
 from openzaak.tests.utils import AdminTestMixin
 
+from ...api.audits import AUDIT_ZRC
 from ..factories import RolFactory, ZaakFactory
 from ..utils import get_operation_url
 
@@ -46,7 +47,7 @@ class RolAdminTests(AdminTestMixin, WebTest):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "create")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -82,7 +83,7 @@ class RolAdminTests(AdminTestMixin, WebTest):
         rol.refresh_from_db()
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "update")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -114,7 +115,7 @@ class RolAdminTests(AdminTestMixin, WebTest):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "destroy")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -143,7 +144,7 @@ class RolAdminTests(AdminTestMixin, WebTest):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "destroy")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")

--- a/src/openzaak/components/zaken/tests/admin/test_status_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/test_status_audittrail.py
@@ -14,6 +14,7 @@ from openzaak.components.catalogi.tests.factories import StatusTypeFactory
 from openzaak.components.zaken.models import Status
 from openzaak.tests.utils import AdminTestMixin
 
+from ...api.audits import AUDIT_ZRC
 from ..factories import StatusFactory, ZaakFactory
 from ..utils import get_operation_url
 
@@ -56,7 +57,7 @@ class StatusAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "create")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -104,7 +105,7 @@ class StatusAdminTests(AdminTestMixin, TestCase):
         status.refresh_from_db()
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "update")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -136,7 +137,7 @@ class StatusAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "destroy")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -165,7 +166,7 @@ class StatusAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "destroy")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")

--- a/src/openzaak/components/zaken/tests/admin/test_zaak_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/test_zaak_audittrail.py
@@ -10,6 +10,7 @@ from openzaak.components.catalogi.tests.factories import ZaakTypeFactory
 from openzaak.components.zaken.models import Zaak
 from openzaak.tests.utils import AdminTestMixin
 
+from ...api.audits import AUDIT_ZRC
 from ..factories import ZaakFactory
 from ..utils import get_operation_url
 
@@ -48,7 +49,7 @@ class ZaakAdminTests(AdminTestMixin, WebTest):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "create")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -88,7 +89,7 @@ class ZaakAdminTests(AdminTestMixin, WebTest):
         zaak.refresh_from_db()
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "update")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")

--- a/src/openzaak/components/zaken/tests/admin/test_zaakeigenschap_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/test_zaakeigenschap_audittrail.py
@@ -12,6 +12,7 @@ from openzaak.components.catalogi.tests.factories import EigenschapFactory
 from openzaak.components.zaken.models import ZaakEigenschap
 from openzaak.tests.utils import AdminTestMixin
 
+from ...api.audits import AUDIT_ZRC
 from ..factories import ZaakEigenschapFactory, ZaakFactory
 from ..utils import get_operation_url
 
@@ -47,7 +48,7 @@ class ZaakEigenschapAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "create")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -93,7 +94,7 @@ class ZaakEigenschapAdminTests(AdminTestMixin, TestCase):
         zaakeigenschap.refresh_from_db()
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "update")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -133,7 +134,7 @@ class ZaakEigenschapAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "destroy")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -172,7 +173,7 @@ class ZaakEigenschapAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "destroy")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")

--- a/src/openzaak/components/zaken/tests/admin/test_zaakinformatieobject_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/test_zaakinformatieobject_audittrail.py
@@ -15,6 +15,7 @@ from openzaak.components.documenten.tests.factories import (
 from openzaak.components.zaken.models import ZaakInformatieObject
 from openzaak.tests.utils import AdminTestMixin
 
+from ...api.audits import AUDIT_ZRC
 from ..factories import ZaakFactory, ZaakInformatieObjectFactory
 from ..utils import get_operation_url
 
@@ -51,7 +52,7 @@ class ZaakInformatieObjectAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "create")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -95,7 +96,7 @@ class ZaakInformatieObjectAdminTests(AdminTestMixin, TestCase):
         zaakinformatieobject.refresh_from_db()
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "update")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -135,7 +136,7 @@ class ZaakInformatieObjectAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "destroy")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -175,7 +176,7 @@ class ZaakInformatieObjectAdminTests(AdminTestMixin, TestCase):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "destroy")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")

--- a/src/openzaak/components/zaken/tests/admin/test_zaakobject_audittrail.py
+++ b/src/openzaak/components/zaken/tests/admin/test_zaakobject_audittrail.py
@@ -10,6 +10,7 @@ from openzaak.components.catalogi.tests.factories import ZaakObjectTypeFactory
 from openzaak.components.zaken.models import ZaakObject
 from openzaak.tests.utils import AdminTestMixin
 
+from ...api.audits import AUDIT_ZRC
 from ..factories import ZaakFactory, ZaakObjectFactory
 from ..utils import get_operation_url
 
@@ -48,7 +49,7 @@ class ZaakObjectAdminTests(AdminTestMixin, WebTest):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "create")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -84,7 +85,7 @@ class ZaakObjectAdminTests(AdminTestMixin, WebTest):
         zaakobject.refresh_from_db()
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "update")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -120,7 +121,7 @@ class ZaakObjectAdminTests(AdminTestMixin, WebTest):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "destroy")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")
@@ -154,7 +155,7 @@ class ZaakObjectAdminTests(AdminTestMixin, WebTest):
 
         audittrail = AuditTrail.objects.get()
 
-        self.assertEqual(audittrail.bron, "ZRC")
+        self.assertEqual(audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(audittrail.actie, "destroy")
         self.assertEqual(audittrail.resultaat, 0)
         self.assertEqual(audittrail.applicatie_weergave, "admin")

--- a/src/openzaak/components/zaken/tests/test_audittrails.py
+++ b/src/openzaak/components/zaken/tests/test_audittrails.py
@@ -34,6 +34,7 @@ from openzaak.components.documenten.tests.factories import (
 from openzaak.tests.utils import JWTAuthMixin
 from openzaak.utils.urls import reverse
 
+from ..api.audits import AUDIT_ZRC
 from ..models import Resultaat, Rol, Zaak, ZaakInformatieObject, ZaakObject
 from .factories import RolFactory, ZaakFactory, ZaakObjectFactory
 from .test_rol import BETROKKENE
@@ -72,7 +73,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Verify that the audittrail for the Zaak creation contains the correct
         # information
         zaak_create_audittrail = audittrails.get()
-        self.assertEqual(zaak_create_audittrail.bron, "ZRC")
+        self.assertEqual(zaak_create_audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(zaak_create_audittrail.actie, "create")
         self.assertEqual(zaak_create_audittrail.resultaat, 201)
         self.assertEqual(zaak_create_audittrail.oud, None)
@@ -179,7 +180,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
 
         zaak_audittrail = AuditTrail.objects.get(resource="zaak")
 
-        self.assertEqual(zaak_audittrail.bron, "ZRC")
+        self.assertEqual(zaak_audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(zaak_audittrail.actie, "create")
         self.assertEqual(zaak_audittrail.oud, None)
         self.assertEqual(zaak_audittrail.nieuw, response.data["zaak"])
@@ -187,7 +188,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
 
         status_audittrail = AuditTrail.objects.get(resource="status")
 
-        self.assertEqual(status_audittrail.bron, "ZRC")
+        self.assertEqual(status_audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(status_audittrail.actie, "create")
         self.assertEqual(status_audittrail.resource, "status")
         self.assertEqual(status_audittrail.oud, None)
@@ -195,17 +196,17 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         self.assertEqual(status_audittrail.hoofd_object, response.data["zaak"]["url"])
 
         for trail in AuditTrail.objects.filter(resource="rol"):
-            self.assertEqual(trail.bron, "ZRC")
+            self.assertEqual(trail.bron, AUDIT_ZRC.component_name)
             self.assertEqual(trail.actie, "create")
             self.assertEqual(trail.oud, None)
 
         for trail in AuditTrail.objects.filter(resource="zaakobject"):
-            self.assertEqual(trail.bron, "ZRC")
+            self.assertEqual(trail.bron, AUDIT_ZRC.component_name)
             self.assertEqual(trail.actie, "create")
             self.assertEqual(trail.oud, None)
 
         for trail in AuditTrail.objects.filter(resource="zaakinformatieobject"):
-            self.assertEqual(trail.bron, "ZRC")
+            self.assertEqual(trail.bron, AUDIT_ZRC.component_name)
             self.assertEqual(trail.actie, "create")
             self.assertEqual(trail.oud, None)
 
@@ -233,7 +234,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Verify that the audittrail for the Resultaat creation contains the
         # correct information
         resultaat_create_audittrail = audittrails[1]
-        self.assertEqual(resultaat_create_audittrail.bron, "ZRC")
+        self.assertEqual(resultaat_create_audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(resultaat_create_audittrail.actie, "create")
         self.assertEqual(resultaat_create_audittrail.resultaat, 201)
         self.assertEqual(resultaat_create_audittrail.oud, None)
@@ -245,7 +246,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Verify that the audittrail for the Resultaat deletion contains the
         # correct information
         resultaat_delete_audittrail = audittrails[2]
-        self.assertEqual(resultaat_delete_audittrail.bron, "ZRC")
+        self.assertEqual(resultaat_delete_audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(resultaat_delete_audittrail.actie, "destroy")
         self.assertEqual(resultaat_delete_audittrail.resultaat, 204)
         self.assertEqual(resultaat_delete_audittrail.oud, resultaat_response)
@@ -271,7 +272,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Verify that the audittrail for the Zaak update contains the correct
         # information
         zaak_update_audittrail = audittrails[1]
-        self.assertEqual(zaak_update_audittrail.bron, "ZRC")
+        self.assertEqual(zaak_update_audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(zaak_update_audittrail.actie, "update")
         self.assertEqual(zaak_update_audittrail.resultaat, 200)
         self.assertEqual(zaak_update_audittrail.oud, zaak_data)
@@ -293,7 +294,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Verify that the audittrail for the Zaak partial_update contains the
         # correct information
         zaak_update_audittrail = audittrails[1]
-        self.assertEqual(zaak_update_audittrail.bron, "ZRC")
+        self.assertEqual(zaak_update_audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(zaak_update_audittrail.actie, "partial_update")
         self.assertEqual(zaak_update_audittrail.resultaat, 200)
         self.assertEqual(zaak_update_audittrail.oud, zaak_data)
@@ -337,7 +338,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
             resource="zaak", actie="partial_update"
         )
 
-        self.assertEqual(zaak_audittrail.bron, "ZRC")
+        self.assertEqual(zaak_audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(zaak_audittrail.oud, zaak_data)
         self.assertEqual(zaak_audittrail.nieuw, response.data["zaak"])
         self.assertEqual(zaak_audittrail.hoofd_object, response.data["zaak"]["url"])
@@ -347,7 +348,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
 
         status_audittrail = AuditTrail.objects.get(resource="status")
 
-        self.assertEqual(status_audittrail.bron, "ZRC")
+        self.assertEqual(status_audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(status_audittrail.actie, "create")
         self.assertEqual(status_audittrail.resource, "status")
         self.assertEqual(status_audittrail.oud, None)
@@ -411,14 +412,14 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
             resource="zaak", actie="partial_update"
         )
 
-        self.assertEqual(zaak_audittrail.bron, "ZRC")
+        self.assertEqual(zaak_audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(zaak_audittrail.oud, zaak_data)
         self.assertEqual(zaak_audittrail.nieuw, response.data["zaak"])
         self.assertEqual(zaak_audittrail.hoofd_object, response.data["zaak"]["url"])
 
         status_audittrail = AuditTrail.objects.get(resource="status")
 
-        self.assertEqual(status_audittrail.bron, "ZRC")
+        self.assertEqual(status_audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(status_audittrail.actie, "create")
         self.assertEqual(status_audittrail.resource, "status")
         self.assertEqual(status_audittrail.oud, None)
@@ -426,7 +427,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         self.assertEqual(status_audittrail.hoofd_object, response.data["zaak"]["url"])
 
         for trail in AuditTrail.objects.filter(resource="rol"):
-            self.assertEqual(trail.bron, "ZRC")
+            self.assertEqual(trail.bron, AUDIT_ZRC.component_name)
             self.assertEqual(trail.actie, "create")
             self.assertEqual(trail.oud, None)
 
@@ -585,7 +586,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         zaak_audittrail = AuditTrail.objects.get(
             resource="zaak", actie="partial_update"
         )
-        self.assertEqual(zaak_audittrail.bron, "ZRC")
+        self.assertEqual(zaak_audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(zaak_audittrail.oud, zaak_data)
         self.assertEqual(zaak_audittrail.nieuw, response.data["zaak"])
         self.assertEqual(zaak_audittrail.hoofd_object, response.data["zaak"]["url"])
@@ -598,7 +599,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         )
 
         resultaat_audittrail = AuditTrail.objects.get(resource="resultaat")
-        self.assertEqual(resultaat_audittrail.bron, "ZRC")
+        self.assertEqual(resultaat_audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(resultaat_audittrail.actie, "create")
         self.assertEqual(resultaat_audittrail.oud, None)
         self.assertEqual(resultaat_audittrail.nieuw, response.data["resultaat"])
@@ -607,7 +608,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         )
 
         status_audittrail = AuditTrail.objects.get(resource="status")
-        self.assertEqual(status_audittrail.bron, "ZRC")
+        self.assertEqual(status_audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(status_audittrail.actie, "create")
         self.assertEqual(status_audittrail.oud, None)
         self.assertEqual(status_audittrail.nieuw, response.data["status"])
@@ -651,14 +652,14 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
             resource="zaak", actie="partial_update"
         )
 
-        self.assertEqual(zaak_audittrail.bron, "ZRC")
+        self.assertEqual(zaak_audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(zaak_audittrail.oud, zaak_data)
         self.assertEqual(zaak_audittrail.nieuw, response.data["zaak"])
         self.assertEqual(zaak_audittrail.hoofd_object, response.data["zaak"]["url"])
 
         status_audittrail = AuditTrail.objects.get(resource="status")
 
-        self.assertEqual(status_audittrail.bron, "ZRC")
+        self.assertEqual(status_audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(status_audittrail.actie, "create")
         self.assertEqual(status_audittrail.resource, "status")
         self.assertEqual(status_audittrail.oud, None)
@@ -694,7 +695,7 @@ class AuditTrailTests(JWTAuthMixin, APITestCase):
         # Verify that the audittrail for the ZaakInformatieObject creation
         # contains the correct information
         zio_create_audittrail = audittrails[1]
-        self.assertEqual(zio_create_audittrail.bron, "ZRC")
+        self.assertEqual(zio_create_audittrail.bron, AUDIT_ZRC.component_name)
         self.assertEqual(zio_create_audittrail.actie, "create")
         self.assertEqual(zio_create_audittrail.resultaat, 201)
         self.assertEqual(zio_create_audittrail.oud, None)

--- a/src/openzaak/notifications/viewsets.py
+++ b/src/openzaak/notifications/viewsets.py
@@ -36,6 +36,11 @@ from vng_api_common.constants import ComponentTypes
 
 from openzaak.utils.permissions import AuthScopesRequired
 
+from ..utils.namespacing import (
+    get_nested_main_object_url_from_dict,
+    get_nested_main_object_url_from_instance,
+    replace_namespaces,
+)
 from .kanaal import Kanaal
 from .scopes import SCOPE_CLOUDEVENTS_BEZORGEN
 
@@ -148,25 +153,6 @@ class MultipleChannelNotificationMixin(NotificationMixin):
     notifications_main_resource_keys: dict[str, str] | None = None
     notifications_replace_urls_for: list[str] | None = None
 
-    def _get_nested_main_object_url_from_instance(
-        self, key: str, instance: models.Model
-    ) -> str | None:
-        """Returns the url of a nested FK field"""
-        obj = instance
-        for field in key.split("."):
-            obj = getattr(obj, field, None)
-        return obj.get_absolute_api_url(request=self.request) if obj else None
-
-    def _get_nested_main_object_url_from_dict(
-        self, key: str, data: object
-    ) -> str | None:
-        """Returns a nested url field from a dict"""
-        for field in key.split("."):
-            if not isinstance(data, dict):
-                raise KeyError
-            data = data.get(field)
-        return data if isinstance(data, str) else None
-
     def _get_nested_main_object_url(
         self,
         key: str,  # format a.b.c
@@ -175,33 +161,15 @@ class MultipleChannelNotificationMixin(NotificationMixin):
         """returns the nested url key field from an instance or dict"""
         url = None
         if isinstance(main_object_resource, dict):
-            url = self._get_nested_main_object_url_from_dict(key, main_object_resource)
+            url = get_nested_main_object_url_from_dict(key, main_object_resource)
 
         elif isinstance(main_object_resource, models.Model):
-            url = self._get_nested_main_object_url_from_instance(
-                key, main_object_resource
+            url = get_nested_main_object_url_from_instance(
+                key, main_object_resource, self.request
             )
 
         final_key = key.split(".")[-1]
         return {final_key: url} if url else None
-
-    def _replace_namespace(self, url: str, namespace: str) -> str:
-        prefix, sep, rest = url.partition("/api")
-        if not sep:
-            return url
-
-        base, _, old_namespace = prefix.rpartition("/")
-        return f"{base}/{namespace}{sep}{rest}"
-
-    def _replace_urls(
-        self, replace_urls_for: list[str] | None, data: dict, namespace: str
-    ) -> None:
-        if replace_urls_for is None:
-            replace_urls_for = []
-        replace_urls_for.append("url")
-
-        for field in replace_urls_for:
-            data[field] = self._replace_namespace(data[field], namespace)
 
     def _iter_kanalen(
         self,
@@ -212,7 +180,9 @@ class MultipleChannelNotificationMixin(NotificationMixin):
         main_resource_keys: dict[str, str] | None = None,
         main_object_resource: models.Model | dict | None = None,
     ) -> Generator[tuple[Kanaal, dict], None, None]:
-        notification_data = data.copy()
+        if replace_urls_for is None:
+            replace_urls_for = []
+        replace_urls_for.append("url")
         for kanaal_config in kanaal_configs:
             if (
                 kanaal_config.get("deprecated", False)
@@ -221,6 +191,7 @@ class MultipleChannelNotificationMixin(NotificationMixin):
                 continue
             kanaal = kanaal_config["kanaal"]
             namespace = kanaal_config.get("namespace", kanaal.label)
+            notification_data = replace_namespaces(data, replace_urls_for, namespace)
             # if model == main_resource the url field is used which is always set
             # if the model is not main_resource it can be port of notification_data or from a related model.
             # No notification should be sent if the main resource is not set (because it's not required on the model).
@@ -251,8 +222,6 @@ class MultipleChannelNotificationMixin(NotificationMixin):
                         continue
                     else:
                         notification_data.update(url_data)
-
-            self._replace_urls(replace_urls_for, notification_data, namespace)
 
             yield kanaal, notification_data
 

--- a/src/openzaak/notifications/viewsets.py
+++ b/src/openzaak/notifications/viewsets.py
@@ -180,9 +180,8 @@ class MultipleChannelNotificationMixin(NotificationMixin):
         main_resource_keys: dict[str, str] | None = None,
         main_object_resource: models.Model | dict | None = None,
     ) -> Generator[tuple[Kanaal, dict], None, None]:
-        if replace_urls_for is None:
-            replace_urls_for = []
-        replace_urls_for.append("url")
+        fields = ["url"] + (replace_urls_for or [])
+
         for kanaal_config in kanaal_configs:
             if (
                 kanaal_config.get("deprecated", False)
@@ -191,7 +190,7 @@ class MultipleChannelNotificationMixin(NotificationMixin):
                 continue
             kanaal = kanaal_config["kanaal"]
             namespace = kanaal_config.get("namespace", kanaal.label)
-            notification_data = replace_namespaces(data, replace_urls_for, namespace)
+            notification_data = replace_namespaces(data, fields, namespace)
             # if model == main_resource the url field is used which is always set
             # if the model is not main_resource it can be port of notification_data or from a related model.
             # No notification should be sent if the main resource is not set (because it's not required on the model).

--- a/src/openzaak/tests/test_api_deprecation.py
+++ b/src/openzaak/tests/test_api_deprecation.py
@@ -286,15 +286,20 @@ class BesluitAudittrailTests(JWTAuthMixin, APITestCase):
 
         audittrail = AuditTrail.objects.get()
         besluit = Besluit.objects.get()
-        besluit_url = reverse(besluit, namespace="zaken")
 
         with self.subTest("audittrail model"):
             self.assertEqual(audittrail.bron, "BRC")  # TODO see BRC_AUDIT comment
             self.assertEqual(audittrail.actie, "create")
             self.assertEqual(audittrail.resultaat, 201)
-            self.assertEqual(audittrail.hoofd_object, f"http://testserver{besluit_url}")
+            self.assertEqual(
+                audittrail.hoofd_object,
+                f"http://testserver{reverse(besluit, namespace='besluiten')}",
+            )
             self.assertEqual(audittrail.resource, "besluit")
-            self.assertEqual(audittrail.resource_url, f"http://testserver{besluit_url}")
+            self.assertEqual(
+                audittrail.resource_url,
+                f"http://testserver{reverse(besluit, namespace='besluiten')}",
+            )
             self.assertEqual(
                 audittrail.resource_weergave, besluit.unique_representation()
             )
@@ -310,14 +315,20 @@ class BesluitAudittrailTests(JWTAuthMixin, APITestCase):
             data = response.json()[0]
 
             self.assertEqual(data["bron"], "BRC")
-            self.assertEqual(data["hoofdObject"], f"http://testserver{besluit_url}")
-            self.assertEqual(data["resourceUrl"], f"http://testserver{besluit_url}")
+            self.assertEqual(
+                data["hoofdObject"],
+                f"http://testserver{reverse(besluit, namespace='besluiten')}",
+            )
+            self.assertEqual(
+                data["resourceUrl"],
+                f"http://testserver{reverse(besluit, namespace='besluiten')}",
+            )
             self.assertEqual(
                 data["wijzigingen"],
                 {
                     "oud": None,
                     "nieuw": {
-                        "url": f"http://testserver{besluit_url}",
+                        "url": f"http://testserver{reverse(besluit, namespace='besluiten')}",
                         "zaak": "",
                         "datum": "2026-05-05",
                         "besluittype": self.besluittype_url,
@@ -347,14 +358,20 @@ class BesluitAudittrailTests(JWTAuthMixin, APITestCase):
             data = response.json()[0]
 
             self.assertEqual(data["bron"], "BRC")
-            self.assertEqual(data["hoofdObject"], f"http://testserver{besluit_url}")
-            self.assertEqual(data["resourceUrl"], f"http://testserver{besluit_url}")
+            self.assertEqual(
+                data["hoofdObject"],
+                f"http://testserver{reverse(besluit, namespace='besluiten')}",
+            )
+            self.assertEqual(
+                data["resourceUrl"],
+                f"http://testserver{reverse(besluit, namespace='besluiten')}",
+            )
             self.assertEqual(
                 data["wijzigingen"],
                 {
                     "oud": None,
                     "nieuw": {
-                        "url": f"http://testserver{besluit_url}",
+                        "url": f"http://testserver{reverse(besluit, namespace='besluiten')}",
                         "zaak": "",
                         "datum": "2026-05-05",
                         "besluittype": self.besluittype_url,
@@ -397,9 +414,7 @@ class BesluitAudittrailTests(JWTAuthMixin, APITestCase):
         self.assertIn("/besluiten/api/v1/besluiten/", create_trail.nieuw["url"])
 
         self.assertEqual(update_trail.actie, "partial_update")
-        self.assertIn("/zaken/api/v1/besluiten/", update_trail.hoofd_object)
-        self.assertIn("/zaken/api/v1/besluiten/", update_trail.resource_url)
-        self.assertIn(
-            "/zaken/api/v1/besluiten/", update_trail.oud["url"]
-        )  # TODO old data is generate from serializer and uses current namespace.
-        self.assertIn("/zaken/api/v1/besluiten/", update_trail.nieuw["url"])
+        self.assertIn("/besluiten/api/v1/besluiten/", update_trail.hoofd_object)
+        self.assertIn("/besluiten/api/v1/besluiten/", update_trail.resource_url)
+        self.assertIn("/besluiten/api/v1/besluiten/", update_trail.oud["url"])
+        self.assertIn("/besluiten/api/v1/besluiten/", update_trail.nieuw["url"])

--- a/src/openzaak/tests/test_api_deprecation.py
+++ b/src/openzaak/tests/test_api_deprecation.py
@@ -5,6 +5,7 @@
 from rest_framework import status
 from rest_framework.test import APITestCase
 from vng_api_common.audittrails.models import AuditTrail
+from vng_api_common.tests import get_validation_errors
 
 from openzaak.components.besluiten.models import Besluit, BesluitInformatieObject
 from openzaak.components.besluiten.tests.factories import (
@@ -15,6 +16,7 @@ from openzaak.components.catalogi.tests.factories import BesluitTypeFactory
 from openzaak.components.documenten.tests.factories import (
     EnkelvoudigInformatieObjectFactory,
 )
+from openzaak.components.zaken.tests.factories import ZaakFactory
 from openzaak.tests.utils import JWTAuthMixin
 from openzaak.utils.urls import reverse
 
@@ -160,6 +162,62 @@ class BesluitenApiDeprecationTests(JWTAuthMixin, APITestCase):
             },
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_create_bio_in_zaken_with_non_existent_namespace(self):
+        """
+        resolve_path in permission check returns ObjectNotFound
+        """
+        url = reverse(BesluitInformatieObject, namespace="zaken")
+
+        besluit = BesluitFactory.create()
+        eio = EnkelvoudigInformatieObjectFactory.create()
+        eio.informatieobjecttype.besluittypen.add(besluit.besluittype)
+
+        response = self.client.post(
+            url,
+            {
+                "besluit": f"http://testserver/blabla/api/v1/besluiten/{besluit.uuid}",
+                "informatieobject": f"http://testserver{reverse(eio)}",
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "besluit")
+        self.assertEqual(error["code"], "object-does-not-exist")
+
+    def test_create_zaakbesluit(self):
+        zaak = ZaakFactory.create()
+        besluit = BesluitFactory.create(zaak=zaak)
+        besluit.besluittype.zaaktypen.add(zaak.zaaktype)
+
+        with self.subTest("both in zaken namespace"):
+            url = f"{reverse(zaak, namespace='zaken')}/besluiten"
+            response = self.client.post(
+                url,
+                {
+                    "besluit": f"http://testserver{reverse(besluit, namespace='zaken')}",
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        with self.subTest("besluit namespace"):
+            url = f"{reverse(zaak, namespace='zaken')}/besluiten"
+            response = self.client.post(
+                url,
+                {
+                    "besluit": f"http://testserver{reverse(besluit, namespace='besluiten')}",
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        with self.subTest("non existent namespace"):
+            url = f"{reverse(zaak, namespace='zaken')}/besluiten"
+            response = self.client.post(
+                url,
+                {
+                    "besluit": f"http://testserver/blabla/api/v1/besluiten/{besluit.uuid}",
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 class BesluitAudittrailTests(JWTAuthMixin, APITestCase):

--- a/src/openzaak/tests/test_api_deprecation.py
+++ b/src/openzaak/tests/test_api_deprecation.py
@@ -7,6 +7,7 @@ from rest_framework.test import APITestCase
 from vng_api_common.audittrails.models import AuditTrail
 from vng_api_common.tests import get_validation_errors
 
+from openzaak.components.besluiten.api.audits import AUDIT_BRC
 from openzaak.components.besluiten.models import Besluit, BesluitInformatieObject
 from openzaak.components.besluiten.tests.factories import (
     BesluitFactory,
@@ -252,7 +253,7 @@ class BesluitAudittrailTests(JWTAuthMixin, APITestCase):
         besluit_url = reverse(besluit)
 
         with self.subTest("audittrail model"):
-            self.assertEqual(audittrail.bron, "BRC")
+            self.assertEqual(audittrail.bron, AUDIT_BRC.component_name)
             self.assertEqual(audittrail.actie, "create")
             self.assertEqual(audittrail.resultaat, 201)
             self.assertEqual(audittrail.hoofd_object, f"http://testserver{besluit_url}")
@@ -272,7 +273,7 @@ class BesluitAudittrailTests(JWTAuthMixin, APITestCase):
 
             data = response.json()[0]
 
-            self.assertEqual(data["bron"], "BRC")
+            self.assertEqual(data["bron"], AUDIT_BRC.component_name)
             self.assertEqual(data["hoofdObject"], f"http://testserver{besluit_url}")
             self.assertEqual(data["resourceUrl"], f"http://testserver{besluit_url}")
             self.assertEqual(
@@ -309,7 +310,7 @@ class BesluitAudittrailTests(JWTAuthMixin, APITestCase):
 
             data = response.json()[0]
 
-            self.assertEqual(data["bron"], "BRC")
+            self.assertEqual(data["bron"], AUDIT_BRC.component_name)
             self.assertEqual(data["hoofdObject"], f"http://testserver{besluit_url}")
             self.assertEqual(data["resourceUrl"], f"http://testserver{besluit_url}")
             self.assertEqual(
@@ -346,7 +347,9 @@ class BesluitAudittrailTests(JWTAuthMixin, APITestCase):
         besluit = Besluit.objects.get()
 
         with self.subTest("audittrail model"):
-            self.assertEqual(audittrail.bron, "BRC")  # TODO see BRC_AUDIT comment
+            self.assertEqual(
+                audittrail.bron, AUDIT_BRC.component_name
+            )  # TODO see BRC_AUDIT comment
             self.assertEqual(audittrail.actie, "create")
             self.assertEqual(audittrail.resultaat, 201)
             self.assertEqual(
@@ -372,7 +375,7 @@ class BesluitAudittrailTests(JWTAuthMixin, APITestCase):
 
             data = response.json()[0]
 
-            self.assertEqual(data["bron"], "BRC")
+            self.assertEqual(data["bron"], AUDIT_BRC.component_name)
             self.assertEqual(
                 data["hoofdObject"],
                 f"http://testserver{reverse(besluit, namespace='besluiten')}",
@@ -415,7 +418,7 @@ class BesluitAudittrailTests(JWTAuthMixin, APITestCase):
 
             data = response.json()[0]
 
-            self.assertEqual(data["bron"], "BRC")
+            self.assertEqual(data["bron"], AUDIT_BRC.component_name)
             self.assertEqual(
                 data["hoofdObject"],
                 f"http://testserver{reverse(besluit, namespace='besluiten')}",

--- a/src/openzaak/utils/admin.py
+++ b/src/openzaak/utils/admin.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple
 from urllib.parse import urlencode
 
 from django.contrib import admin
+from django.contrib.admin import ModelAdmin
 from django.db import transaction
 from django.db.models.base import Model, ModelBase
 from django.http import HttpRequest
@@ -161,12 +162,27 @@ class AuditTrailAdminMixin:
         serializer = viewset.get_serializer(obj)
         return serializer.data
 
-    def trail(self, obj, viewset, request, action, data_before, data_after):
+    def trail(
+        self,
+        obj,
+        viewset,
+        request,
+        action,
+        data_before,
+        data_after,
+        audit=None,
+        main_object=None,
+    ):
         model = obj.__class__
         basename = model._meta.object_name.lower()
         data = data_after or data_before
 
-        if basename == viewset.audit.main_resource:
+        if not audit:
+            audit = viewset.audit
+
+        if main_object:
+            pass
+        elif basename == viewset.audit.main_resource:
             main_object = data["url"]
         elif hasattr(viewset, "audittrail_main_resource_key"):
             main_object = data[viewset.audittrail_main_resource_key]
@@ -177,7 +193,7 @@ class AuditTrailAdminMixin:
             zip(CommonResourceAction.names, CommonResourceAction.labels)
         )
         trail = AuditTrail(
-            bron=viewset.audit.component_name,
+            bron=audit.component_name,
             applicatie_weergave="admin",
             actie=action,
             actie_weergave=action_labels.get(action, ""),
@@ -294,6 +310,77 @@ class AuditTrailAdminMixin:
             self.trail(
                 obj, viewset, request, CommonResourceAction.create, None, data_after
             )
+
+
+class MultipleAuditTrailAdminMixin(AuditTrailAdminMixin):
+    def save_model(self, request, obj, form, change):
+        viewset = self.get_viewset(request)
+        if not viewset:
+            ModelAdmin.delete_model(self, request, obj)
+            return
+
+        model = obj.__class__
+        basename = model._meta.object_name.lower()
+        action = CommonResourceAction.update if change else CommonResourceAction.create
+
+        # data before
+        data_before = None
+        if change:
+            obj_before = model.objects.filter(pk=obj.pk).get()
+            data_before = self.get_serializer_data(request, viewset, obj_before)
+
+        ModelAdmin.save_model(self, request, obj, form, change)
+
+        # data after
+        data = self.get_serializer_data(request, viewset, obj)
+
+        if data_before != data:
+            for audit in viewset.audits:
+                main_object, data_before, data = viewset._handle_namespacing(
+                    audit,
+                    obj,
+                    version_before_edit=data_before,
+                    version_after_edit=data,
+                    basename=basename,
+                )
+
+                if main_object is None:
+                    continue
+
+                self.trail(
+                    obj, viewset, request, action, data_before, data, audit, main_object
+                )
+
+    def delete_model(self, request, obj):
+        viewset = self.get_viewset(request)
+        if not viewset:
+            ModelAdmin.delete_model(self, request, obj)
+            return
+
+        model = obj.__class__
+        basename = model._meta.object_name.lower()
+        action = CommonResourceAction.destroy
+
+        data = self.get_serializer_data(request, viewset, obj)
+
+        with transaction.atomic():
+            ModelAdmin.delete_model(self, request, obj)
+            for audit in viewset.audits:
+                main_object, data, _ = viewset._handle_namespacing(
+                    audit, obj, version_before_edit=data, basename=basename
+                )
+
+                if main_object is None:
+                    continue
+
+                if basename == audit.main_resource:
+                    with transaction.atomic():
+                        AuditTrail.objects.filter(hoofd_object=data["url"]).delete()
+                        return
+
+                self.trail(
+                    obj, viewset, request, action, data, None, audit, main_object
+                )
 
 
 class AuditTrailInlineAdminMixin:

--- a/src/openzaak/utils/admin.py
+++ b/src/openzaak/utils/admin.py
@@ -180,14 +180,13 @@ class AuditTrailAdminMixin:
         if not audit:
             audit = viewset.audit
 
-        if main_object:
-            pass
-        elif basename == viewset.audit.main_resource:
-            main_object = data["url"]
-        elif hasattr(viewset, "audittrail_main_resource_key"):
-            main_object = data[viewset.audittrail_main_resource_key]
-        else:
-            main_object = data[viewset.audit.main_resource]
+        if not main_object:
+            if basename == viewset.audit.main_resource:
+                main_object = data["url"]
+            elif hasattr(viewset, "audittrail_main_resource_key"):
+                main_object = data[viewset.audittrail_main_resource_key]
+            else:
+                main_object = data[viewset.audit.main_resource]
 
         action_labels = dict(
             zip(CommonResourceAction.names, CommonResourceAction.labels)
@@ -316,7 +315,7 @@ class MultipleAuditTrailAdminMixin(AuditTrailAdminMixin):
     def save_model(self, request, obj, form, change):
         viewset = self.get_viewset(request)
         if not viewset:
-            ModelAdmin.delete_model(self, request, obj)
+            ModelAdmin.save_model(self, request, obj, form, change)
             return
 
         model = obj.__class__
@@ -376,7 +375,7 @@ class MultipleAuditTrailAdminMixin(AuditTrailAdminMixin):
                 if basename == audit.main_resource:
                     with transaction.atomic():
                         AuditTrail.objects.filter(hoofd_object=data["url"]).delete()
-                        return
+                        continue
 
                 self.trail(
                     obj, viewset, request, action, data, None, audit, main_object

--- a/src/openzaak/utils/audittrails.py
+++ b/src/openzaak/utils/audittrails.py
@@ -47,9 +47,9 @@ class MultipleAuditTrailsMixin(AuditTrailMixin):
         return obj.get_absolute_api_url(request=self.request) if obj else None
 
     def _get_audittrail_main_object_url(
-        self, data: dict, audit: Audit, instance: Type[models.Model]
+        self, data: dict, audit: Audit, instance: Type[models.Model], basename: str
     ) -> str | None:
-        if self.basename == audit.main_resource:
+        if basename == audit.main_resource:
             return data["url"]
 
         if audit.main_resource not in data:
@@ -71,6 +71,7 @@ class MultipleAuditTrailsMixin(AuditTrailMixin):
         instance: Type[models.Model],
         version_before_edit: dict | None = None,
         version_after_edit: dict | None = None,
+        basename: str | None = None,
     ):
         fields = getattr(self, "audittrail_replace_urls_for", [])
         fields.append("url")
@@ -90,7 +91,13 @@ class MultipleAuditTrailsMixin(AuditTrailMixin):
             )
 
         data = version_after_edit or version_before_edit
-        main_object = self._get_audittrail_main_object_url(data, audit, instance)
+
+        if not basename:
+            basename = self.basename
+
+        main_object = self._get_audittrail_main_object_url(
+            data, audit, instance, basename
+        )
 
         return main_object, version_before_edit, version_after_edit
 

--- a/src/openzaak/utils/audittrails.py
+++ b/src/openzaak/utils/audittrails.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2026 Dimpact
+from typing import Type
+
+from django.db import models, transaction
+
+from vng_api_common.audittrails.audits import Audit
+from vng_api_common.audittrails.models import AuditTrail
+from vng_api_common.audittrails.viewsets import (
+    AuditTrailMixin,
+)
+from vng_api_common.constants import CommonResourceAction
+from vng_api_common.utils import get_uuid_from_path
+
+
+class MultipleAuditTrailsMixin(AuditTrailMixin):
+    audits: list[Audit]
+    audittrail_main_resource_keys: dict[str, str]
+
+    _AUDIT_NAMESPACE_MAPPING = {"BRC": "besluiten", "ZRC": "zaken"}
+
+    def _replace_namespace(self, url: str, namespace: str) -> str:
+        # TODO move to deprecated api utils
+        prefix, sep, rest = url.partition("/api")
+        if not sep:
+            return url
+
+        base, _, old_namespace = prefix.rpartition("/")
+        return f"{base}/{namespace}{sep}{rest}"
+
+    def _replace_namespaces(
+        self, data: dict, fields: list[str], namespace: str
+    ) -> list[str]:
+        new_data = data.copy()
+        for field in fields:
+            new_data[field] = self._replace_namespace(new_data[field], namespace)
+
+        return new_data
+
+    def _get_nested_main_resource_url_from_instance(
+        self, key: str, instance: Type[models.Model]
+    ) -> str | None:
+        """Returns the url of an nested FK field"""
+        obj = instance
+        for field in key.split("."):
+            obj = getattr(obj, field, None)
+        return obj.get_absolute_api_url(request=self.request) if obj else None
+
+    def _get_audittrail_main_object_url(
+        self, data: dict, audit: Audit, instance: Type[models.Model]
+    ) -> str | None:
+        if self.basename == audit.main_resource:
+            return data["url"]
+
+        if audit.main_resource not in data:
+            # TODO WATCH OUT MultipleChannelNotificationMixin methods are also accessible since everything is a mixin on the viewset
+            url = self._get_nested_main_resource_url_from_instance(
+                self.audittrail_main_resource_keys[audit.component_name],
+                instance,
+            )
+        else:
+            url = data[audit.main_resource]
+            if url == "":
+                url = None
+
+        return url
+
+    def _handle_namespacing(
+        self,
+        audit: Audit,
+        instance: Type[models.Model],
+        version_before_edit: dict | None = None,
+        version_after_edit: dict | None = None,
+    ):
+        fields = getattr(self, "audittrail_replace_urls_for", [])
+        fields.append("url")
+
+        if version_before_edit:
+            version_before_edit = self._replace_namespaces(
+                version_before_edit,
+                fields,
+                self._AUDIT_NAMESPACE_MAPPING[audit.component_name],
+            )
+
+        if version_after_edit:
+            version_after_edit = self._replace_namespaces(
+                version_after_edit,
+                fields,
+                self._AUDIT_NAMESPACE_MAPPING[audit.component_name],
+            )
+
+        data = version_after_edit or version_before_edit
+        main_object = self._get_audittrail_main_object_url(data, audit, instance)
+
+        return main_object, version_before_edit, version_after_edit
+
+
+class MultipleAuditTrailsCreateMixin(MultipleAuditTrailsMixin):
+    # TODO
+    def get_audittrail_instance(self, response):
+        if self._audittrail_serializer is not None:
+            return self._audittrail_serializer.instance
+        zaak_uuid = get_uuid_from_path(response.data["url"])
+        instance = self.get_queryset().get(uuid=zaak_uuid)  # type: ignore
+        return instance
+
+    # TODO
+    def perform_create(self, serializer):
+        super().perform_create(serializer)  # type: ignore
+        # cache for future re-use
+        self._audittrail_serializer = serializer
+
+    def create(self, request, *args, **kwargs):
+        response = super().create(request, *args, **kwargs)  # type: ignore
+        instance = self.get_audittrail_instance(response)
+        version_after_edit = response.data
+
+        for audit in self.audits:
+            main_object, _, version_after_edit = self._handle_namespacing(
+                audit, instance, version_after_edit=version_after_edit
+            )
+
+            # Do not create audittrail if audit main resource does not exist on the instance
+            # E.g. besluit zaak is not required
+            if main_object is None:
+                continue
+
+            self.create_audittrail(
+                response.status_code,
+                CommonResourceAction.create,
+                version_before_edit=None,
+                version_after_edit=version_after_edit,
+                unique_representation=instance.unique_representation(),
+                audit=audit,
+                main_object=main_object,
+            )
+        return response
+
+
+class MultipleAuditTrailsUpdateMixin(MultipleAuditTrailsMixin):
+    def update(self, request, *args, **kwargs):
+        # Retrieve the data stored in the object before updating
+        instance = self.get_object()  # type: ignore
+        serializer = self.get_serializer(instance)  # type: ignore
+        version_before_edit = serializer.data
+
+        action = (
+            CommonResourceAction.partial_update
+            if kwargs.get("partial", False)
+            else CommonResourceAction.update
+        )
+
+        response = super().update(request, *args, **kwargs)  # type: ignore
+        version_after_edit = response.data
+
+        for audit in self.audits:
+            main_object, version_before_edit, version_after_edit = (
+                self._handle_namespacing(
+                    audit,
+                    instance,
+                    version_before_edit=version_before_edit,
+                    version_after_edit=version_after_edit,
+                )
+            )
+
+            # Do not create audittrail if audit main resource does not exist on the instance
+            # E.g. besluit zaak is not required
+            if main_object is None:
+                continue
+
+            self.create_audittrail(
+                response.status_code,
+                action,
+                version_before_edit=version_before_edit,
+                version_after_edit=version_after_edit,
+                unique_representation=instance.unique_representation(),
+                audit=audit,
+                main_object=main_object,
+            )
+        return response
+
+
+class MultipleAuditTrailsDestroyMixin(MultipleAuditTrailsMixin):
+    def destroy(self, request, *args, **kwargs):
+        # Retrieve the data stored in the object before updating
+        instance = self.get_object()  # type: ignore
+        serializer = self.get_serializer(instance)  # type: ignore
+        version_before_edit = serializer.data
+
+        with transaction.atomic():
+            response = super().destroy(request, *args, **kwargs)
+            for audit in self.audits:
+                main_object, version_before_edit, _ = self._handle_namespacing(
+                    audit, instance, version_before_edit=version_before_edit
+                )
+
+                # Do not create audittrail if audit main resource does not exist on the instance
+                # E.g. besluit zaak is not required
+                if main_object is None:
+                    continue
+
+                # If the resource being deleted is the main resource, delete all the
+                # audittrails associated with it
+                if self.basename == audit.main_resource:  # type: ignore
+                    self._destroy_related_audittrails(version_before_edit["url"])
+                else:
+                    self.create_audittrail(
+                        response.status_code,
+                        CommonResourceAction.destroy,
+                        version_before_edit=version_before_edit,
+                        version_after_edit=None,
+                        unique_representation=instance.unique_representation(),
+                        audit=audit,
+                        main_object=main_object,
+                    )
+
+            return response
+
+    def _destroy_related_audittrails(self, main_object_url):
+        AuditTrail.objects.filter(hoofd_object=main_object_url).delete()
+
+
+class MultipleAuditTrailsViewsetMixin(
+    MultipleAuditTrailsCreateMixin,
+    MultipleAuditTrailsUpdateMixin,
+    MultipleAuditTrailsDestroyMixin,
+):
+    pass

--- a/src/openzaak/utils/audittrails.py
+++ b/src/openzaak/utils/audittrails.py
@@ -22,6 +22,7 @@ from openzaak.utils.namespacing import (
 class MultipleAuditTrailsMixin(AuditTrailMixin):
     audits: list[Audit]
     audittrail_main_resource_keys: dict[str, str]
+    audittrail_replace_urls_for: list[str] | None = None
 
     _AUDIT_NAMESPACE_MAPPING = {"BRC": "besluiten", "ZRC": "zaken"}
 
@@ -52,9 +53,7 @@ class MultipleAuditTrailsMixin(AuditTrailMixin):
         version_after_edit: dict | None = None,
         basename: str | None = None,
     ):
-        fields = getattr(self, "audittrail_replace_urls_for", [])
-        fields.append("url")
-
+        fields = ["url"] + (self.audittrail_replace_urls_for or [])
         if version_before_edit:
             version_before_edit = replace_namespaces(
                 version_before_edit,

--- a/src/openzaak/utils/audittrails.py
+++ b/src/openzaak/utils/audittrails.py
@@ -13,6 +13,8 @@ from vng_api_common.audittrails.viewsets import (
 )
 from vng_api_common.constants import CommonResourceAction
 
+from openzaak.components.besluiten.api.audits import AUDIT_BRC
+from openzaak.components.zaken.api.audits import AUDIT_ZRC
 from openzaak.utils.namespacing import (
     get_nested_main_object_url_from_instance,
     replace_namespaces,
@@ -24,7 +26,7 @@ class MultipleAuditTrailsMixin(AuditTrailMixin):
     audittrail_main_resource_keys: dict[str, str]
     audittrail_replace_urls_for: list[str] | None = None
 
-    _AUDIT_NAMESPACE_MAPPING = {"BRC": "besluiten", "ZRC": "zaken"}
+    _AUDIT_NAMESPACE_MAPPING = {AUDIT_BRC: "besluiten", AUDIT_ZRC: "zaken"}
 
     def _get_audittrail_main_object_url(
         self, data: dict, audit: Audit, instance: Type[models.Model], basename: str
@@ -58,14 +60,14 @@ class MultipleAuditTrailsMixin(AuditTrailMixin):
             version_before_edit = replace_namespaces(
                 version_before_edit,
                 fields,
-                self._AUDIT_NAMESPACE_MAPPING[audit.component_name],
+                self._AUDIT_NAMESPACE_MAPPING[audit],
             )
 
         if version_after_edit:
             version_after_edit = replace_namespaces(
                 version_after_edit,
                 fields,
-                self._AUDIT_NAMESPACE_MAPPING[audit.component_name],
+                self._AUDIT_NAMESPACE_MAPPING[audit],
             )
 
         data = version_after_edit or version_before_edit

--- a/src/openzaak/utils/audittrails.py
+++ b/src/openzaak/utils/audittrails.py
@@ -5,12 +5,18 @@ from typing import Type
 from django.db import models, transaction
 
 from vng_api_common.audittrails.audits import Audit
-from vng_api_common.audittrails.models import AuditTrail
 from vng_api_common.audittrails.viewsets import (
+    AuditTrailCreateMixin,
+    AuditTrailDestroyMixin,
     AuditTrailMixin,
+    AuditTrailUpdateMixin,
 )
 from vng_api_common.constants import CommonResourceAction
-from vng_api_common.utils import get_uuid_from_path
+
+from openzaak.utils.namespacing import (
+    get_nested_main_object_url_from_instance,
+    replace_namespaces,
+)
 
 
 class MultipleAuditTrailsMixin(AuditTrailMixin):
@@ -19,33 +25,6 @@ class MultipleAuditTrailsMixin(AuditTrailMixin):
 
     _AUDIT_NAMESPACE_MAPPING = {"BRC": "besluiten", "ZRC": "zaken"}
 
-    def _replace_namespace(self, url: str, namespace: str) -> str:
-        # TODO move to deprecated api utils
-        prefix, sep, rest = url.partition("/api")
-        if not sep:
-            return url
-
-        base, _, old_namespace = prefix.rpartition("/")
-        return f"{base}/{namespace}{sep}{rest}"
-
-    def _replace_namespaces(
-        self, data: dict, fields: list[str], namespace: str
-    ) -> list[str]:
-        new_data = data.copy()
-        for field in fields:
-            new_data[field] = self._replace_namespace(new_data[field], namespace)
-
-        return new_data
-
-    def _get_nested_main_resource_url_from_instance(
-        self, key: str, instance: Type[models.Model]
-    ) -> str | None:
-        """Returns the url of an nested FK field"""
-        obj = instance
-        for field in key.split("."):
-            obj = getattr(obj, field, None)
-        return obj.get_absolute_api_url(request=self.request) if obj else None
-
     def _get_audittrail_main_object_url(
         self, data: dict, audit: Audit, instance: Type[models.Model], basename: str
     ) -> str | None:
@@ -53,10 +32,10 @@ class MultipleAuditTrailsMixin(AuditTrailMixin):
             return data["url"]
 
         if audit.main_resource not in data:
-            # TODO WATCH OUT MultipleChannelNotificationMixin methods are also accessible since everything is a mixin on the viewset
-            url = self._get_nested_main_resource_url_from_instance(
+            url = get_nested_main_object_url_from_instance(
                 self.audittrail_main_resource_keys[audit.component_name],
                 instance,
+                self.request,
             )
         else:
             url = data[audit.main_resource]
@@ -77,14 +56,14 @@ class MultipleAuditTrailsMixin(AuditTrailMixin):
         fields.append("url")
 
         if version_before_edit:
-            version_before_edit = self._replace_namespaces(
+            version_before_edit = replace_namespaces(
                 version_before_edit,
                 fields,
                 self._AUDIT_NAMESPACE_MAPPING[audit.component_name],
             )
 
         if version_after_edit:
-            version_after_edit = self._replace_namespaces(
+            version_after_edit = replace_namespaces(
                 version_after_edit,
                 fields,
                 self._AUDIT_NAMESPACE_MAPPING[audit.component_name],
@@ -102,23 +81,9 @@ class MultipleAuditTrailsMixin(AuditTrailMixin):
         return main_object, version_before_edit, version_after_edit
 
 
-class MultipleAuditTrailsCreateMixin(MultipleAuditTrailsMixin):
-    # TODO
-    def get_audittrail_instance(self, response):
-        if self._audittrail_serializer is not None:
-            return self._audittrail_serializer.instance
-        zaak_uuid = get_uuid_from_path(response.data["url"])
-        instance = self.get_queryset().get(uuid=zaak_uuid)  # type: ignore
-        return instance
-
-    # TODO
-    def perform_create(self, serializer):
-        super().perform_create(serializer)  # type: ignore
-        # cache for future re-use
-        self._audittrail_serializer = serializer
-
+class MultipleAuditTrailsCreateMixin(AuditTrailCreateMixin, MultipleAuditTrailsMixin):
     def create(self, request, *args, **kwargs):
-        response = super().create(request, *args, **kwargs)  # type: ignore
+        response = super(AuditTrailCreateMixin, self).create(request, *args, **kwargs)  # type: ignore
         instance = self.get_audittrail_instance(response)
         version_after_edit = response.data
 
@@ -144,7 +109,7 @@ class MultipleAuditTrailsCreateMixin(MultipleAuditTrailsMixin):
         return response
 
 
-class MultipleAuditTrailsUpdateMixin(MultipleAuditTrailsMixin):
+class MultipleAuditTrailsUpdateMixin(AuditTrailUpdateMixin, MultipleAuditTrailsMixin):
     def update(self, request, *args, **kwargs):
         # Retrieve the data stored in the object before updating
         instance = self.get_object()  # type: ignore
@@ -157,7 +122,7 @@ class MultipleAuditTrailsUpdateMixin(MultipleAuditTrailsMixin):
             else CommonResourceAction.update
         )
 
-        response = super().update(request, *args, **kwargs)  # type: ignore
+        response = super(AuditTrailUpdateMixin, self).update(request, *args, **kwargs)  # type: ignore
         version_after_edit = response.data
 
         for audit in self.audits:
@@ -187,7 +152,7 @@ class MultipleAuditTrailsUpdateMixin(MultipleAuditTrailsMixin):
         return response
 
 
-class MultipleAuditTrailsDestroyMixin(MultipleAuditTrailsMixin):
+class MultipleAuditTrailsDestroyMixin(AuditTrailDestroyMixin, MultipleAuditTrailsMixin):
     def destroy(self, request, *args, **kwargs):
         # Retrieve the data stored in the object before updating
         instance = self.get_object()  # type: ignore
@@ -195,7 +160,9 @@ class MultipleAuditTrailsDestroyMixin(MultipleAuditTrailsMixin):
         version_before_edit = serializer.data
 
         with transaction.atomic():
-            response = super().destroy(request, *args, **kwargs)
+            response = super(AuditTrailDestroyMixin, self).destroy(
+                request, *args, **kwargs
+            )
             for audit in self.audits:
                 main_object, version_before_edit, _ = self._handle_namespacing(
                     audit, instance, version_before_edit=version_before_edit
@@ -222,9 +189,6 @@ class MultipleAuditTrailsDestroyMixin(MultipleAuditTrailsMixin):
                     )
 
             return response
-
-    def _destroy_related_audittrails(self, main_object_url):
-        AuditTrail.objects.filter(hoofd_object=main_object_url).delete()
 
 
 class MultipleAuditTrailsViewsetMixin(

--- a/src/openzaak/utils/namespacing.py
+++ b/src/openzaak/utils/namespacing.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2026 Dimpact
+from django.db import models
+
+from rest_framework.request import Request
+
+
+def replace_namespace(url: str, namespace: str) -> str:
+    prefix, sep, rest = url.partition("/api")
+    if not sep:
+        return url
+
+    base, _, old_namespace = prefix.rpartition("/")
+    return f"{base}/{namespace}{sep}{rest}"
+
+
+def replace_namespaces(data: dict, fields: list[str], namespace: str) -> dict:
+    new_data = data.copy()
+    for field in fields:
+        new_data[field] = replace_namespace(new_data[field], namespace)
+
+    return new_data
+
+
+def get_nested_main_object_url_from_instance(
+    key: str, instance: models.Model, request: Request
+) -> str | None:
+    """Returns the url of a nested FK field"""
+    obj = instance
+    for field in key.split("."):
+        obj = getattr(obj, field, None)
+    return obj.get_absolute_api_url(request=request) if obj else None
+
+
+def get_nested_main_object_url_from_dict(key: str, data: object) -> str | None:
+    """Returns a nested url field from a dict"""
+    for field in key.split("."):
+        if not isinstance(data, dict):
+            raise KeyError
+        data = data.get(field)
+    return data if isinstance(data, str) else None


### PR DESCRIPTION
Partially closes #2451

**Changes**
- adds MultipleAuditTrailAdminMixin
- moves common methods needed for notifs & trails to utils/namespacing.py
- adds MultipleAuditTrailAdminMixin to besluiten to create trails on both besluit & zaak

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [ ] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/open-zaak/open-zaak/wiki/Architectural-Decision-Records-(ADR))
