### PR TITLE
Fix/2426 oauth2 token url to service form

### DIFF
--- a/src/openzaak/config/forms.py
+++ b/src/openzaak/config/forms.py
@@ -76,4 +76,5 @@ class ExternalServiceForm(ModelForm):
             "header_key",
             "header_value",
             "slug",
+            "oauth2_token_url",
         )

--- a/src/openzaak/js/components/admin/external-services/auth-type.js
+++ b/src/openzaak/js/components/admin/external-services/auth-type.js
@@ -92,6 +92,28 @@ function AuthType(props) {
                     />
                 </div>) : null}
 
+            {(selectedAuthType === 'oauth2_client_credentials') ?
+                (<>
+                    <AuthField
+                        name='client_id'
+                        value={values.client_id}
+                        label='Client ID'
+                        errors={errors.client_id}
+                    />
+                    <AuthField
+                        name='secret'
+                        value={values.secret}
+                        label='Secret'
+                        errors={errors.secret}
+                    />
+                    <AuthField
+                        name='oauth2_token_url'
+                        value={values.oauth2_token_url}
+                        label='OAuth2 token-endpoint'
+                        errors={errors.oauth2_token_url}
+                    />
+                </>) : null}
+
         </>
     );
 }


### PR DESCRIPTION
Closes #2426 

**Changes**
- Add `oauth2_token_url` to ExternalServiceForm
- Add `client_id`,  `secret` and `oauth2_token_url` TextInput to external service form js

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [ ] Any experimental features added in this PR are backwards compatible
  - [ ] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [ ] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/open-zaak/open-zaak/wiki/Architectural-Decision-Records-(ADR))
