### PR TITLE
:sparkles: Fix/2426 add slug to service form

### DIFF
--- a/src/openzaak/config/forms.py
+++ b/src/openzaak/config/forms.py
@@ -75,4 +75,5 @@ class ExternalServiceForm(ModelForm):
             "user_representation",
             "header_key",
             "header_value",
+            "slug",
         )

--- a/src/openzaak/js/components/admin/external-services/external-form.js
+++ b/src/openzaak/js/components/admin/external-services/external-form.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: EUPL-1.2
 // Copyright (C) 2020 Dimpact
-import React from "react";
+import React, {useRef, useState} from "react";
 import {CheckBoxInputLabel, TextInput} from "../../../forms/inputs";
 import {API_TYPES} from "../../../forms/constants";
 import {SelectInput} from "./select";
@@ -16,6 +16,42 @@ function ExternalForm(props) {
     const name_prefix = (field) => `form-${index}-${field}`;
     const isEven = (index % 2) === 0;
 
+    const [slug, setSlug] = useState(values.slug ?? "");
+    const slugManuallyEdited = useRef(Boolean(values.slug));
+    const isCreate = !values.id;
+
+    /**
+     * Automatically populates the slug from the label when the slug
+     * has not been manually edited and the form is in create mode.
+     * @param {string} label
+     */
+    const handleSlugChange = (label) => {
+        if (!isCreate || slugManuallyEdited.current === true) {
+            return;
+        }
+
+        /*
+        * Convert the label into a URL-friendly slug:
+        * 1. Convert all characters to lowercase.
+        * 2. Remove whitespace from the beginning and end.
+        * 3. Replace one or more spaces with a hyphen (-).
+        * 4. Remove special characters, keeping only letters, numbers,
+        *    underscores, and hyphens.
+        * 5. Set the resulting value as the slug.
+        */
+       const slugLabel = label
+                .toLowerCase()
+                .trim()
+                .replace(/\s+/g, "-")
+                .replace(/[^\w-]/g, "");
+        setSlug(slugLabel);
+    };
+
+    const handleManualSlugChange = (value) => {
+        slugManuallyEdited.current = true;
+        setSlug(value);
+    };
+
     return (
         <tr className={`form-row external-form external-form--${isEven ? 'even' : 'odd'}`}>
             <td className='external-form__hidden'>
@@ -29,6 +65,7 @@ function ExternalForm(props) {
                     name={name_prefix('label')}
                     initial={values.label}
                     errors={errors.label}
+                    onChange={handleSlugChange}
                     classes="external-form__field--wide"
                 />
             </td>
@@ -51,6 +88,18 @@ function ExternalForm(props) {
                     name={name_prefix('api_root')}
                     initial={values.api_root}
                     errors={errors.api_root}
+                    classes="external-form__field--wide"
+                />
+            </td>
+
+            {/*slug*/}
+            <td className='external-form__field'>
+                <TextInput
+                    id={id_prefix('slug')}
+                    name={name_prefix('slug')}
+                    value={slug}
+                    errors={errors.slug}
+                    onChange={handleManualSlugChange}
                     classes="external-form__field--wide"
                 />
             </td>

--- a/src/openzaak/js/components/admin/external-services/external-formset.js
+++ b/src/openzaak/js/components/admin/external-services/external-formset.js
@@ -57,6 +57,7 @@ function ExternalFormSet(props) {
                             <th className='external-formset__col'>Service</th>
                             <th className='external-formset__col'>API type</th>
                             <th className='external-formset__col--big'>URL</th>
+                            <th className='external-formset__col'>Slug</th>
                             <th className='external-formset__col'>NLX outway URL</th>
                             <th className='external-formset__col'>Authorization</th>
                             <th className='external-formset__col--small'>Verwijderen</th>

--- a/src/openzaak/js/forms/inputs.js
+++ b/src/openzaak/js/forms/inputs.js
@@ -64,9 +64,13 @@ const CheckBoxInputLabel = (props) => {
 
 
 const TextInput = (props) => {
-    const { id, name, initial, classes, errors } = props;
+    // `onChange` is used to update the controlledValue
+    const { id, name, initial, value: controlledValue, classes, errors, onChange } = props;
     const [value, setValue] = useState(initial || "");
     const [_errors, setErrors] = useState(errors);
+    const valueProps = controlledValue === undefined
+        ? {defaultValue: value}
+        : {value: controlledValue};
 
     return (
         <>
@@ -75,11 +79,16 @@ const TextInput = (props) => {
                 type="text"
                 name={name}
                 id={id}
-                onChange={ (event) => {
-                    setValue(event.text);
+                onChange={(event) => {
+                    const newValue = event.target.value;
+                    setValue(newValue);
                     setErrors([]);
+
+                    if (onChange) {
+                        onChange(newValue);
+                    }
                 }}
-                defaultValue={value}
+                {...valueProps}
                 className={classes}
             ></input>
         </>


### PR DESCRIPTION
Closes #2426 

**Changes**
- Add `slug` to ExternalServiceForm
- Add `slug` to Admin external form in js
  - When entering a label, the slug can now be auto-populated by replacing spaces with hypens (-)
  - If the slug already contains a value, it will not be automatically updated when entering a label. 

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [ ] Any experimental features added in this PR are backwards compatible
  - [ ] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [ ] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/open-zaak/open-zaak/wiki/Architectural-Decision-Records-(ADR))
